### PR TITLE
fix: Actually fix version

### DIFF
--- a/crates/buildenv/build.rs
+++ b/crates/buildenv/build.rs
@@ -1,12 +1,21 @@
 use std::process::Command;
 
+/// Environment variable to use to override the git tag. If unset, we'll shell
+/// out `git` to get the tag info.
+const GIT_TAG_OVERRIDE: &str = "GIT_TAG_OVERRIDE";
+
 fn main() {
-    let git_tag = match Command::new("git")
-        .args(["describe", "--tags", "--always"])
-        .output()
-    {
-        Ok(output) => String::from_utf8(output.stdout).unwrap(),
-        Err(_) => String::from("unknown"),
+    let git_tag = match std::env::var(GIT_TAG_OVERRIDE) {
+        Ok(tag) => tag,
+        Err(_) => {
+            match Command::new("git")
+                .args(["describe", "--tags", "--always"])
+                .output()
+            {
+                Ok(output) => String::from_utf8(output.stdout).unwrap(),
+                Err(_) => String::from("unknown"),
+            }
+        }
     };
     println!("cargo:rustc-env=GIT_TAG={}", git_tag);
 }

--- a/flake.nix
+++ b/flake.nix
@@ -86,8 +86,12 @@
           # The `prost` crate uses `protoc` for parsing protobuf files. Ensure it
           # can find the one we're providing with nix.
           PROTOC = "${pkgs.protobuf}/bin/protoc";
-        };
 
+          # Used during build time to inject the git revision into the binary.
+          #
+          # See the `buildenv` crate.
+          GIT_TAG_OVERRIDE = self.rev or "dirty";
+        };
 
         # Build all dependencies. Built dependencies will be reused across checks
         # and builds.


### PR DESCRIPTION
Adds an `GIT_TAG_OVERRIDE` that's set by nix during build time. This uses nix's `rev` thing. On untagged commits, it'll be the full commit hash, on tagged commits, it'll be the tag.

Fixes https://github.com/GlareDB/glaredb/issues/398