### PR TITLE
fix: use sanitized branch name instead of base64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
           shopt -s globstar
           if ./scripts/files-changed-in-branch.sh \
             "scripts/prepare-testdata.sh" \
+            "scripts/create-test-bigquery-db.sh" \
             "testdata/sqllogictests_datasources_common/data" \
             "testdata/sqllogictests_bigquery/data"
           then

--- a/scripts/cleanup-bigquery-dataset.sh
+++ b/scripts/cleanup-bigquery-dataset.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-GIT_BRANCH=$1
+GIT_BRANCH="$1"
 
-BQ_DATASET=$(echo "$GIT_BRANCH" | base64)
+BQ_DATASET=$(./scripts/get-sanitized-name.sh "$GIT_BRANCH")
 BQ_DATASET="glaredb_test_$BQ_DATASET"
 
 LOCATION="US"

--- a/scripts/create-test-bigquery-db.sh
+++ b/scripts/create-test-bigquery-db.sh
@@ -6,7 +6,8 @@ set -e
 
 # If override is set, use the main dataset instead (only for CI).
 if [ -z "$BIGQUERY_USE_MAIN_DATASET" ]; then
-	BQ_DATASET=$(git branch --show-current | base64)
+	GIT_BRANCH=$(git branch --show-current)
+	BQ_DATASET=$(./scripts/get-sanitized-name.sh "$GIT_BRANCH")
 	BQ_DATASET="glaredb_test_$BQ_DATASET"
 else
 	BQ_DATASET="glaredb_test"

--- a/scripts/get-sanitized-name.sh
+++ b/scripts/get-sanitized-name.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Get a name only consisting of alphanumeric chars and underscores.
+
+printf "$1" | tr -c -s '[:alnum:]' '_'


### PR DESCRIPTION
Two reasons for doing this:
1. Base64 might be padded with `=` which doesn't solve the issue
2. Might be easier to search for dataset when dataset name matches the branch name.