### PR TITLE
fix: Ensure temp dir exists when creating TempObjectStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,7 @@ dependencies = [
  "object_store",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/object_store_util/Cargo.toml
+++ b/crates/object_store_util/Cargo.toml
@@ -12,3 +12,4 @@ async-trait = "0.1.58"
 futures = "0.3.25"
 tokio = { version = "1", features = ["full"] }
 bytes = "1.2.1"
+tracing = "0.1"


### PR DESCRIPTION
Fixes https://github.com/GlareDB/glaredb/issues/252