### PR TITLE
Restructure nix flake

### DIFF
--- a/flake-parts/apps/default.nix
+++ b/flake-parts/apps/default.nix
@@ -1,0 +1,20 @@
+{
+  inputs,
+  self,
+  ...
+}: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    ...
+  }: rec {
+    apps = {
+      cli = {
+        type = "app";
+        program = "${self.packages.${system}.cli}/bin/glaredb";
+      };
+      default = apps.cli;
+    };
+  };
+}

--- a/flake-parts/checks/default.nix
+++ b/flake-parts/checks/default.nix
@@ -1,0 +1,16 @@
+{
+  inputs,
+  self,
+  ...
+} @ part-inputs: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    ...
+  }: {
+    checks = {
+      pre-commit = import ./pre-commit.nix part-inputs system;
+    };
+  };
+}

--- a/flake-parts/checks/pre-commit.nix
+++ b/flake-parts/checks/pre-commit.nix
@@ -1,0 +1,13 @@
+{
+  self,
+  inputs,
+  ...
+} @ part-inputs: system:
+  inputs.pre-commit-hooks.lib.${system}.run {
+    src = self.lib.flake_source;
+    hooks = {
+      alejandra.enable = true;
+      # rustfmt.enable = true;
+      # clippy.enable = true;
+    };
+  }

--- a/flake-parts/default.nix
+++ b/flake-parts/default.nix
@@ -1,0 +1,9 @@
+_inputs: {
+  imports = [
+    ./lib
+    ./packages
+    ./apps
+    ./checks
+    ./devshell
+  ];
+}

--- a/flake-parts/devshell/default.nix
+++ b/flake-parts/devshell/default.nix
@@ -1,0 +1,61 @@
+{
+  inputs,
+  self,
+  ...
+} @ part-inputs: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    ...
+  }: let
+    rust-stable = self.lib.rust-stable system;
+    rust-nightly = self.lib.rust-nightly system;
+    devTools = with pkgs; [
+      rustfmt
+      bacon
+      cargo-udeps
+      cocogitto
+    ];
+  in rec {
+    devShells = {
+      default = devShells.nightly;
+      stable = pkgs.mkShell rec {
+        buildInputs = [rust-stable] ++ devTools;
+        inherit (self.checks.${system}.pre-commit) shellHook;
+      };
+      nightly = pkgs.mkShell rec {
+        buildInputs = [rust-nightly] ++ devTools;
+        inherit (self.checks.${system}.pre-commit) shellHook;
+      };
+      postgres = with pkgs;
+        mkShell rec {
+          buildInputs = [postgresql rust-stable];
+          shellHook = ''
+            ${self.checks.${system}.pre-commit.shellHook}
+            export PGDATA="$PWD/db"
+            export PGHOST="$PGDATA"
+            export PGLOG=$PGDATA/postgres.log
+
+            if [ ! -d $PGDATA ]; then
+                mkdir -p $PGDATA
+                initdb -D $PGDATA --auth=trust --no-locale --encoding=UTF8
+                createuser postgres
+            fi
+
+            if ! pg_ctl status
+            then
+                pg_ctl start -l $PGLOG -o "--unix-socket-directories='$PGDATA'"
+            fi
+
+            function end {
+                echo "Shutting down postgres..."
+                pg_ctl stop
+            }
+
+            trap end EXIT
+          '';
+        };
+    };
+  };
+}

--- a/flake-parts/lib/default.nix
+++ b/flake-parts/lib/default.nix
@@ -1,0 +1,14 @@
+{
+  inputs,
+  self,
+  ...
+}: let
+  inherit (inputs.gitignore.lib) gitignoreSource;
+in {
+  flake.lib = {
+    flake_source = gitignoreSource ../..;
+    cargo_lock = ../../Cargo.lock;
+    rust-stable = system: inputs.rust-overlay.packages.${system}.rust;
+    rust-nightly = system: inputs.rust-overlay.packages.${system}.rust-nightly;
+  };
+}

--- a/flake-parts/packages/default.nix
+++ b/flake-parts/packages/default.nix
@@ -1,0 +1,36 @@
+{
+  inputs,
+  self,
+  ...
+}: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    ...
+  }: let
+    rust-stable = self.lib.rust-stable system;
+    rust-nightly = self.lib.rust-nightly system;
+  in rec {
+    packages = {
+      default = packages.cli;
+      cli = pkgs.rustPlatform.buildRustPackage {
+        pname = "glaredb-cli";
+        version = "0.1.0";
+
+        buildAndTestSubdir = "crates/sqlengine";
+        src = self.lib.flake_source;
+        cargoLock = {
+          lockFile = self.lib.cargo_lock;
+        };
+        buildInputs = [rust-stable];
+      };
+      server_image = pkgs.dockerTools.buildLayeredImage {
+        name = "glaredb-tcp-server";
+        tag = "latest";
+        contents = [packages.cli];
+        config.Cmd = ["${packages.cli}/bin/glaredb" "server"];
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,85 +21,14 @@
 
   outputs = {
     self,
-    nixpkgs,
     flake-utils,
     flake-parts,
-    gitignore,
-    rust-overlay,
-    pre-commit-hooks,
     ...
   }:
     flake-parts.lib.mkFlake {inherit self;} {
-      perSystem = {
-        config,
-        self',
-        inputs',
-        pkgs,
-        system,
-        ...
-      }: let
-        inherit (gitignore.lib) gitignoreSource;
-        pre-commit-check = pre-commit-hooks.lib.${system}.run {
-          src = gitignoreSource ./.;
-          hooks = {
-            alejandra.enable = true;
-          };
-        };
-
-        opkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            rust-overlay.overlays.default
-          ];
-        };
-        rust-stable = opkgs.rust-bin.stable.latest.default;
-        rust-nightly = opkgs.rust-bin.nightly.latest.default;
-        shellInputs = with pkgs; [
-          rustfmt
-          bacon
-          cargo-udeps
-          miniserve
-        ];
-      in rec {
-        devShells = {
-          default = pkgs.mkShell rec {
-            buildInputs = [rust-stable] ++ shellInputs;
-            inherit (pre-commit-check) shellHook;
-          };
-          nightly = pkgs.mkShell rec {
-            buildInputs = [rust-nightly] ++ shellInputs;
-            inherit (pre-commit-check) shellHook;
-          };
-          postgres = with pkgs;
-            mkShell rec {
-              buildInputs = [postgresql rust-stable];
-              shellHook = ''
-                ${pre-commit-check.shellHook}
-                export PGDATA="$PWD/db"
-                export PGHOST="$PGDATA"
-                export PGLOG=$PGDATA/postgres.log
-
-                if [ ! -d $PGDATA ]; then
-                    mkdir -p $PGDATA
-                    initdb -D $PGDATA --auth=trust --no-locale --encoding=UTF8
-                    createuser postgres
-                fi
-
-                if ! pg_ctl status
-                then
-                    pg_ctl start -l $PGLOG -o "--unix-socket-directories='$PGDATA'"
-                fi
-
-                function end {
-                    echo "Shutting down postgres..."
-                    pg_ctl stop
-                }
-
-                trap end EXIT
-              '';
-            };
-        };
-      };
       systems = flake-utils.lib.defaultSystems;
+      imports = [
+        ./flake-parts
+      ];
     };
 }


### PR DESCRIPTION
This restructures the nix flake into a more organized scheme following success using `flake-parts` imports in [egui-playground](https://github.com/justinrubek/egui-playground/) to organize a flake. `flake.nix` is now primary used for specifying imports and all of its outputs are produced by importing the relevant files using [flake-parts](https://github.com/hercules-ci/flake-parts). Each flake output is then organized into a sub-folder inside the `flake-parts` directory

# additions

In addition to re-organization, the flake now exposes packages and apps in addition to devShells. Here is a overview of what is available on the flake.

## packages

These are physical files that can be produced using `nix build .#${package_name}` (see `flake-parts/packages/default.nix`)


- `cli`: the glaredb binary application
- `server_image`: an OCI image configured to run the cli with the server subcommand
  - use `podman load --input result` or docker/similar to access
  - `./result` is a tarball containing the image.

(tip: this creates a `result` file/directory containing the build in the PWD)


## apps

Apps are anything that can be ran. If packages corresponded to `cargo build`, then apps correspond to `cargo run`. Use `nix run .#${app_name}` (see `flake-parts/apps/default.nix`)

- `cli`: the glaredb binary application


## checks

Operations performed when running `nix flake check` (in addition to the checks nix always does to evaluate the flake). Currently this is limited to formatting via [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) (see `flake-parts/checks/pre-commit.nix`)
