### PR TITLE
feat: Add option to output logs in json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,17 +3651,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "nu-ansi-term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -18,8 +18,13 @@ use tokio::runtime::{Builder, Runtime};
 #[clap(version = "pre-release")]
 #[clap(about = "CLI for GlareDB", long_about = None)]
 struct Cli {
+    /// Log verbosity.
     #[clap(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
+
+    /// Output logs in json format.
+    #[clap(long)]
+    json_logging: bool,
 
     #[clap(subcommand)]
     command: Commands,
@@ -92,7 +97,7 @@ enum ClientCommands {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    logutil::init(cli.verbose);
+    logutil::init(cli.verbose, cli.json_logging);
 
     match cli.command {
         Commands::RaftNode {

--- a/crates/logutil/Cargo.toml
+++ b/crates/logutil/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 log = "0.4.0"
 env_logger = "0.9"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["std", "fmt"] }
+tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json"] }
 tracing-log = "0.1.3"

--- a/crates/logutil/src/lib.rs
+++ b/crates/logutil/src/lib.rs
@@ -1,6 +1,6 @@
 //! Utilities for logging and tracing.
 use tracing::{info, subscriber, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::{fmt::SubscriberBuilder, FmtSubscriber};
 
 #[derive(Debug)]
 pub enum Verbosity {
@@ -40,17 +40,31 @@ pub fn init_test() {
     let _ = subscriber::set_global_default(subscriber);
 }
 
+// TODO: It's likely we'll move to a "Builder" pattern for constructing the
+// global logger as we continue to add more options/integrations for cloud
+// logging.
+
 /// Initialize a trace subsriber printing to the console using the given
 /// verbosity count.
-pub fn init(verbosity: impl Into<Verbosity>) {
+pub fn init(verbosity: impl Into<Verbosity>, json: bool) {
     let verbosity = verbosity.into();
     let level: Level = verbosity.into();
-    let subscriber = FmtSubscriber::builder()
+
+    if json {
+        let builder = default_fmt_builder(level).json();
+        subscriber::set_global_default(builder.finish()).unwrap();
+    } else {
+        let builder = default_fmt_builder(level);
+        subscriber::set_global_default(builder.finish()).unwrap();
+    }
+
+    info!(%level, "log level set");
+}
+
+fn default_fmt_builder(level: Level) -> SubscriberBuilder {
+    FmtSubscriber::builder()
         .with_max_level(level)
         .with_thread_ids(true)
         .with_thread_names(true)
         .with_line_number(true)
-        .finish();
-    subscriber::set_global_default(subscriber).unwrap();
-    info!(%level, "log level set");
 }

--- a/crates/pgsrv/examples/pgsrv_stub.rs
+++ b/crates/pgsrv/examples/pgsrv_stub.rs
@@ -8,7 +8,7 @@ use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    logutil::init(1);
+    logutil::init(1, false);
 
     let args: Vec<_> = std::env::args().collect();
     let bind_addr = args.get(1).cloned().unwrap_or("localhost:0".to_string());

--- a/crates/slt_runner/src/main.rs
+++ b/crates/slt_runner/src/main.rs
@@ -39,7 +39,7 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    logutil::init(cli.verbose);
+    logutil::init(cli.verbose, false);
 
     let files = cli
         .files


### PR DESCRIPTION
This will make logs a bit more readable in the cloud console. There might be mismatches between how the `tracing` lib structures logs, and what GCP expected. We'll have to figure those out, but this should get us started.

This does not get us Cloud Trace or OpenTelemetry tracing. We will want to have support for those eventually, but it's not an immediate need.

Closes https://github.com/GlareDB/glaredb/issues/246.