### PR TITLE
chore: Add stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,7 @@ daysUntilStale: 21
 # Number of days of inactivity before a stale issue is closed.
 daysUntilClose: 7
 # Label to use when marking an issue as stale.
-staleLabel: stale
+staleLabel: stale :bread:
 # Comment to post when marking an issue as stale. Set to `false` to disable.
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Issues marked stale after 21 days, closed after an additional 7.

Rationale for this is we probably shouldn't have issue be open for a month with no activity at this stage of product development. If an issue is open for longer than this with no activity, it either doesn't matter, or the issue isn't actionable in its current state.