### PR TITLE
feat: Use oid for ssh tunnel in connection options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
 name = "datasource_common"
 version = "0.1.0"
 dependencies = [
+ "metastore",
  "openssh",
  "rand 0.8.5",
  "ssh-key",

--- a/crates/datasource_common/Cargo.toml
+++ b/crates/datasource_common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+metastore = {path = "../metastore"}
 openssh = "0.9.9"
 rand = "0.8.5"
 ssh-key = { version = "0.5.1", features = ["ed25519", "alloc"] }

--- a/crates/datasource_common/src/ssh.rs
+++ b/crates/datasource_common/src/ssh.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::os::unix::prelude::PermissionsExt;
 
+use metastore::types::catalog::ConnectionOptionsSsh;
 use openssh::{ForwardType, KnownHosts, Session, SessionBuilder};
 use ssh_key::sec1::der::zeroize::Zeroizing;
 use ssh_key::{LineEnding, PrivateKey};
@@ -141,6 +142,19 @@ impl SshTunnelAccess {
             )
         })?;
         listener.local_addr()
+    }
+}
+
+impl TryFrom<&ConnectionOptionsSsh> for SshTunnelAccess {
+    type Error = Error;
+    fn try_from(value: &ConnectionOptionsSsh) -> Result<Self> {
+        let keypair = SshKey::from_bytes(&value.keypair)?;
+        Ok(SshTunnelAccess {
+            host: value.host.clone(),
+            user: value.user.clone(),
+            port: value.port,
+            keypair,
+        })
     }
 }
 

--- a/crates/metastore/proto/catalog.proto
+++ b/crates/metastore/proto/catalog.proto
@@ -218,7 +218,8 @@ message ConnectionOptionsDebug {}
 
 message ConnectionOptionsPostgres {
   string connection_string = 1;
-  optional string ssh_tunnel = 2; // Connection name for ssh tunnel
+  reserved 2;
+  optional uint32 ssh_tunnel = 3; // Connection id for ssh tunnel
 }
 
 message ConnectionOptionsBigQuery {
@@ -228,7 +229,8 @@ message ConnectionOptionsBigQuery {
 
 message ConnectionOptionsMysql {
   string connection_string = 1;
-  optional string ssh_tunnel = 2; // Connection name for ssh tunnel
+  reserved 2;
+  optional uint32 ssh_tunnel = 3; // Connection id for ssh tunnel
 }
 
 message ConnectionOptionsLocal {}

--- a/crates/metastore/src/proto/catalog.rs
+++ b/crates/metastore/src/proto/catalog.rs
@@ -318,9 +318,9 @@ pub struct ConnectionOptionsDebug {}
 pub struct ConnectionOptionsPostgres {
     #[prost(string, tag = "1")]
     pub connection_string: ::prost::alloc::string::String,
-    /// Connection name for ssh tunnel
-    #[prost(string, optional, tag = "2")]
-    pub ssh_tunnel: ::core::option::Option<::prost::alloc::string::String>,
+    /// Connection id for ssh tunnel
+    #[prost(uint32, optional, tag = "3")]
+    pub ssh_tunnel: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -335,9 +335,9 @@ pub struct ConnectionOptionsBigQuery {
 pub struct ConnectionOptionsMysql {
     #[prost(string, tag = "1")]
     pub connection_string: ::prost::alloc::string::String,
-    /// Connection name for ssh tunnel
-    #[prost(string, optional, tag = "2")]
-    pub ssh_tunnel: ::core::option::Option<::prost::alloc::string::String>,
+    /// Connection id for ssh tunnel
+    #[prost(uint32, optional, tag = "3")]
+    pub ssh_tunnel: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/metastore/src/types/catalog.rs
+++ b/crates/metastore/src/types/catalog.rs
@@ -372,6 +372,16 @@ impl From<ConnectionEntry> for catalog::ConnectionEntry {
     }
 }
 
+impl ConnectionEntry {
+    /// Try to get ssh options if this connection is an ssh connection.
+    pub fn try_get_ssh_options(&self) -> Option<&ConnectionOptionsSsh> {
+        match &self.options {
+            ConnectionOptions::Ssh(ssh) => Some(ssh),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Arbitrary)]
 pub struct ExternalTableEntry {
     pub meta: EntryMeta,
@@ -777,7 +787,7 @@ impl From<ConnectionOptionsDebug> for catalog::ConnectionOptionsDebug {
 #[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
 pub struct ConnectionOptionsPostgres {
     pub connection_string: String,
-    pub ssh_tunnel: Option<String>,
+    pub ssh_tunnel: Option<u32>,
 }
 
 impl TryFrom<catalog::ConnectionOptionsPostgres> for ConnectionOptionsPostgres {
@@ -827,7 +837,7 @@ impl From<ConnectionOptionsBigQuery> for catalog::ConnectionOptionsBigQuery {
 #[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
 pub struct ConnectionOptionsMysql {
     pub connection_string: String,
-    pub ssh_tunnel: Option<String>,
+    pub ssh_tunnel: Option<u32>,
 }
 
 impl TryFrom<catalog::ConnectionOptionsMysql> for ConnectionOptionsMysql {

--- a/crates/sqlexec/src/dispatch.rs
+++ b/crates/sqlexec/src/dispatch.rs
@@ -179,9 +179,10 @@ impl<'a> SessionDispatcher<'a> {
                     connection_string: conn.connection_string.clone(),
                 };
 
-                let ssh_tunnel_access = self
-                    .ctx
-                    .get_ssh_tunnel_access(conn.ssh_tunnel.to_owned())
+                let tunn_access = conn
+                    .ssh_tunnel
+                    .map(|oid| self.ctx.get_ssh_tunnel_access_by_oid(oid))
+                    .transpose()
                     .map_err(|e| DispatchError::MissingSshTunnel(Box::new(e)))?;
 
                 let predicate_pushdown = *self
@@ -193,7 +194,7 @@ impl<'a> SessionDispatcher<'a> {
                     task::block_in_place(move || {
                         Handle::current().block_on(async move {
                             let accessor =
-                                PostgresAccessor::connect(table_access, ssh_tunnel_access).await?;
+                                PostgresAccessor::connect(table_access, tunn_access).await?;
                             let provider = accessor.into_table_provider(predicate_pushdown).await?;
                             Ok(provider)
                         })
@@ -231,9 +232,10 @@ impl<'a> SessionDispatcher<'a> {
                     connection_string: conn.connection_string.clone(),
                 };
 
-                let ssh_tunnel_access = self
-                    .ctx
-                    .get_ssh_tunnel_access(conn.ssh_tunnel.to_owned())
+                let tunn_access = conn
+                    .ssh_tunnel
+                    .map(|oid| self.ctx.get_ssh_tunnel_access_by_oid(oid))
+                    .transpose()
                     .map_err(|e| DispatchError::MissingSshTunnel(Box::new(e)))?;
 
                 let predicate_pushdown = *self
@@ -245,7 +247,7 @@ impl<'a> SessionDispatcher<'a> {
                     task::block_in_place(move || {
                         Handle::current().block_on(async move {
                             let accessor =
-                                MysqlAccessor::connect(table_access, ssh_tunnel_access).await?;
+                                MysqlAccessor::connect(table_access, tunn_access).await?;
                             let provider = accessor.into_table_provider(predicate_pushdown).await?;
                             Ok(provider)
                         })

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -48,8 +48,17 @@ pub enum ExecError {
         want: metastore::types::catalog::EntryType,
     },
 
-    #[error("Missing connection; schema: {schema}, name: {name}")]
-    MissingConnection { schema: String, name: String },
+    #[error("Missing connection by name; schema: {schema}, name: {name}")]
+    MissingConnectionByName { schema: String, name: String },
+
+    #[error("Missing connection by oid: {oid}")]
+    MissingConnectionByOid { oid: u32 },
+
+    #[error("Invalid connection type; expected: {expected}, got: {got}")]
+    InvalidConnectionType {
+        expected: &'static str,
+        got: &'static str,
+    },
 
     #[error("An ssh connection is not supported datasource for CREATE EXTERNAL TABLE. An ssh connection must be provided as an optional ssh_tunnel with another connection type")]
     ExternalTableWithSsh,


### PR DESCRIPTION
(Split out from dependencies pr, good to get this in quickly.)

Changes the table options for mysql and postgres to use the connection id instead of name when using an ssh tunnel. This provides two benefits:

- Makes determining dependencies easier.
- Avoid breakage when renaming a connection (when that gets in).