### PR TITLE
chore: Remove extra return keyword

### DIFF
--- a/crates/sqlexec/src/information_schema.rs
+++ b/crates/sqlexec/src/information_schema.rs
@@ -163,7 +163,7 @@ impl SchemaProvider for InformationSchemaProvider {
     }
 
     fn table_exist(&self, name: &str) -> bool {
-        return matches!(name.to_ascii_lowercase().as_str(), TABLES | VIEWS | COLUMNS);
+        matches!(name.to_ascii_lowercase().as_str(), TABLES | VIEWS | COLUMNS)
     }
 }
 


### PR DESCRIPTION
New `needless-return` lint in clippy in 1.66.