### PR TITLE
chore: Add cacerts to glaredb image

### DIFF
--- a/flake-parts/packages/default.nix
+++ b/flake-parts/packages/default.nix
@@ -81,7 +81,7 @@
 
       glaredb_image = pkgs.dockerTools.buildLayeredImage {
         name = "glaredb";
-        contents = [packages.cli] ++ debugPackages;
+        contents = [packages.cli pkgs.cacert] ++ debugPackages;
         created = "now";
         config.Cmd = ["${packages.cli}/bin/glaredb"];
       };


### PR DESCRIPTION
Needed to connect to object store.