### PR TITLE
fix: Do not sample 0 tables

### DIFF
--- a/crates/datasource_mongodb/src/infer.rs
+++ b/crates/datasource_mongodb/src/infer.rs
@@ -27,6 +27,10 @@ impl TableSampler {
         if sample_count as usize > MAX_SAMPLE_SIZE {
             sample_count = MAX_SAMPLE_SIZE as i64;
         }
+        // Very small table.
+        if sample_count == 0 {
+            sample_count = MAX_SAMPLE_SIZE as i64;
+        }
 
         let sample_pipeline = [doc! {
             "$sample": {"size": sample_count}


### PR DESCRIPTION
With small tables, it's possible the resulting sample count is calculated to be zero. In such cases, just set to max allowed size. This may end up reading the entire table, but it's better than not reading anything.

When sample count was returning 0, we were inferring an empty schema...