### PR TITLE
feat: Attach user id to session

### DIFF
--- a/crates/pgsrv/src/auth.rs
+++ b/crates/pgsrv/src/auth.rs
@@ -13,6 +13,8 @@ pub struct DatabaseDetails {
     pub port: String,
     /// ID of the database we're connecting to (UUID).
     pub database_id: String,
+    /// ID of the user initiating the connection (UUID).
+    pub user_id: String,
 }
 
 #[async_trait]

--- a/crates/pgsrv/src/errors.rs
+++ b/crates/pgsrv/src/errors.rs
@@ -29,11 +29,11 @@ pub enum PgSrvError {
     #[error("missing org ID: pass it as an option, or subdomain in proxy or in database as '<org>/<db>'")]
     MissingOrgId,
 
-    #[error("Invalid database ID: {0}")]
-    InvalidDatabaseId(String),
+    #[error("Missing key '{0}' in startup params.")]
+    MissingProxyKey(&'static str),
 
-    #[error("Missing database ID param.")]
-    MissingDatabaseIdParam,
+    #[error("Invalid value for key '{key}': {value}")]
+    InvalidValueForProxyKey { key: &'static str, value: String },
 
     /// A stringified error from cloud.
     #[error("cloud: {0}")]

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -27,13 +27,13 @@ impl Engine {
     }
 
     /// Create a new session with the given id.
-    pub async fn new_session(&self, conn_id: Uuid, db_id: Uuid) -> Result<Session> {
+    pub async fn new_session(&self, user_id: Uuid, conn_id: Uuid, db_id: Uuid) -> Result<Session> {
         let metastore = self.supervisor.init_client(conn_id, db_id).await?;
 
         let state = metastore.get_cached_state().await?;
         let catalog = SessionCatalog::new(state);
 
-        let session = Session::new(conn_id, catalog, metastore, self.tracker.clone())?;
+        let session = Session::new(user_id, conn_id, catalog, metastore, self.tracker.clone())?;
         Ok(session)
     }
 }


### PR DESCRIPTION
Adds an additional param holding the user id the pgsrv will will append to the startup params. This is threaded down to session creates so it can be used for telemetry.

This also adds the `ProxyKey` trait with a single implementation. Additional implementations will be added for supporting https://github.com/GlareDB/glaredb/issues/600.

Related Cloud change: https://github.com/GlareDB/cloud/pull/613