### PR TITLE
fix: include glaredb cli package in container images

### DIFF
--- a/flake-parts/default.nix
+++ b/flake-parts/default.nix
@@ -165,7 +165,7 @@
 
       glaredb_image = mkContainer {
         name = "glaredb";
-        contents = [pkgs.cacert packages.config];
+        contents = [pkgs.cacert packages.config packages.cli];
         config.Cmd = ["${packages.cli}/bin/glaredb"];
       };
 
@@ -178,7 +178,7 @@
       # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
       pgsrv_image = mkContainer {
         name = "pgsrv";
-        contents = [pkgs.cacert];
+        contents = [pkgs.cacert packages.cli];
         config.Cmd = ["${packages.cli}/bin/glaredb"];
       };
 


### PR DESCRIPTION
#302 removed the cli package from the containers. The idea was that it would be included automatically by being in the image's Cmd input. However our deployment specifies the command explicitly and was unable to start the server resulting in a failed run https://github.com/GlareDB/cloud/actions/runs/3483784825

The easiest solution-- just put the cli back in the container