### PR TITLE
fix: Ensure tmp dir exists for cache directory

### DIFF
--- a/crates/glaredb/src/server.rs
+++ b/crates/glaredb/src/server.rs
@@ -2,9 +2,12 @@ use anyhow::Result;
 use pgsrv::handler::{Handler, PostgresHandler};
 use sqlexec::runtime::AccessRuntime;
 use sqlexec::{engine::Engine, runtime::AccessConfig};
+use std::env;
+use std::fs;
 use std::{path::PathBuf, sync::Arc};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
+use tracing::trace;
 use tracing::{debug, info};
 
 pub struct ServerConfig {


### PR DESCRIPTION
Similar to `TempObjectStore`, our container does not have "/tmp". This fix ensures we have that tmp dir. This is duplicated with the temp object store, but that's fine.