### PR TITLE
chore: Add some tests for Metastore workers in sqlexec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tower",
  "tracing",
  "uuid",
 ]

--- a/crates/sqlexec/Cargo.toml
+++ b/crates/sqlexec/Cargo.toml
@@ -37,3 +37,4 @@ tonic = { version = "0.8", features = ["transport", "tls", "tls-roots"] }
 
 [dev-dependencies]
 tempfile = "3"
+tower = "0.4"


### PR DESCRIPTION
Adds a couple of tests.

Also tweaked the behavior where the worker exits after some amount of inactivity.