### PR TITLE
Add example to execute a query

### DIFF
--- a/crates/sqlengine/examples/execute.rs
+++ b/crates/sqlengine/examples/execute.rs
@@ -1,7 +1,6 @@
 //! Execute a query string against an in-memory data source.
 use lemur::execute::stream::source::MemoryDataSource;
 use sqlengine::engine::Engine;
-use sqlengine::server::{Client, Response, Server};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
`cargo run --example execute "select * from (values (1, 'hello'), (2,'world'));"`

results in:

```
QueryResult { df: df: num rows: 2, num_cols: 2
0: Int8(Some(1)) Utf8(Some("hello"))
1: Int8(Some(2)) Utf8(Some("world"))  }
```

Note that the catalog interface currently panics, so this example cannot
reference any tables right now. Eventually the catalog should be stubbable, e.g.:
https://github.com/GlareDB/glaredb/blob/e24d4cc035cca5d3f72e1651228e12a547a96cca/crates/sqlengine/examples/logicalplan.rs#L60

This also showcases a bug where `select 1` returns nothing (https://github.com/GlareDB/glaredb/issues/9).