### PR TITLE
chore: Remove anyhow from lib crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,6 @@ dependencies = [
 name = "pgsrv"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "bytesutil",
@@ -2231,7 +2230,6 @@ dependencies = [
 name = "raft"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode",
  "clap",

--- a/crates/pgsrv/Cargo.toml
+++ b/crates/pgsrv/Cargo.toml
@@ -10,7 +10,6 @@ logutil = {path = "../logutil"}
 ioutil = {path = "../ioutil"}
 sqlexec = {path = "../sqlexec"}
 bytesutil = {path = "../bytesutil"}
-anyhow = "1.0"
 thiserror = "1.0"
 tracing = "0.1"
 async-trait = "0.1.56"

--- a/crates/raft/Cargo.toml
+++ b/crates/raft/Cargo.toml
@@ -14,7 +14,6 @@ prost = "0.11.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 thiserror = "1.0"
-anyhow = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
 tokio = { version = "1", features = ["full"] }

--- a/crates/raft/src/error.rs
+++ b/crates/raft/src/error.rs
@@ -3,10 +3,7 @@ use openraft::error::RPCError;
 use crate::repr::{Node, NodeId};
 
 #[derive(thiserror::Error)]
-pub enum Error {
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
+pub enum Error {}
 
 impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Still in `glaredb` and `slt_runner`, but I consider those binary crates, so using anyhow there seems reasonable.

Closes https://github.com/GlareDB/glaredb/issues/51