### PR TITLE
chore: Spoof a real postgres version

### DIFF
--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -24,7 +24,8 @@ use tracing::{trace, warn};
 /// other parameters we may want to provide.
 ///
 /// Some parameters  will eventually be provided at runtime.
-const DEFAULT_READ_ONLY_PARAMS: &[(&str, &str)] = &[("server_version", "0.0.0")];
+// TODO: Decide proper postgres version to spoof/support
+const DEFAULT_READ_ONLY_PARAMS: &[(&str, &str)] = &[("server_version", "15.1")];
 
 /// A wrapper around a SQL engine that implements the Postgres frontend/backend
 /// protocol.


### PR DESCRIPTION
Could not test this with airbyte local, not able to see my local host but could see that psql does not give the warning that it used to:

<img width="554" alt="image" src="https://user-images.githubusercontent.com/2547411/207890977-92f5e13b-c483-4499-8eb5-770e8363d1b8.png">
