### PR TITLE
chore: disable `create table` and return "unsupported"

### DIFF
--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -105,9 +105,10 @@ impl Session {
         }
     }
 
-    pub(crate) async fn create_table(&self, plan: CreateTable) -> Result<()> {
-        self.ctx.create_table(plan)?;
-        Ok(())
+    pub(crate) async fn create_table(&self, _plan: CreateTable) -> Result<()> {
+        // Disable creating table temporarily since we actually can't insert
+        // anything into tables yet.
+        Err(ExecError::UnsupportedFeature("CREATE TABLE ..."))
     }
 
     pub(crate) async fn create_external_table(&self, plan: CreateExternalTable) -> Result<()> {

--- a/testdata/sqllogictests/aggregates.slt
+++ b/testdata/sqllogictests/aggregates.slt
@@ -5,10 +5,10 @@
 # Built-in aggregates should match the behavior of Postgres.
 # See: https://www.postgresql.org/docs/8.2/functions-aggregate.html
 
+halt
+
 statement ok
 create table t_aggs (a smallint, b real, c text);
-
-halt
 
 statement ok
 insert into t_aggs values (1, 1.0, '1'), (2, 2.0, '2'), (3, 3.0, '3'), (4, 4.0, '4');

--- a/testdata/sqllogictests/cte/cte_basic.slt
+++ b/testdata/sqllogictests/cte/cte_basic.slt
@@ -6,10 +6,10 @@ create schema basic_cte;
 statement ok
 set search_path = basic_cte;
 
+halt
+
 statement ok
 create table a(i integer);
-
-halt
 
 statement ok
 insert into a values (42);

--- a/testdata/sqllogictests/information_schema.slt
+++ b/testdata/sqllogictests/information_schema.slt
@@ -1,5 +1,7 @@
 # Queries related to the information_schema.
 
+halt
+
 statement ok
 create table schema_table (a int, b text);
 
@@ -7,8 +9,6 @@ query TT
 select table_name, table_type from information_schema.tables where table_name = 'schema_table';
 ----
 schema_table    BASE TABLE
-
-halt
 
 query TTT
 select table_name, column_name, data_type from information_schema.columns where table_name = 'schema_table' order by column_name;

--- a/testdata/sqllogictests/joins/full_outer/full_outer_join.slt
+++ b/testdata/sqllogictests/joins/full_outer/full_outer_join.slt
@@ -6,10 +6,10 @@ create schema full_outer_join;
 statement ok
 set search_path = full_outer_join;
 
+halt
+
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER)
-
-halt
 
 statement ok
 INSERT INTO integers VALUES (1, 1), (3, 3)

--- a/testdata/sqllogictests/joins/full_outer/full_outer_join_complex.slt
+++ b/testdata/sqllogictests/joins/full_outer/full_outer_join_complex.slt
@@ -6,10 +6,10 @@ create schema full_outer_join_complex;
 statement ok
 set search_path = full_outer_join_complex;
 
+halt
+
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER)
-
-halt
 
 statement ok
 INSERT INTO integers VALUES (1, 1)

--- a/testdata/sqllogictests/joins/inner_join/inner_join.slt
+++ b/testdata/sqllogictests/joins/inner_join/inner_join.slt
@@ -6,10 +6,10 @@ create schema inner_join;
 statement ok
 set search_path = inner_join;
 
+halt
+
 statement ok
 CREATE TABLE test (a INTEGER, b INTEGER);
-
-halt
 
 statement ok
 INSERT INTO test VALUES (11, 1), (12, 2), (13, 3)

--- a/testdata/sqllogictests/joins/inner_join/using_join.slt
+++ b/testdata/sqllogictests/joins/inner_join/using_join.slt
@@ -6,11 +6,11 @@ create schema using_join;
 statement ok
 set search_path = using_join;
 
+halt
+
 # create tables
 statement ok
 CREATE TABLE t1 (a INTEGER, b INTEGER, c INTEGER)
-
-halt
 
 statement ok
 INSERT INTO t1 VALUES (1,2,3)

--- a/testdata/sqllogictests/joins/join_on_aggregates.slt
+++ b/testdata/sqllogictests/joins/join_on_aggregates.slt
@@ -6,11 +6,10 @@ create schema join_on_aggregates;
 statement ok
 set search_path = join_on_aggregates;
 
+halt
+
 statement ok
 CREATE TABLE integers(i INTEGER)
-
-# TODO: Can't insert null into table.
-halt
 
 statement ok
 INSERT INTO integers VALUES (1), (2), (3), (NULL)

--- a/testdata/sqllogictests/search_path.slt
+++ b/testdata/sqllogictests/search_path.slt
@@ -6,11 +6,11 @@ create schema search_path_schema_1;
 statement ok
 set search_path = search_path_schema_1;
 
+halt
+
 # Creates table in 'search_path_schema_1'
 statement ok
 create table t (a int);
-
-halt
 
 # Marker values for first schema.
 statement ok

--- a/testdata/sqllogictests/simple.slt
+++ b/testdata/sqllogictests/simple.slt
@@ -16,14 +16,14 @@ select * from (values (1, 2, 3), (3, 4, 5))
 1 2 3
 3 4 5
 
+halt
+
 statement ok
 create table t1 (a smallint, b smallint)
 
 # Table already exists.
 statement error
 create table t1 (a smallint, b smallint)
-
-halt
 
 statement ok
 insert into t1 values (1, 2), (3, 4), (5, 6)

--- a/testdata/sqllogictests/topn/topn_basic.slt
+++ b/testdata/sqllogictests/topn/topn_basic.slt
@@ -6,10 +6,10 @@ create schema topn_basic;
 statement ok
 set search_path = topn_basic;
 
+halt
+
 statement ok
 CREATE TABLE test (b INTEGER);
-
-halt
 
 statement ok
 INSERT INTO test VALUES (22), (2), (7);

--- a/testdata/sqllogictests/window/over_grouping.slt
+++ b/testdata/sqllogictests/window/over_grouping.slt
@@ -6,14 +6,14 @@ create schema over_grouping;
 statement ok
 set search_path = over_grouping;
 
+halt
+
 statement ok
 create table image  (
     id          smallint primary key,
     width       int not null,
     height      integer not null
 );
-
-halt
 
 statement ok
 insert into image (id, width, height) values (1, 500, 297);


### PR DESCRIPTION
Since we actually can't insert anything into the tables, creating a table returns the "unsupported feature" error message.

Fixes: #466
