### PR TITLE
chore: Include generated certs in glaredb image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -204,7 +204,14 @@
           # GlareDB image.
           glaredb-image = mkContainer {
             name = "glaredb";
-            contents = [pkgs.cacert config-directory packages.glaredb-bin];
+            contents = [
+              pkgs.cacert
+              config-directory
+              packages.glaredb-bin
+              # Generated certs used for SSL connections in pgsrv. GlareDB
+              # proper does not currently use certs.
+              generated-certs
+            ];
             config.Cmd = ["${packages.glaredb-bin}/bin/glaredb"];
           };
 


### PR DESCRIPTION
Previously they were only injected to the pgsrv image, but if we choose to do https://github.com/GlareDB/cloud/issues/517, then they'll need to be injected into the image that we share across all services. I think the glaredb image should be that shared image.