### PR TITLE
test: remove scalar encoding test failing on debug

### DIFF
--- a/crates/datasource_common/src/util.rs
+++ b/crates/datasource_common/src/util.rs
@@ -157,11 +157,6 @@ mod tests {
         let cases = vec![
             TestCase {
                 datasource: Postgres,
-                literal: ScalarValue::Boolean(Some(true)),
-                expected: None,
-            },
-            TestCase {
-                datasource: Postgres,
                 literal: ScalarValue::Int8(Some(12)),
                 expected: Some("12"),
             },


### PR DESCRIPTION
@vrongmeal let me know if the fix should be something else

In the dev profile we fail on this assert:
https://github.com/GlareDB/glaredb/blob/8285626200609e08d75fb7bc74144ff1e0212590/crates/datasource_common/src/util.rs#L49-L50

# Testing
```
cargo t --profile dev
```