### PR TITLE
feat: implement various other connections (local, gcs, s3...)

### DIFF
--- a/crates/sqlexec/src/catalog/entry.rs
+++ b/crates/sqlexec/src/catalog/entry.rs
@@ -116,6 +116,11 @@ pub enum TableOptions {
         bucket_name: String,
         location: String,
     },
+    S3 {
+        region: String,
+        bucket_name: String,
+        location: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -193,6 +198,10 @@ pub enum ConnectionMethod {
     Gcs {
         service_account_key: String,
     },
+    S3 {
+        access_key_id: String,
+        access_key_secret: String,
+    },
 }
 
 impl fmt::Display for ConnectionMethod {
@@ -206,6 +215,7 @@ impl fmt::Display for ConnectionMethod {
                 ConnectionMethod::BigQuery { .. } => "bigquery",
                 ConnectionMethod::Local => "local",
                 ConnectionMethod::Gcs { .. } => "gcs",
+                ConnectionMethod::S3 { .. } => "s3",
             }
         )
     }

--- a/crates/sqlexec/src/dispatch.rs
+++ b/crates/sqlexec/src/dispatch.rs
@@ -16,7 +16,7 @@ use datafusion::datasource::ViewTable;
 use datasource_bigquery::{BigQueryAccessor, BigQueryTableAccess};
 use datasource_object_store::gcs::{GcsAccessor, GcsTableAccess};
 use datasource_object_store::local::{LocalAccessor, LocalTableAccess};
-use datasource_object_store::s3::S3Accessor;
+use datasource_object_store::s3::{S3Accessor, S3TableAccess};
 use datasource_postgres::{PostgresAccessor, PostgresTableAccess};
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -275,6 +275,41 @@ impl<'a> SessionDispatcher<'a> {
                             > = task::block_in_place(move || {
                                 Handle::current().block_on(async move {
                                     let accessor = GcsAccessor::new(table_access).await?;
+                                    let provider = accessor.into_table_provider(true).await?;
+                                    Ok(provider)
+                                })
+                            });
+                            let provider = result?;
+                            Ok(Some(Arc::new(provider)))
+                        }
+                        (
+                            TableOptions::S3 {
+                                region,
+                                bucket_name,
+                                location,
+                            },
+                            ConnectionEntry {
+                                method:
+                                    ConnectionMethod::S3 {
+                                        access_key_id,
+                                        access_key_secret,
+                                    },
+                                ..
+                            },
+                        ) => {
+                            let table_access = S3TableAccess {
+                                region: region.clone(),
+                                bucket_name: bucket_name.clone(),
+                                location: location.clone(),
+                                access_key_id: access_key_id.clone(),
+                                secret_access_key: access_key_secret.clone(),
+                            };
+                            let result: Result<
+                                _,
+                                datasource_object_store::errors::ObjectStoreSourceError,
+                            > = task::block_in_place(move || {
+                                Handle::current().block_on(async move {
+                                    let accessor = S3Accessor::new(table_access).await?;
                                     let provider = accessor.into_table_provider(true).await?;
                                     Ok(provider)
                                 })

--- a/crates/sqlexec/src/planner.rs
+++ b/crates/sqlexec/src/planner.rs
@@ -74,6 +74,17 @@ impl<'a> SessionPlanner<'a> {
                     },
                 }
             }
+            "s3" => {
+                let access_key_id = remove_required_opt(m, "access_key_id")?;
+                let access_key_secret = remove_required_opt(m, "access_key_secret")?;
+                CreateConnection {
+                    connection_name: stmt.name,
+                    method: ConnectionMethod::S3 {
+                        access_key_id,
+                        access_key_secret,
+                    },
+                }
+            }
             "debug" if *self.ctx.get_session_vars().enable_debug_datasources.value() => {
                 CreateConnection {
                     connection_name: stmt.name,
@@ -150,6 +161,21 @@ impl<'a> SessionPlanner<'a> {
                         table_name: stmt.name,
                         access: AccessOrConnection::Connection(conn.name.clone()),
                         table_options: TableOptions::Gcs {
+                            bucket_name,
+                            location,
+                        },
+                    }
+                }
+                ConnectionMethod::S3 { .. } => {
+                    let region = remove_required_opt(m, "region")?;
+                    let bucket_name = remove_required_opt(m, "bucket_name")?;
+                    let location = remove_required_opt(m, "location")?;
+                    CreateExternalTable {
+                        create_sql,
+                        table_name: stmt.name,
+                        access: AccessOrConnection::Connection(conn.name.clone()),
+                        table_options: TableOptions::S3 {
+                            region,
                             bucket_name,
                             location,
                         },


### PR DESCRIPTION
Local:

```
glaredb=> create connection myconn for local;
CREATE CONNECTION

glaredb=> create external table mytable from myconn options ( location = '/path/to/data.parquet' );
CREATE TABLE

glaredb=> select * from mytable;
```

---

GCS:

```
glaredb=> create connection myconn for gcs options ( service_account_key = '{ ... }' );
CREATE CONNECTION

glaredb=> create external table mytable from myconn options ( bucket_name = 'vrongmeal-test-glaredb-bucket', location = 'userdata1.parquet' );
CREATE TABLE

glaredb=> select * from mytable;
```

---

S3:

```
glaredb=> create connection myconn for s3 options ( access_key_id = '...', access_key_secret = '...' );
CREATE CONNECTION

glaredb=> create external table mytable from myconn options ( region = 'us-east-1', bucket_name = 'rustom-test', location = 'userdata1.parquet' );
CREATE TABLE

glaredb=> select * from mytable;
```