### PR TITLE
fix: metastore panics due to clap option collision

### DIFF
--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -76,7 +76,7 @@ enum Commands {
         bind: String,
 
         /// Bucket to use for database catalogs.
-        #[clap(short, long, value_parser)]
+        #[clap(short = 'u', long, value_parser)]
         bucket: Option<String>,
 
         /// Path to GCP service account to use when connecting to GCS.


### PR DESCRIPTION
- Update short option alias for `--bucket` to `-u` to prevent collision with `--bind` option