### PR TITLE
build: Update Rust to 1.67.1

### DIFF
--- a/crates/pgsrv/src/errors.rs
+++ b/crates/pgsrv/src/errors.rs
@@ -9,7 +9,7 @@ pub enum PgSrvError {
     InvalidProtocolVersion(i32),
 
     #[error("unexpected frontend message: {0:?}")]
-    UnexpectedFrontendMessage(FrontendMessage),
+    UnexpectedFrontendMessage(Box<FrontendMessage>), // Boxed since frontend message has a large variant.
 
     #[error("unexpected backend message: {0:?}")]
     UnexpectedBackendMessage(BackendMessage),

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -146,7 +146,7 @@ impl ProtocolHandler {
                 // TODO: Do something with password.
                 framed.send(BackendMessage::AuthenticationOk).await?;
             }
-            Some(other) => return Err(PgSrvError::UnexpectedFrontendMessage(other)), // TODO: Send error.
+            Some(other) => return Err(PgSrvError::UnexpectedFrontendMessage(Box::new(other))), // TODO: Send error.
             None => return Ok(()),
         }
 

--- a/crates/pgsrv/src/proxy.rs
+++ b/crates/pgsrv/src/proxy.rs
@@ -314,7 +314,7 @@ impl<A: ConnectionAuthenticator> ProxyHandler<A> {
                     .await?;
                 Ok(details)
             }
-            other => Err(PgSrvError::UnexpectedFrontendMessage(other)),
+            other => Err(PgSrvError::UnexpectedFrontendMessage(Box::new(other))),
         }
     }
 }

--- a/crates/slt_runner/src/main.rs
+++ b/crates/slt_runner/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
             };
 
             let server = Server::connect(metastore_addr, None, true).await?;
-            let _ = tokio::spawn(server.serve(server_conf));
+            tokio::spawn(server.serve(server_conf));
 
             let runner = TestRunner::connect_embedded(pg_addr).await?;
             match runner.exec_tests(&files).await {

--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1673677311,
-        "narHash": "sha256-V7vEMy7vzvD9wyz/822G8rLV+3jkum5EsfAIy9gds1I=",
+        "lastModified": 1676874310,
+        "narHash": "sha256-wqjYQ56g5xzyDebDlSt00xux+Pf9fMaDhPAlyPXmG6I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "39e4f1d72376620d76fefe4cdf52a448f12c90aa",
+        "rev": "a7627120dc5578487e5edc9524f0365c63242644",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1673611648,
-        "narHash": "sha256-Qptnat6M6twwJiXSMt0cJlZdZreExeyzY7cdCG0LicM=",
+        "lastModified": 1676584162,
+        "narHash": "sha256-8h0sV0fmMSB7KydJJD5Iz1kJxR3YzYa3iJ71VD2zePk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "a119352adab65d0cab25c13ae0fd7676bed7100f",
+        "rev": "a6603fc21d50b3386a488c96225b2d1fd492e533",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes a couple new clippy lints too:

- Large error variant in pgsrv: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
- Assigning future to underscore in slt runner: https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_future