### PR TITLE
feat: Allow running metastore in process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "datafusion",
+ "futures",
  "logutil",
  "object_store",
  "object_store_util",
@@ -2542,6 +2543,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tower",
  "tracing",
  "uuid",
 ]
@@ -4238,6 +4240,7 @@ dependencies = [
  "glaredb",
  "glob",
  "logutil",
+ "metastore",
  "object_store",
  "regex",
  "sqllogictest",

--- a/README.md
+++ b/README.md
@@ -10,24 +10,11 @@ Repository for the core GlareDB database.
 
 ## Running
 
-An in-memory version of GlareDB can be started with the following two commands:
-
-``` shell
-cargo run --bin glaredb -- -v metastore
-```
-
-and
+An in-memory version of GlareDB can be started with the following command:
 
 ``` shell
 cargo run --bin glaredb -- -v server -l
 ```
-
-The first command starts up Metastore, the service responsible for managing the
-database's catalog. The second command starts up the server portion of GlareDB
-that's responsible for executing queries.
-
-Metastore will start up on port 6545 and the GlareDB server will start up on
-port 6543.
 
 To connect, use any Postgres compatible client. E.g. `psql`:
 
@@ -36,6 +23,26 @@ psql "host=localhost dbname=glaredb port=6543"
 ```
 
 When prompted for a password, any password will do[^1].
+
+### Running Metastore Separately
+
+By default, when the glaredb command is provided the `-l` flag, an in-process
+Metastore will be spun up. Metastore is the service responsible for managing
+catalogs for databases. But it may also be ran seperately (which is done in
+production).
+
+The following two commands may be used to spin up the server and metastore
+components seperately:
+
+``` shell
+cargo run --bin glaredb -- -v metastore
+```
+
+and
+
+``` shell
+cargo run --bin glaredb -- -v server -l -m http://localhost:6545
+```
 
 ## Service Overview
 

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -37,8 +37,11 @@ enum Commands {
         bind: String,
 
         /// Address to the Metastore.
-        #[clap(short, long, value_parser, default_value_t = String::from("http://localhost:6545"))]
-        metastore_addr: String,
+        ///
+        /// If not provided and `local` is set to a true, an in-process
+        /// metastore will be started.
+        #[clap(short, long, value_parser)]
+        metastore_addr: Option<String>,
 
         /// Whether or not this instance is running locally.
         ///
@@ -147,7 +150,7 @@ fn main() -> Result<()> {
 
 fn begin_server(
     pg_bind: &str,
-    metastore_addr: String,
+    metastore_addr: Option<String>,
     segment_key: Option<String>,
     local: bool,
 ) -> Result<()> {

--- a/crates/metastore/Cargo.toml
+++ b/crates/metastore/Cargo.toml
@@ -23,6 +23,8 @@ object_store = "0.5"
 once_cell = "1.17.1"
 proptest = "1.1"
 proptest-derive = "0.3"
+tower = "0.4"
+futures = "0.3.26"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/crates/metastore/src/errors.rs
+++ b/crates/metastore/src/errors.rs
@@ -41,6 +41,9 @@ pub enum MetastoreError {
     #[error("Object {object} has invalid parent id: {parent}")]
     ObjectHasInvalidParentId { object: u32, parent: u32 },
 
+    #[error("Failed in-process startup: {0}")]
+    FailedInProcessStartup(String),
+
     #[error(transparent)]
     Storage(#[from] crate::storage::StorageError),
 

--- a/crates/metastore/src/lib.rs
+++ b/crates/metastore/src/lib.rs
@@ -1,6 +1,7 @@
 //! The metastore crate defines the service for managing database catalogs.
 pub mod builtins;
 pub mod errors;
+pub mod local;
 pub mod proto;
 pub mod session;
 pub mod srv;

--- a/crates/metastore/src/local.rs
+++ b/crates/metastore/src/local.rs
@@ -1,0 +1,53 @@
+use crate::errors::{MetastoreError, Result};
+use crate::proto::service::metastore_service_client::MetastoreServiceClient;
+use crate::proto::service::metastore_service_server::MetastoreServiceServer;
+use crate::srv::Service;
+use object_store::{memory::InMemory, ObjectStore};
+use std::sync::Arc;
+use tonic::transport::{Channel, Endpoint, Server, Uri};
+
+/// Starts an in-process, in-memory metastore.
+pub async fn start_inprocess_inmemory() -> Result<MetastoreServiceClient<Channel>> {
+    start_inprocess(Arc::new(InMemory::new())).await
+}
+
+/// Starts an in-process metastore service, returning a client for the service.
+///
+/// Useful for some tests, as well as when running GlareDB locally for testing.
+/// This should never be used in production.
+pub async fn start_inprocess(
+    store: Arc<dyn ObjectStore>,
+) -> Result<MetastoreServiceClient<Channel>> {
+    let (client, server) = tokio::io::duplex(1024);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(MetastoreServiceServer::new(Service::new(store)))
+            .serve_with_incoming(futures::stream::iter(vec![Ok::<_, MetastoreError>(server)]))
+            .await
+            .unwrap()
+    });
+
+    let mut client = Some(client);
+    // Note that while we're providing a uri to bind to, we don't actually use
+    // it.
+    let channel = Endpoint::try_from("http://[::]/6545")
+        .map_err(|e| MetastoreError::FailedInProcessStartup(format!("create endpoint: {}", e)))?
+        .connect_with_connector(tower::service_fn(move |_: Uri| {
+            let client = client.take();
+            async move {
+                match client {
+                    Some(client) => Ok(client),
+                    None => Err(MetastoreError::FailedInProcessStartup(
+                        "client already taken".to_string(),
+                    )),
+                }
+            }
+        }))
+        .await
+        .map_err(|e| {
+            MetastoreError::FailedInProcessStartup(format!("connect with connector: {}", e))
+        })?;
+
+    Ok(MetastoreServiceClient::new(channel))
+}

--- a/crates/slt_runner/Cargo.toml
+++ b/crates/slt_runner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 logutil = {path = "../logutil"}
 glaredb = {path = "../glaredb"}
+metastore = {path = "../metastore"}
 tokio = { version = "1", features = ["full"] }
 sqllogictest = "0.13.0"
 tokio-postgres = "0.7.7"


### PR DESCRIPTION
When the `-l` flag is specified and the `--metastore-addr` flag is left unspecified, an in-process metastore will be used. This simplifies development and some tests.

An in-process metastore should never be used in production.