### PR TITLE
chore: Cache `target` in ci tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,6 @@ jobs:
         uses: actions/checkout@v2
 
       # Taken from: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      #
-      # Does not include the "target" directory as running the miri script will
-      # remove it anyways.
       - uses: actions/cache@v2
         with:
           path: |
@@ -22,6 +19,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Tests (Stable)


### PR DESCRIPTION
Speeds up tests in ci.

This was originally omitted because I previously had miri running on every
commit as well. But I removed running miri for the time being, since there's no
unsafe code currently.

Eventually I do want to run miri for crates that contain unsafe, and we'll have
to revisit exactly which directories need cached.