### PR TITLE
fix(mysql): differentiate between text and blob datatypes

### DIFF
--- a/testdata/sqllogictests_mysql/datatypes.slt
+++ b/testdata/sqllogictests_mysql/datatypes.slt
@@ -1,5 +1,7 @@
 # Basic tests for postgres external tables 
 
+include ./include/conn.slti
+
 # Create an external table that connects to the datatypes tables
 statement ok
 CREATE EXTERNAL TABLE numeric_datatypes
@@ -43,7 +45,7 @@ NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
 query TTTTT
 SELECT * FROM string_datatypes;
 ----
-a bc 100,101,102 {"a": [1, 2]} 98,105,110
+a bc def {"a": [1, 2]} 98,105,110
 NULL NULL NULL NULL NULL
 
 # Currently we are not formatting dates other than outputing epoch time with


### PR DESCRIPTION
Column flags indicate whether or not the field is a text type (utf-8) or a binary blob. Use the flag to cast into datafusion types.