### PR TITLE
test(sqlengine): resolve unused variable warnings in tests

### DIFF
--- a/crates/sqlengine/src/engine.rs
+++ b/crates/sqlengine/src/engine.rs
@@ -428,16 +428,16 @@ mod tests {
         let mut session = prepare_session(MemoryDataSource::new()).await;
 
         let query = "create table foo (a int, b int)";
-        let create_table = session.execute_query(query).await.unwrap();
+        let _create_table = session.execute_query(query).await.unwrap();
 
         let query = "create table bar (a int, b int)";
-        let create_table = session.execute_query(query).await.unwrap();
+        let _create_table = session.execute_query(query).await.unwrap();
         println!("session: {:?}", session);
-        let record_a = session
+        let _record_a = session
             .execute_query("insert into foo values (10000001, 10000002)")
             .await
             .unwrap();
-        let record_b = session
+        let _record_b = session
             .execute_query("insert into bar values (10000003, 10000002)")
             .await
             .unwrap();


### PR DESCRIPTION
Resolve warnings from sqlengine test due to unused variable warning

```
$ cargo t
warning: unused variable: `create_table`
   --> crates/sqlengine/src/engine.rs:431:13
    |
431 |         let create_table = session.execute_query(query).await.unwrap();
    |             ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_create_table`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `create_table`
   --> crates/sqlengine/src/engine.rs:434:13
    |
434 |         let create_table = session.execute_query(query).await.unwrap();
    |             ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_create_table`

warning: unused variable: `record_a`
   --> crates/sqlengine/src/engine.rs:436:13
    |
436 |         let record_a = session
    |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_record_a`

warning: unused variable: `record_b`
   --> crates/sqlengine/src/engine.rs:440:13
    |
440 |         let record_b = session
    |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_record_b`

warning: `sqlengine` (lib test) generated 4 warnings
    Finished test [unoptimized + debuginfo] target(s) in 0.16s
     Running unittests src/lib.rs (target/debug/deps/glaredb-d76641a3269948fb)
```