### PR TITLE
chore: Remove building and pushing pgsrv image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -204,21 +204,6 @@
             config.Cmd = ["${packages.glaredb-bin}/bin/glaredb"];
           };
 
-          # Pgsrv image.
-          #
-          # Note that this currently uses the same command as the glaredb image. The
-          # pgsrv proxy uses the same root command. Eventually this may be moved to
-          # its own binary.
-          #
-          # Arguments will be provided in the k8s/terraform config. The api addr for
-          # Cloud will be set to some internal uri.
-          # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
-          pgsrv-image = mkContainer {
-            name = "pgsrv";
-            contents = [pkgs.cacert packages.glaredb-bin generated-certs];
-            config.Cmd = ["${packages.glaredb-bin}/bin/glaredb"];
-          };
-
           slt-runner-bin = craneLib.buildPackage ({
             inherit cargoArtifacts;
             pname = "slt-runner";

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Build, tag, and push the 'glaredb' and 'pgsrv' docker images.
+# Build, tag, and push the 'glaredb' docker image.
 #
 # Requires that docker be configured with the cloud project.
 #
@@ -62,11 +62,8 @@ check_command() {
 
 # build the container archives
 nix build .#glaredb-image --out-link glaredb_image
-nix build .#pgsrv-image --out-link pgsrv_image
 
 # ensure that the command can be executed inside the containers before pushing
 check_command "glaredb_image" "glaredb --help" "glaredb"
-check_command "pgsrv_image" "glaredb --help" "pgsrv"
 
 push_image "glaredb_image" "glaredb"
-push_image "pgsrv_image" "pgsrv"


### PR DESCRIPTION
No longer needed. See https://github.com/GlareDB/cloud/pull/543