### PR TITLE
ci: Update cachix settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: configure cachix
         uses: cachix/cachix-action@v10
         with:
-          name: glaredb
+          name: glaredb-ci
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: run checks

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: configure cachix
         uses: cachix/cachix-action@v10
         with:
-          name: glaredb
+          name: glaredb-ci
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
Uses a new binary cache named "glaredb-ci" ("glaredb" is attached to my personal cachix account that's now limited to 5GB).

Updated the github secret as well.