### PR TITLE
feat: Add minimal storage engine crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,16 +108,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -259,6 +312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,10 +473,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemur"
@@ -424,7 +504,7 @@ dependencies = [
  "logutil",
  "parking_lot",
  "paste",
- "rand",
+ "rand 0.8.5",
  "serde",
  "tokio",
  "tokio-stream",
@@ -436,6 +516,42 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.0+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -480,6 +596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +631,16 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -593,6 +725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +761,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -690,13 +834,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -706,8 +863,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -716,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -754,6 +935,31 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -843,6 +1049,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +1097,7 @@ dependencies = [
  "lemur",
  "logutil",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rustyline",
  "serde",
  "sqlparser",
@@ -904,6 +1116,28 @@ checksum = "f531637a13132fa3d38c54d4cd8f115905e5dc3e72f6e77bd6160481f482e25d"
 dependencies = [
  "log",
  "serde",
+]
+
+[[package]]
+name = "storageengine"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "futures",
+ "lemur",
+ "logutil",
+ "parking_lot",
+ "rocksdb",
+ "serde",
+ "tempdir",
+ "thiserror",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -934,6 +1168,16 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "termcolor"
@@ -1139,6 +1383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,4 +1481,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/crates/storageengine/Cargo.toml
+++ b/crates/storageengine/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "storageengine"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+logutil = {path = "../logutil"}
+lemur = {path = "../lemur"}
+tracing = "0.1"
+tracing-subscriber = "0.3"
+thiserror = "1.0"
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive", "rc"] }
+tokio = { version = "1", features = ["full"] }
+async-trait = "0.1.56"
+futures = "0.3.21"
+parking_lot = "0.12.1"
+tokio-util = { version = "0.7.3", features = ["codec"] }
+tokio-serde = { version = "0.8", features = ["bincode"] }
+rocksdb = "0.19.0"
+bincode = "1.3.3"
+tempdir = "0.3.7"

--- a/crates/storageengine/src/errors.rs
+++ b/crates/storageengine/src/errors.rs
@@ -1,0 +1,38 @@
+use crate::repr::InternalValue;
+use std::io;
+
+pub type Result<T, E = StorageError> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    /// A primary key may contain multiple values from multiple columns. Hitting
+    /// this error means we're attempting to access a non-existent column.
+    #[error("missing value for pk at idx: {idx}")]
+    MissingPkPart { idx: usize },
+    /// A value lookup is not of the type we're looking for.
+    #[error("unexpected internal value: {0:?}")]
+    UnexpectedInternalValue(InternalValue),
+    /// (De)serialization errors related to bincode.
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    /// IO errors
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    /// FFI errors for RocksDB.
+    #[error(transparent)]
+    Rocks(#[from] rocksdb::Error),
+    #[error("internal: {0}")]
+    Internal(String),
+    /// Laziness. Anyhow is not used in this crate, but other crates that are
+    /// depended upon do use it.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Create an internal error variant using string formatting.
+#[allow(unused_macros)]
+macro_rules! internal {
+    ($($arg:tt)*) => {
+        crate::errors::StorageError::Internal(std::format!($($arg)*))
+    };
+}

--- a/crates/storageengine/src/lib.rs
+++ b/crates/storageengine/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod errors;
+pub mod repr;
+pub mod rocks;

--- a/crates/storageengine/src/repr.rs
+++ b/crates/storageengine/src/repr.rs
@@ -1,0 +1,44 @@
+use crate::errors::Result;
+use lemur::repr::value::{Row, Value};
+use serde::{Deserialize, Serialize};
+
+pub type TableId = String;
+
+pub type PrimaryKeyIndices<'a> = &'a [usize];
+
+pub type PrimaryKey<'a> = &'a [Value];
+
+/// Key representations.
+///
+/// TODO: Timestamp these to provide transactional semantics.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Key {
+    /// A primary record.
+    Primary(TableId, Vec<Value>),
+}
+
+impl Key {
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        Ok(bincode::serialize(self)?)
+    }
+
+    pub fn deserialize<B: AsRef<[u8]>>(buf: B) -> Result<Self> {
+        Ok(bincode::deserialize(buf.as_ref())?)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum InternalValue {
+    PrimaryRecord(Row),
+    Tombstone,
+}
+
+impl InternalValue {
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        Ok(bincode::serialize(self)?)
+    }
+
+    pub fn deserialize<B: AsRef<[u8]>>(buf: B) -> Result<Self> {
+        Ok(bincode::deserialize(buf.as_ref())?)
+    }
+}

--- a/crates/storageengine/src/rocks.rs
+++ b/crates/storageengine/src/rocks.rs
@@ -1,0 +1,318 @@
+use lemur::repr::df::DataFrame;
+use lemur::repr::expr::ScalarExpr;
+use lemur::repr::value::Row;
+use parking_lot::RwLock;
+use rocksdb::{Direction, IteratorMode, DB};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tracing::debug;
+
+use crate::errors::{Result, StorageError};
+use crate::repr::{InternalValue, Key, PrimaryKey, PrimaryKeyIndices, TableId};
+
+const DB_FILENAME: &str = "rocks.db";
+
+#[derive(Debug)]
+pub struct StorageConfig {
+    pub data_dir: String,
+}
+
+/// A simple storage implementation backed by RocksDB.
+#[derive(Debug, Clone)]
+pub struct RocksStore {
+    inner: Arc<InnerDb>,
+}
+
+impl RocksStore {
+    /// Open a store backed by a RocksDB instance with the given config.
+    pub fn open(conf: StorageConfig) -> Result<RocksStore> {
+        let path = Path::new(&conf.data_dir).join(DB_FILENAME);
+        let db = DB::open_default(path)?;
+        Ok(RocksStore {
+            inner: Arc::new(InnerDb {
+                db,
+                active_txs: RwLock::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    /// Begin a transaction.
+    // TODO: There's currently no transactional semantics.
+    pub fn begin(&self) -> StorageTxRef {
+        static ID_GEN: AtomicU64 = AtomicU64::new(0);
+        let id = ID_GEN.fetch_add(1, Ordering::Relaxed);
+        let tx = Arc::new(StorageTx {
+            id,
+            inner: self.inner.clone(),
+        });
+
+        {
+            let mut active = self.inner.active_txs.write();
+            active.insert(id, tx.clone());
+        }
+        tx
+    }
+
+    /// Resume an active transaction.
+    pub fn resume(&self, id: u64) -> Option<StorageTxRef> {
+        let active = self.inner.active_txs.read();
+        active.get(&id).cloned()
+    }
+}
+
+#[derive(Debug)]
+struct InnerDb {
+    db: DB,
+    active_txs: RwLock<BTreeMap<u64, StorageTxRef>>,
+}
+
+impl InnerDb {
+    fn remove(&self, id: u64) {
+        let mut active = self.active_txs.write();
+        if active.remove(&id).is_none() {
+            // TODO: This may happen if there's multiple outstanding references
+            // that commit/abort at the same time. Ideally we can add a barrier
+            // of some sort ensuring that this doesn't happen.
+            debug!(id, "attempted to remove transaction we don't know about");
+        }
+    }
+}
+
+pub type StorageTxRef = Arc<StorageTx>;
+
+#[derive(Debug)]
+pub struct StorageTx {
+    id: u64,
+    inner: Arc<InnerDb>,
+}
+
+impl StorageTx {
+    pub fn get_id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn commit(self) -> Result<()> {
+        self.inner.remove(self.id);
+        Ok(())
+    }
+
+    pub fn abort(self) -> Result<()> {
+        self.inner.remove(self.id);
+        Ok(())
+    }
+
+    pub fn insert(&self, table: TableId, idxs: PrimaryKeyIndices<'_>, row: Row) -> Result<()> {
+        let mut pk = Vec::with_capacity(idxs.len());
+        for idx in idxs.iter() {
+            pk.push(
+                row.values
+                    .get(*idx)
+                    .cloned()
+                    .ok_or(StorageError::MissingPkPart { idx: *idx })?,
+            );
+        }
+
+        let key = Key::Primary(table, pk);
+        let val = InternalValue::PrimaryRecord(row);
+
+        self.inner.db.put(key.serialize()?, val.serialize()?)?;
+
+        Ok(())
+    }
+
+    pub fn delete(&self, table: TableId, pk: PrimaryKey<'_>) -> Result<()> {
+        let buf = Key::Primary(table, pk.to_vec()).serialize()?;
+        self.inner
+            .db
+            .put(&buf, InternalValue::Tombstone.serialize()?)?;
+        Ok(())
+    }
+
+    pub fn get(&self, table: TableId, pk: PrimaryKey<'_>) -> Result<Option<Row>> {
+        let buf = Key::Primary(table, pk.to_vec()).serialize()?;
+        match self.inner.db.get_pinned(&buf)? {
+            Some(val) => {
+                let internal = InternalValue::deserialize(val)?;
+                match internal {
+                    InternalValue::PrimaryRecord(row) => Ok(Some(row)),
+                    InternalValue::Tombstone => Ok(None),
+                    // Note that there's currently no additional internal value
+                    // types, but there will be in the future.
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn scan(
+        &self,
+        table: TableId,
+        begin: PrimaryKey<'_>,
+        limit: usize,
+        filter: Option<ScalarExpr>,
+    ) -> Result<DataFrame> {
+        let begin = Key::Primary(table.clone(), begin.to_vec()).serialize()?;
+        let iter = self
+            .inner
+            .db
+            .iterator(IteratorMode::From(&begin, Direction::Forward));
+
+        let mut stacked_df: Option<DataFrame> = None;
+        let mut rows_cap = limit;
+        let mut rows = Vec::with_capacity(rows_cap);
+
+        for item in iter {
+            let (key, val) = item?;
+            let key = Key::deserialize(&key)?;
+            match key {
+                Key::Primary(scanned, _) if scanned == table => {
+                    let val = InternalValue::deserialize(&val)?;
+                    if let InternalValue::PrimaryRecord(row) = val {
+                        rows.push(row);
+                        if rows.len() == rows_cap {
+                            // We've reached the limit, create a new data frame
+                            // from the rows we've collected.
+                            let chunk_rows =
+                                std::mem::replace(&mut rows, Vec::with_capacity(rows_cap));
+                            let mut chunk = DataFrame::from_rows(chunk_rows)?;
+                            if let Some(ref filter) = filter {
+                                chunk = chunk.filter_expr(filter)?
+                            }
+                            // Filtering might've trimmed down the data frame,
+                            // next iteration should try scan what's left to
+                            // fill.
+                            rows_cap -= chunk.num_rows();
+                            match &mut stacked_df {
+                                Some(df) => *df = df.clone().vstack(chunk)?, // Clone is cheap.
+                                None => stacked_df = Some(chunk),
+                            }
+                            // No more scanning needed.
+                            if rows_cap == 0 {
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ => break, // No longer scanning the same table.
+            }
+        }
+
+        // Might not have processed rows yet, create a chunk and stack onto the
+        // dataframe.
+        let mut chunk = DataFrame::from_rows(std::mem::take(&mut rows))?;
+        if let Some(ref filter) = filter {
+            chunk = chunk.filter_expr(filter)?
+        }
+        match &mut stacked_df {
+            Some(df) => *df = df.clone().vstack(chunk)?,
+            None => stacked_df = Some(chunk),
+        }
+
+        Ok(stacked_df.unwrap_or_else(DataFrame::empty))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lemur::repr::expr::BinaryOperation;
+    use lemur::repr::value::Value;
+    use tempdir::TempDir;
+
+    #[test]
+    fn simple_scan() {
+        logutil::init_test();
+
+        let temp = TempDir::new("simple_scan").unwrap();
+        let conf = StorageConfig {
+            data_dir: temp.path().to_str().unwrap().to_string(),
+        };
+        let db = RocksStore::open(conf).unwrap();
+
+        let table = "test_table".to_string();
+        let tx = db.begin();
+
+        let rows = vec![
+            vec![Value::Int32(Some(4))],
+            vec![Value::Int32(Some(6))],
+            vec![Value::Int32(Some(7))],
+            vec![Value::Int32(Some(8))],
+        ]
+        .into_iter()
+        .map(Row::from);
+
+        for row in rows {
+            tx.insert(table.clone(), &[0], row).unwrap();
+        }
+
+        // Scan everything.
+        let df = tx
+            .scan(table.clone(), &[Value::Int32(Some(0))], 10, None)
+            .unwrap();
+        let expected = DataFrame::from_rows(
+            vec![
+                vec![Value::Int32(Some(4))],
+                vec![Value::Int32(Some(6))],
+                vec![Value::Int32(Some(7))],
+                vec![Value::Int32(Some(8))],
+            ]
+            .into_iter()
+            .map(Row::from),
+        )
+        .unwrap();
+        assert_eq!(expected, df);
+
+        // Scan from middle.
+        let df = tx
+            .scan(table.clone(), &[Value::Int32(Some(7))], 10, None)
+            .unwrap();
+        let expected = DataFrame::from_rows(
+            vec![vec![Value::Int32(Some(7))], vec![Value::Int32(Some(8))]]
+                .into_iter()
+                .map(Row::from),
+        )
+        .unwrap();
+        assert_eq!(expected, df);
+
+        // Scan after end.
+        let df = tx
+            .scan(table.clone(), &[Value::Int32(Some(32))], 10, None)
+            .unwrap();
+        assert_eq!(0, df.num_rows());
+
+        // Scan with filter.
+        let filter = Some(ScalarExpr::Binary {
+            op: BinaryOperation::Gt,
+            left: ScalarExpr::Column(0).boxed(),
+            right: ScalarExpr::Constant(Value::Int32(Some(5))).boxed(),
+        });
+        let df = tx
+            .scan(table.clone(), &[Value::Int32(Some(0))], 10, filter)
+            .unwrap();
+        let expected = DataFrame::from_rows(
+            vec![
+                vec![Value::Int32(Some(6))],
+                vec![Value::Int32(Some(7))],
+                vec![Value::Int32(Some(8))],
+            ]
+            .into_iter()
+            .map(Row::from),
+        )
+        .unwrap();
+        assert_eq!(expected, df);
+
+        // Scan with limit.
+        let df = tx
+            .scan(table.clone(), &[Value::Int32(Some(0))], 2, None)
+            .unwrap();
+        let expected = DataFrame::from_rows(
+            vec![vec![Value::Int32(Some(4))], vec![Value::Int32(Some(6))]]
+                .into_iter()
+                .map(Row::from),
+        )
+        .unwrap();
+        assert_eq!(expected, df);
+    }
+}


### PR DESCRIPTION
This adds a `RocksStore` type that provides a `StorageTx` allow for various
storage operations on the underlying db. Note that this a very early version,
and as such, lacks a ton features that we'll need to add in over time. Also, the
api is not set in stone, but is close to what I would want to expose to the rest
of the system.

- Every record has a primary index that acts as the key to some row. When
inserting a row, this is a list of usize values which index into the row values
themselves. Keys will be extended to included a timestamp to allow for
transactional semantics.

- Rows are inserted as a "primary row internal value". The other type of
"internal value" is a tombstone, which indicates a record deletion. "Internal
values" will be expanded to encompass things like write intents for interactive
and distributed transactions.

- Everything (keys and values) is currently serialized using bincode. As such,
there are very light guarantees about ordering during a scan.

- This does not map super well to lemur's source traits, and there will need to
be some modifications to both the traits and the api presented here.

- Very inefficient. This is very much a "let's get something working".

- Minimal thought has been put into recovery. Rocks has a WAL, which is fine for
now, but will be lacking when raft is added on top.