### PR TITLE
fix: Remove datafusion-proto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,6 @@ dependencies = [
  "arrow",
  "async-trait",
  "datafusion",
- "datafusion-proto",
  "futures",
  "logutil",
  "parking_lot",
@@ -1318,20 +1317,6 @@ dependencies = [
  "regex",
  "sha2 0.10.2",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "datafusion-proto"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ff1bd4294e862a1bd6d6c4278fee8d149f5125c138b9a3fb795540d8d9222e"
-dependencies = [
- "arrow",
- "datafusion",
- "datafusion-common",
- "datafusion-expr",
- "prost",
- "prost-build",
 ]
 
 [[package]]

--- a/crates/arrowstore/Cargo.toml
+++ b/crates/arrowstore/Cargo.toml
@@ -17,7 +17,6 @@ tonic = { version = "0.8.0", features = ["transport", "codegen"] }
 prost = "0.11.0"
 futures = "0.3"
 datafusion = "12.0.0"
-datafusion-proto = "12.0.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
We're not using if for anything yet, and this release seems to break building container images.

```
error: builder for '/nix/store/75lddm4kg8mzn2x5nz8lg36gdj16p7ka-glaredb-cli-0.1.0.drv' failed with exit code 101;
       last 10 log lines:
       > Caused by:
       >   process didn't exit successfully: `/build/source/target/release/build/datafusion-proto-497b9ae0fe438eda/build-script-build` (exit status: 1)
       >   --- stdout
       >   cargo:rerun-if-env-changed=FORCE_REBUILD
       >   cargo:rerun-if-changed=proto/datafusion.proto
       >   Running: "/nix/store/2qg94y58v1jr4dw360bmpxlrs30m31ca-protobuf-3.19.4/bin/protoc" "--include_imports" "--include_source_info" "-o" "/build/prost-buildFXFfZG/prost-descriptor-set" "-I" "proto" "-I" "/nix/store/2qg94y58v1jr4dw360bmpxlrs30m31ca-protobuf-3.19.4/include" "proto/datafusion.proto"
       >
       >   --- stderr
       >   Error: "protobuf compilation failed: Permission denied (os error 13)"
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run 'nix log /nix/store/75lddm4kg8mzn2x5nz8lg36gdj16p7ka-glaredb-cli-0.1.0.drv'.
```

Possibly related: https://github.com/apache/arrow-datafusion/issues/3538