### PR TITLE
feat: Include db name in object store locations

### DIFF
--- a/crates/access/src/compact.rs
+++ b/crates/access/src/compact.rs
@@ -52,13 +52,14 @@ impl Compactor {
     /// TODO: Remove needing schema here.
     pub async fn compact_deltas(
         &self,
+        db_name: &str,
         deltas: Arc<DeltaCache>,
         partition: PartitionKey,
         input_schema: SchemaRef,
     ) -> Result<()> {
         let _g = CompactionGuard::new(self);
 
-        let path = partition.object_path();
+        let path = partition.object_path(db_name);
         // TODO: Do we want to cache metas to avoid needing to fetch it
         // everytime?
         let exec: Arc<dyn ExecutionPlan> = match self.store.head(&path).await {

--- a/crates/access/src/keys.rs
+++ b/crates/access/src/keys.rs
@@ -47,8 +47,11 @@ pub struct PartitionKey {
 
 impl PartitionKey {
     /// Get the object path for a partition.
-    pub fn object_path(&self) -> ObjectPath {
-        let path = format!("table_{}_part_{}.data", self.table_id, self.part_id);
+    pub fn object_path(&self, db_name: &str) -> ObjectPath {
+        let path = format!(
+            "{}/table_{}_part_{}.data",
+            db_name, self.table_id, self.part_id
+        );
         ObjectPath::from(path)
     }
 }

--- a/crates/access/src/runtime.rs
+++ b/crates/access/src/runtime.rs
@@ -61,6 +61,7 @@ impl FromStr for ObjectStoreKind {
 //TODO: use new default, better yet ensure everything is set in config file
 #[derive(Debug, Default)]
 pub struct AccessConfig {
+    pub db_name: String,
     pub object_store: ObjectStoreKind,
     pub cached: bool,
     pub max_object_store_cache_size: Option<u64>,

--- a/crates/glaredb/src/server.rs
+++ b/crates/glaredb/src/server.rs
@@ -42,8 +42,10 @@ impl Server {
 
         let cache_dir = PathBuf::from(TempDir::new()?.path());
         let object_store = object_store.parse()?;
+        let db_name = db_name.into();
 
         let config = AccessConfig {
+            db_name,
             object_store,
             cached: true,
             max_object_store_cache_size: Some(DEFAULT_MAX_CACHE_SIZE),
@@ -53,7 +55,7 @@ impl Server {
         info!(?config, "Access Config");
         let access = Arc::new(AccessRuntime::new(config)?);
 
-        let engine = Engine::new(db_name, access)?;
+        let engine = Engine::new(access)?;
         Ok(Server {
             pg_handler: Arc::new(Handler::new(engine)),
         })

--- a/crates/pgsrv/examples/pgsrv_stub.rs
+++ b/crates/pgsrv/examples/pgsrv_stub.rs
@@ -17,11 +17,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!(%listen_addr, "listening");
 
     let config = AccessConfig {
+        db_name: "test".into(),
         object_store: ObjectStoreKind::LocalTemp,
         ..AccessConfig::default()
     };
 
-    let engine = Engine::new("test", Arc::new(AccessRuntime::new(config)?))?;
+    let engine = Engine::new(Arc::new(AccessRuntime::new(config)?))?;
 
     let handler = Arc::new(Handler::new(engine));
 

--- a/crates/sqlexec/src/datasource.rs
+++ b/crates/sqlexec/src/datasource.rs
@@ -56,6 +56,7 @@ impl DeltaTable {
                 .runtime
                 .compactor()
                 .compact_deltas(
+                    &self.runtime.config().db_name,
                     self.runtime.delta_cache().clone(),
                     key.clone(),
                     self.schema.clone(),
@@ -104,42 +105,42 @@ impl TableProvider for DeltaTable {
 
         let merr = Into::<DataFusionError>::into;
 
-        let exec: Arc<dyn ExecutionPlan> =
-            match self.runtime.object_store().head(&key.object_path()).await {
-                Ok(meta) => {
-                    let children: Vec<Arc<dyn ExecutionPlan>> = vec![
-                        Arc::new(
-                            DeltaInsertsExec::new(
-                                key.clone(),
-                                self.schema.clone(),
-                                self.runtime.delta_cache().clone(),
-                                projection.clone(),
-                            )
-                            .map_err(merr)?,
-                        ),
-                        Arc::new(
-                            LocalPartitionExec::new(
-                                self.runtime.object_store().clone(),
-                                meta,
-                                self.schema.clone(),
-                                projection.clone(),
-                            )
-                            .map_err(merr)?,
-                        ),
-                    ];
-                    Arc::new(SelectUnorderedExec::new(children).map_err(merr)?)
-                }
-                Err(ObjectStoreError::NotFound { .. }) => Arc::new(
-                    DeltaInsertsExec::new(
-                        key.clone(),
-                        self.schema.clone(),
-                        self.runtime.delta_cache().clone(),
-                        projection.clone(),
-                    )
-                    .map_err(merr)?,
-                ),
-                Err(e) => return Err(e.into()),
-            };
+        let location = &key.object_path(&self.runtime.config().db_name);
+        let exec: Arc<dyn ExecutionPlan> = match self.runtime.object_store().head(location).await {
+            Ok(meta) => {
+                let children: Vec<Arc<dyn ExecutionPlan>> = vec![
+                    Arc::new(
+                        DeltaInsertsExec::new(
+                            key.clone(),
+                            self.schema.clone(),
+                            self.runtime.delta_cache().clone(),
+                            projection.clone(),
+                        )
+                        .map_err(merr)?,
+                    ),
+                    Arc::new(
+                        LocalPartitionExec::new(
+                            self.runtime.object_store().clone(),
+                            meta,
+                            self.schema.clone(),
+                            projection.clone(),
+                        )
+                        .map_err(merr)?,
+                    ),
+                ];
+                Arc::new(SelectUnorderedExec::new(children).map_err(merr)?)
+            }
+            Err(ObjectStoreError::NotFound { .. }) => Arc::new(
+                DeltaInsertsExec::new(
+                    key.clone(),
+                    self.schema.clone(),
+                    self.runtime.delta_cache().clone(),
+                    projection.clone(),
+                )
+                .map_err(merr)?,
+            ),
+            Err(e) => return Err(e.into()),
+        };
 
         Ok(exec)
     }

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -12,7 +12,8 @@ pub struct Engine {
 }
 
 impl Engine {
-    pub fn new(db_name: impl Into<String>, access: Arc<AccessRuntime>) -> Result<Engine> {
+    pub fn new(access: Arc<AccessRuntime>) -> Result<Engine> {
+        let db_name = &access.config().db_name;
         let runtime = RuntimeEnv::default();
 
         let catalog = DatabaseCatalog::new(db_name);

--- a/crates/sqlexec/src/executor.rs
+++ b/crates/sqlexec/src/executor.rs
@@ -139,11 +139,13 @@ mod tests {
 
     #[tokio::test]
     async fn simple() {
-        let catalog = DatabaseCatalog::new("test");
+        let db_name = String::from("test");
+        let catalog = DatabaseCatalog::new(db_name.clone());
         catalog.insert_default_schema().unwrap();
         let cache_dir = TempDir::new().unwrap();
 
         let config = AccessConfig {
+            db_name,
             object_store: ObjectStoreKind::LocalTemp,
             cached: true,
             max_object_store_cache_size: Some(4 * 1024 * 1024 * 1024),


### PR DESCRIPTION
- Store db name in access config
- Have engine get db name from access config, which in turn uses it as the catalog name as well

fixes #260 