### PR TITLE
feat: drop connection support

### DIFF
--- a/crates/metastore/proto/service.proto
+++ b/crates/metastore/proto/service.proto
@@ -43,11 +43,15 @@ message Mutation {
   // next: 7
 }
 
-message DropSchema { string name = 1; }
+message DropSchema {
+  string name = 1;
+  bool if_exists = 2;
+}
 
 message DropObject {
   string schema = 1;
   string name = 2;
+  bool if_exists = 3;
 }
 
 message CreateSchema { string name = 1; }

--- a/crates/metastore/src/proto/service.rs
+++ b/crates/metastore/src/proto/service.rs
@@ -99,6 +99,8 @@ pub mod mutation {
 pub struct DropSchema {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub if_exists: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -107,6 +109,8 @@ pub struct DropObject {
     pub schema: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
+    #[prost(bool, tag = "3")]
+    pub if_exists: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/metastore/src/types/service.rs
+++ b/crates/metastore/src/types/service.rs
@@ -66,19 +66,26 @@ impl From<Mutation> for service::Mutation {
 #[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
 pub struct DropSchema {
     pub name: String,
+    pub if_exists: bool,
 }
 
 impl TryFrom<service::DropSchema> for DropSchema {
     type Error = ProtoConvError;
     fn try_from(value: service::DropSchema) -> Result<Self, Self::Error> {
         // TODO: Check if string is zero value.
-        Ok(DropSchema { name: value.name })
+        Ok(DropSchema {
+            name: value.name,
+            if_exists: value.if_exists,
+        })
     }
 }
 
 impl From<DropSchema> for service::DropSchema {
     fn from(value: DropSchema) -> Self {
-        service::DropSchema { name: value.name }
+        service::DropSchema {
+            name: value.name,
+            if_exists: value.if_exists,
+        }
     }
 }
 
@@ -86,6 +93,7 @@ impl From<DropSchema> for service::DropSchema {
 pub struct DropObject {
     pub schema: String,
     pub name: String,
+    pub if_exists: bool,
 }
 
 impl TryFrom<service::DropObject> for DropObject {
@@ -95,6 +103,7 @@ impl TryFrom<service::DropObject> for DropObject {
         Ok(DropObject {
             schema: value.schema,
             name: value.name,
+            if_exists: value.if_exists,
         })
     }
 }
@@ -104,6 +113,7 @@ impl From<DropObject> for service::DropObject {
         service::DropObject {
             schema: value.schema,
             name: value.name,
+            if_exists: value.if_exists,
         }
     }
 }

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -556,6 +556,9 @@ where
             }
             ExecutionResult::SetLocal => Self::command_complete(conn, "SET").await?,
             ExecutionResult::DropTables => Self::command_complete(conn, "DROP TABLE").await?,
+            ExecutionResult::DropConnections => {
+                Self::command_complete(conn, "DROP CONNECTION").await?
+            }
             ExecutionResult::DropSchemas => Self::command_complete(conn, "DROP SCHEMA").await?,
         }
         Ok(())

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -170,7 +170,28 @@ impl SessionContext {
         let mut drops = Vec::with_capacity(plan.names.len());
         for name in plan.names {
             let (schema, name) = self.resolve_object_reference(name.into())?;
-            drops.push(Mutation::DropObject(service::DropObject { schema, name }));
+            drops.push(Mutation::DropObject(service::DropObject {
+                schema,
+                name,
+                if_exists: plan.if_exists,
+            }));
+        }
+
+        self.mutate_catalog(drops).await?;
+
+        Ok(())
+    }
+
+    /// Drop one or more connections.
+    pub async fn drop_connections(&mut self, plan: DropConnections) -> Result<()> {
+        let mut drops = Vec::with_capacity(plan.names.len());
+        for name in plan.names {
+            let (schema, name) = self.resolve_object_reference(name.into())?;
+            drops.push(Mutation::DropObject(service::DropObject {
+                schema,
+                name,
+                if_exists: plan.if_exists,
+            }));
         }
 
         self.mutate_catalog(drops).await?;
@@ -182,7 +203,10 @@ impl SessionContext {
     pub async fn drop_schemas(&mut self, plan: DropSchemas) -> Result<()> {
         let mut drops = Vec::with_capacity(plan.names.len());
         for name in plan.names {
-            drops.push(Mutation::DropSchema(service::DropSchema { name }));
+            drops.push(Mutation::DropSchema(service::DropSchema {
+                name,
+                if_exists: plan.if_exists,
+            }));
         }
 
         self.mutate_catalog(drops).await?;

--- a/crates/sqlexec/src/logical_plan.rs
+++ b/crates/sqlexec/src/logical_plan.rs
@@ -81,6 +81,7 @@ pub enum DdlPlan {
     CreateConnection(CreateConnection),
     CreateView(CreateView),
     DropTables(DropTables),
+    DropConnections(DropConnections),
     DropSchemas(DropSchemas),
 }
 
@@ -133,6 +134,12 @@ pub struct CreateView {
 
 #[derive(Clone, Debug)]
 pub struct DropTables {
+    pub names: Vec<String>,
+    pub if_exists: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct DropConnections {
     pub names: Vec<String>,
     pub if_exists: bool,
 }

--- a/crates/sqlexec/src/planner.rs
+++ b/crates/sqlexec/src/planner.rs
@@ -1,7 +1,9 @@
 use crate::context::{ContextProviderAdapter, SessionContext};
 use crate::errors::{internal, ExecError, Result};
 use crate::logical_plan::*;
-use crate::parser::{CreateConnectionStmt, CreateExternalTableStmt, StatementWithExtensions};
+use crate::parser::{
+    CreateConnectionStmt, CreateExternalTableStmt, DropConnectionStmt, StatementWithExtensions,
+};
 use datafusion::arrow::datatypes::{
     DataType, Field, TimeUnit, DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
 };
@@ -40,6 +42,7 @@ impl<'a> SessionPlanner<'a> {
                 self.plan_create_external_table(stmt)
             }
             StatementWithExtensions::CreateConnection(stmt) => self.plan_create_connection(stmt),
+            StatementWithExtensions::DropConnection(stmt) => self.plan_drop_connection(stmt),
         }
     }
 
@@ -417,6 +420,14 @@ impl<'a> SessionPlanner<'a> {
 
             stmt => Err(ExecError::UnsupportedSQLStatement(stmt.to_string())),
         }
+    }
+
+    fn plan_drop_connection(&self, stmt: DropConnectionStmt) -> Result<LogicalPlan> {
+        Ok(DdlPlan::DropConnections(DropConnections {
+            if_exists: stmt.if_exists,
+            names: stmt.names,
+        })
+        .into())
     }
 }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -43,6 +43,8 @@ pub enum ExecutionResult {
     SetLocal,
     /// Tables dropped.
     DropTables,
+    /// Connections dropped.
+    DropConnections,
     /// Schemas dropped.
     DropSchemas,
 }
@@ -63,6 +65,7 @@ impl ExecutionResult {
             ExecutionResult::CreateConnection => "create_connection",
             ExecutionResult::SetLocal => "set_local",
             ExecutionResult::DropTables => "drop_tables",
+            ExecutionResult::DropConnections => "drop_connections",
             ExecutionResult::DropSchemas => "drop_schemas",
         }
     }
@@ -83,6 +86,7 @@ impl fmt::Debug for ExecutionResult {
             ExecutionResult::CreateConnection => write!(f, "create connection"),
             ExecutionResult::SetLocal => write!(f, "set local"),
             ExecutionResult::DropTables => write!(f, "drop tables"),
+            ExecutionResult::DropConnections => write!(f, "drop connections"),
             ExecutionResult::DropSchemas => write!(f, "drop schemas"),
         }
     }
@@ -170,6 +174,11 @@ impl Session {
 
     pub(crate) async fn drop_tables(&mut self, plan: DropTables) -> Result<()> {
         self.ctx.drop_tables(plan).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn drop_connections(&mut self, plan: DropConnections) -> Result<()> {
+        self.ctx.drop_connections(plan).await?;
         Ok(())
     }
 
@@ -296,6 +305,10 @@ impl Session {
             LogicalPlan::Ddl(DdlPlan::DropTables(plan)) => {
                 self.drop_tables(plan).await?;
                 ExecutionResult::DropTables
+            }
+            LogicalPlan::Ddl(DdlPlan::DropConnections(plan)) => {
+                self.drop_connections(plan).await?;
+                ExecutionResult::DropConnections
             }
             LogicalPlan::Ddl(DdlPlan::DropSchemas(plan)) => {
                 self.drop_schemas(plan).await?;

--- a/testdata/sqllogictests/drop.slt
+++ b/testdata/sqllogictests/drop.slt
@@ -1,6 +1,6 @@
 # Tests drop schema and drop objects
 
-# Test dropping  empty schema
+# Test dropping empty schema
 
 statement ok
 create schema drop_schema;
@@ -8,12 +8,17 @@ create schema drop_schema;
 statement ok
 drop schema drop_schema;
 
+statement error
+drop schema drop_schema;
+
+statement ok
+drop schema if exists drop_schema;
+
 query T
 select schema_name from glare_catalog.schemas where schema_name='drop_table';
 ----
 
-
-# Test drop schema with objects and drop table
+# Test drop schema with objects, drop connection and drop table
 
 statement ok
 create schema drop_table;
@@ -49,14 +54,24 @@ drop_table
 statement ok
 drop table test;
 
+statement error
+drop table test;
+
+statement error
+drop table if exists test;
+
 query TT
 select schema_name, table_name from glare_catalog.tables where schema_name='drop_table' and table_name='test';
 ----
 
-# TODO this is currently reusing the drop object code for drop table, this
-# needs to be updated once drop connection is added (see GlareDB/glaredb#576)
 statement ok
-drop table debug_conn;
+drop connection debug_conn;
+
+statement error
+drop connection debug_conn;
+
+statement ok
+drop connection if exists debug_conn;
 
 query TT
 select schema_name, connection_name from glare_catalog.connections where schema_name='drop_table' and connection_name='debug_conn';


### PR DESCRIPTION
- Also adds `IF EXISTS` support for drop schema and drop table

# Testing
## SLT
```
cargo run --bin slt_runner -- embedded ~/Developer/glaredb/testdata/sqllogictests/drop.slt
```

## Manual
```
\set ECHO queries

-- Test drop schema
create schema test;
drop schema test;
drop schema if exists test;

-- Test drop connection
set search_path = test;
create schema test;
create connection if not exists pgcon1 for postgres options(postgres_conn='host=localhost port=5432 user=glaredb password=password dbname=glaredb_test sslmode=disable');
drop connection pgcon1;
select schema_name, connection_name from glare_catalog.connections where connection_name = 'pgcon1';
drop schema test;

-- If there is no schema the following will still evaluate correctly and
-- matches postgres, though without the warning that the schema doesn't exist
drop connection if exists pgcon1;

-- Test show the error when dropping a connection before table
create schema test;
create connection if not exists pgcon1 for postgres options(postgres_conn='host=localhost port=5432 user=glaredb password=password dbname=glaredb_test sslmode=disable');
create external table if not exists dt1 from pgcon1 options(schema='public', table='datatypes');
drop connection pgcon1;
select * from test.dt1;
```

Last error will be:
```
select * from test.dt1;
psql:../test.sql:25: ERROR:  Error during planning: failed dispatch for qualified table: Missing object with oid: 20004
```

