### PR TITLE
feat: add snowflake connector (client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,6 +2309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,10 +4043,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls 0.23.2",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4043,6 +4058,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
@@ -4687,6 +4703,25 @@ name = "snap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+
+[[package]]
+name = "snowflake_connector"
+version = "0.1.0"
+dependencies = [
+ "base64 0.21.0",
+ "chrono",
+ "datafusion",
+ "hex",
+ "logutil",
+ "reqwest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "socket2"

--- a/crates/snowflake_connector/Cargo.toml
+++ b/crates/snowflake_connector/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "snowflake_connector"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = "1.0"
+reqwest = { version = "0.11.14", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.94"
+tracing = "0.1"
+chrono = "0.4.23"
+uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+datafusion = "19.0"
+hex = "0.4.3"
+rust_decimal = "1.29.0"
+base64 = "0.21.0"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+logutil = { path = "../logutil" }

--- a/crates/snowflake_connector/src/auth.rs
+++ b/crates/snowflake_connector/src/auth.rs
@@ -1,0 +1,252 @@
+use chrono::{DateTime, Duration, Utc};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
+
+use crate::errors::Result;
+use crate::req::{RequestId, SnowflakeClient};
+
+const SESSION_ENDPOINT: &str = "/session";
+const AUTH_ENDPOINT: &str = "/session/v1/login-request";
+
+#[derive(Debug)]
+pub struct Token {
+    value: String,
+    validity: Duration,
+    created_at: DateTime<Utc>,
+}
+
+impl Token {
+    pub fn new(value: String, validity_in_seconds: i64, created_at: DateTime<Utc>) -> Self {
+        Self {
+            value,
+            validity: Duration::seconds(validity_in_seconds),
+            created_at,
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn is_valid(&self) -> bool {
+        Utc::now().signed_duration_since(self.created_at) < self.validity
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Empty {}
+
+#[derive(Debug)]
+pub struct Session {
+    pub token: Token,
+    pub master_token: Token,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionParams {
+    delete: bool,
+}
+
+impl Session {
+    pub async fn close(&self, client: &SnowflakeClient) -> Result<()> {
+        let _: Empty = client
+            .execute(
+                SESSION_ENDPOINT,
+                &SessionParams { delete: true },
+                &Empty {},
+                Some(&self.token),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+impl From<TokenResponse> for Session {
+    fn from(value: TokenResponse) -> Self {
+        let created_at = Utc::now();
+        Self {
+            token: Token::new(value.token, value.validity_in_seconds, created_at),
+            master_token: Token::new(
+                value.master_token,
+                value.master_validity_in_seconds,
+                created_at,
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Authenticator {
+    Default(DefaultAuthenticator),
+}
+
+#[derive(Debug, Serialize)]
+struct AuthRequest {
+    data: AuthBodyData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthParams {
+    request_id: RequestId,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    database_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warehouse: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role_name: Option<String>,
+}
+
+impl From<AuthOptions> for AuthParams {
+    fn from(value: AuthOptions) -> Self {
+        Self {
+            request_id: RequestId::new(),
+            database_name: value.database_name,
+            schema_name: value.schema_name,
+            warehouse: value.warehouse,
+            role_name: value.role_name,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct AuthOptions {
+    pub database_name: Option<String>,
+    pub schema_name: Option<String>,
+    pub warehouse: Option<String>,
+    pub role_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthResponse {
+    data: TokenResponse,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenResponse {
+    master_token: String,
+    token: String,
+    validity_in_seconds: i64,
+    master_validity_in_seconds: i64,
+}
+
+impl Authenticator {
+    pub(crate) async fn authenticate(
+        self,
+        client: &SnowflakeClient,
+        opts: AuthOptions,
+    ) -> Result<Session> {
+        let res: AuthResponse = match self {
+            Self::Default(req) => Self::execute_req(client, req, opts).await?,
+        };
+
+        Ok(res.data.into())
+    }
+
+    async fn execute_req<R: Into<AuthBodyData>>(
+        client: &SnowflakeClient,
+        req: R,
+        opts: AuthOptions,
+    ) -> Result<AuthResponse> {
+        let params: AuthParams = opts.into();
+        client
+            .execute(
+                AUTH_ENDPOINT,
+                &params,
+                &AuthRequest { data: req.into() },
+                /* Token = */ None,
+            )
+            .await
+    }
+}
+
+#[derive(Debug)]
+pub struct DefaultAuthenticator {
+    pub account_name: String,
+    pub login_name: String,
+    pub password: String,
+}
+
+const CLIENT_APP_ID: &str = "Go";
+const CLIENT_APP_VERSION: &str = "1.6.18";
+const CLIENT_APP_OS: &str = "darwin";
+const CLIENT_APP_OS_VERSION: &str = "gc-arm64";
+
+#[derive(Debug, Default)]
+struct ClientAppId;
+
+impl Serialize for ClientAppId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(CLIENT_APP_ID)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClientAppVersion;
+
+impl Serialize for ClientAppVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(CLIENT_APP_VERSION)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClientEnvironment;
+
+impl Serialize for ClientEnvironment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_map(/* len = */ None)?;
+        s.serialize_entry("APPLICATION", CLIENT_APP_ID)?;
+        s.serialize_entry("OS", CLIENT_APP_OS)?;
+        s.serialize_entry("OS_VERSION", CLIENT_APP_OS_VERSION)?;
+        s.end()
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+struct AuthBodyData {
+    // Client information required so we can identify as a supported client for
+    // snowflake servers. This helps us fetch results in "arrow" format which
+    // they only support for their own clients. Their exposed (documented) rest
+    // api doesn't support returning results in arrow format :/
+    client_app_id: ClientAppId,
+    client_app_version: ClientAppVersion,
+    client_environment: ClientEnvironment,
+
+    account_name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    login_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    password: Option<String>,
+}
+
+impl From<DefaultAuthenticator> for AuthBodyData {
+    fn from(value: DefaultAuthenticator) -> Self {
+        Self {
+            account_name: value.account_name,
+            login_name: Some(value.login_name),
+            password: Some(value.password),
+
+            ..Default::default()
+        }
+    }
+}

--- a/crates/snowflake_connector/src/errors.rs
+++ b/crates/snowflake_connector/src/errors.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SnowflakeError {
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    ArrowError(#[from] datafusion::arrow::error::ArrowError),
+
+    #[error(transparent)]
+    Base64DecodeError(#[from] base64::DecodeError),
+
+    #[error("Invalid URL: {0}")]
+    UrlParseError(Box<dyn std::error::Error>),
+
+    #[error("Request errored with status code: {0}")]
+    HttpError(reqwest::StatusCode),
+
+    #[error("Snowflake Query Error ({code}): {message}")]
+    QueryError { code: String, message: String },
+
+    #[error("Invalid connection parameters: {0}")]
+    InvalidConnectionParameters(String),
+}
+
+pub type Result<T, E = SnowflakeError> = std::result::Result<T, E>;

--- a/crates/snowflake_connector/src/lib.rs
+++ b/crates/snowflake_connector/src/lib.rs
@@ -1,0 +1,109 @@
+use crate::auth::{AuthOptions, Authenticator, DefaultAuthenticator, Session};
+use crate::errors::{Result, SnowflakeError};
+use crate::query::Query;
+use crate::req::SnowflakeClient;
+
+use datafusion::arrow::record_batch::RecordBatch;
+
+mod auth;
+mod query;
+mod req;
+
+pub mod errors;
+
+#[derive(Debug)]
+pub struct ConnectionBuilder {
+    account_name: String,
+    login_name: String,
+
+    password: Option<String>,
+    database_name: Option<String>,
+    schema_name: Option<String>,
+    warehouse: Option<String>,
+    role_name: Option<String>,
+}
+
+macro_rules! builder_fn {
+    ($name:ident, $ty:ty) => {
+        pub fn $name(mut self, $name: $ty) -> Self {
+            self.$name = Some($name);
+            self
+        }
+    };
+}
+
+impl ConnectionBuilder {
+    pub fn new(account_name: String, login_name: String) -> Self {
+        Self {
+            account_name,
+            login_name,
+
+            password: None,
+            database_name: None,
+            schema_name: None,
+            warehouse: None,
+            role_name: None,
+        }
+    }
+
+    builder_fn! {password, String}
+    builder_fn! {database_name, String}
+    builder_fn! {schema_name, String}
+    builder_fn! {warehouse, String}
+    builder_fn! {role_name, String}
+
+    pub async fn build(self) -> Result<Connection> {
+        if self.account_name.is_empty() || self.login_name.is_empty() {
+            return Err(SnowflakeError::InvalidConnectionParameters(
+                "account_name and login_name cannot be empty".to_string(),
+            ));
+        }
+
+        let url = format!("https://{}.snowflakecomputing.com:443", self.account_name);
+        let client = SnowflakeClient::builder().build(url)?;
+
+        let password = self
+            .password
+            .ok_or(SnowflakeError::InvalidConnectionParameters(
+                "password is required for default authentication".to_string(),
+            ))?;
+
+        let auth = DefaultAuthenticator {
+            account_name: self.account_name,
+            login_name: self.login_name,
+            password,
+        };
+        let auth = Authenticator::Default(auth);
+
+        let auth_options = AuthOptions {
+            database_name: self.database_name,
+            schema_name: self.schema_name,
+            warehouse: self.warehouse,
+            role_name: self.role_name,
+        };
+
+        let session = auth.authenticate(&client, auth_options).await?;
+
+        Ok(Connection { client, session })
+    }
+}
+
+pub struct Connection {
+    client: SnowflakeClient,
+    session: Session,
+}
+
+impl Connection {
+    pub fn builder(account_name: String, login_name: String) -> ConnectionBuilder {
+        ConnectionBuilder::new(account_name, login_name)
+    }
+
+    pub async fn close(self) -> Result<()> {
+        self.session.close(&self.client).await
+    }
+
+    pub async fn query(&self, sql: String) -> Result<RecordBatch> {
+        let query = Query { sql };
+        query.exec(&self.client, &self.session).await
+    }
+}

--- a/crates/snowflake_connector/src/query.rs
+++ b/crates/snowflake_connector/src/query.rs
@@ -1,0 +1,412 @@
+use std::{collections::HashMap, io::Cursor, sync::Arc};
+
+use datafusion::arrow::{
+    array::{
+        Array, ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
+        Float64Builder, Int16Array, Int32Array, Int64Array, Int64Builder, Int8Array, StringBuilder,
+        StructArray, Time64NanosecondBuilder, TimestampNanosecondBuilder,
+    },
+    datatypes::{DataType, Field, Schema, TimeUnit},
+    ipc::reader::StreamReader,
+    record_batch::RecordBatch,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    auth::Session,
+    errors::{Result, SnowflakeError},
+    req::{RequestId, SnowflakeClient},
+};
+
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+
+const QUERY_ENDPOINT: &str = "/queries/v1/query-request";
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum QueryResultFormat {
+    Json,
+    Arrow,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryBindParameter {
+    #[serde(rename = "type")]
+    r#type: String,
+    value: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+struct QueryBodyParameters {
+    go_query_result_format: QueryResultFormat,
+}
+
+impl Default for QueryBodyParameters {
+    fn default() -> Self {
+        Self {
+            go_query_result_format: QueryResultFormat::Arrow,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryBody {
+    sql_text: String,
+    async_exec: bool,
+    sequence_id: u64,
+    is_internal: bool,
+    describe_only: bool,
+    parameters: QueryBodyParameters,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bindings: Option<HashMap<String, QueryBindParameter>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bind_stage: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryParams {
+    request_id: RequestId,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryResponse {
+    data: QueryData,
+    message: Option<String>,
+    code: Option<String>,
+    success: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryData {
+    #[allow(unused)]
+    total: Option<i64>,
+    #[allow(unused)]
+    returned: Option<i64>,
+    #[allow(unused)]
+    query_id: Option<String>,
+    // TODO: A lot more other fields...
+    rowtype: Option<Vec<QueryDataRowType>>,
+
+    rowset: Option<Vec<Vec<Option<String>>>>,
+    rowset_base64: Option<String>,
+
+    query_result_format: Option<QueryResultFormat>,
+}
+
+fn snowflake_to_arrow_schema(rowtype: Vec<QueryDataRowType>) -> Schema {
+    let mut fields = Vec::new();
+    for r in rowtype.into_iter() {
+        let datatype = match r.r#type.to_lowercase().as_str() {
+            "binary" => DataType::Binary,
+            "boolean" => DataType::Boolean,
+            "any" | "array" | "object" | "char" | "text" | "variant" => DataType::Utf8,
+            "real" => DataType::Float64,
+            "fixed" => {
+                let (precision, scale) = (r.precision.unwrap() as u8, r.scale.unwrap() as i8);
+                DataType::Decimal128(precision, scale)
+            }
+            "date" => DataType::Date32,
+            "time" => DataType::Time64(TimeUnit::Nanosecond),
+            "timestamp" | "timestamp_ntz" => DataType::Timestamp(TimeUnit::Nanosecond, None),
+            "timestamp_tz" | "timestamp_ltz" => {
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string()))
+            }
+            dt => unreachable!("programming error: snowflake datatype '{dt}' isn't implemented"),
+        };
+        let field = Field::new(r.name, datatype, r.nullable);
+        fields.push(field);
+    }
+    Schema::new(fields)
+}
+
+macro_rules! make_json_column_using {
+    ($arr:expr, $rows:expr, $col_idx:expr, $parse_fn:expr) => {{
+        for row in $rows.iter() {
+            let val = row.get($col_idx).expect("value for column should exist");
+            let val = match val {
+                Some(s) => Some($parse_fn(s)),
+                None => None,
+            };
+            $arr.append_option(val);
+        }
+        Arc::new($arr.finish())
+    }};
+}
+
+macro_rules! make_json_column {
+    ($builder:ty, $rows:expr, $col_idx:expr, $parse_fn:expr) => {{
+        let mut arr = <$builder>::with_capacity($rows.len());
+        make_json_column_using!(arr, $rows, $col_idx, $parse_fn)
+    }};
+}
+
+macro_rules! make_ipc_column {
+    ($col:expr, $from_arr:ty, $map_fn:expr, $builder:ty, $dt:expr) => {{
+        let rows: &$from_arr = $col.as_any().downcast_ref().unwrap();
+        let mut arr = <$builder>::with_capacity(rows.len()).with_data_type($dt.clone());
+        rows.iter().for_each(|row| {
+            let row = row.map($map_fn);
+            arr.append_option(row)
+        });
+        Arc::new(arr.finish())
+    }};
+}
+
+impl QueryData {
+    fn json_to_arrow(self) -> Result<RecordBatch> {
+        let schema =
+            snowflake_to_arrow_schema(self.rowtype.expect("rowtype should exist in query result"));
+        let fields = &schema.fields;
+
+        let rows = self.rowset.expect("rowset should exist in query result");
+
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(fields.len());
+        for (col_idx, field) in schema.fields.iter().enumerate() {
+            let col: ArrayRef = match field.data_type() {
+                DataType::Boolean => {
+                    make_json_column!(BooleanBuilder, rows, col_idx, |s| s == "1")
+                }
+                DataType::Utf8 => {
+                    let mut arr = StringBuilder::with_capacity(rows.len(), rows.len() * 16);
+                    make_json_column_using!(arr, rows, col_idx, String::as_str)
+                }
+                DataType::Binary => {
+                    fn parse_binary(s: &String) -> Vec<u8> {
+                        hex::decode(s).expect("value should be a valid hex representation")
+                    }
+                    let mut arr = BinaryBuilder::with_capacity(rows.len(), rows.len() * 16);
+                    make_json_column_using!(arr, rows, col_idx, parse_binary)
+                }
+                DataType::Float64 => {
+                    fn parse_float(s: &str) -> f64 {
+                        s.parse()
+                            .expect("value should be a valid floating point string representation")
+                    }
+                    make_json_column!(Float64Builder, rows, col_idx, parse_float)
+                }
+                DataType::Int64 => {
+                    fn parse_int(s: &str) -> i64 {
+                        s.parse().expect("value should be a valid i64")
+                    }
+                    make_json_column!(Int64Builder, rows, col_idx, parse_int)
+                }
+                dt @ DataType::Decimal128(_, _) => {
+                    fn parse_decimal(s: &str) -> i128 {
+                        let d: rust_decimal::Decimal = s
+                            .parse()
+                            .expect("value should be a valid decimal representation");
+                        d.mantissa()
+                    }
+                    let mut arr =
+                        Decimal128Builder::with_capacity(rows.len()).with_data_type(dt.clone());
+                    make_json_column_using!(arr, rows, col_idx, parse_decimal)
+                }
+                DataType::Date32 => {
+                    fn parse_date(s: &str) -> i32 {
+                        s.parse()
+                            .expect("value should be a valid i32 (number of days)")
+                    }
+                    make_json_column!(Date32Builder, rows, col_idx, parse_date)
+                }
+                DataType::Time64(TimeUnit::Nanosecond) => {
+                    fn parse_time(s: &str) -> i64 {
+                        let times: Vec<i64> = s
+                            .splitn(2, '.')
+                            .map(|v| {
+                                v.parse().expect(
+                                    "value should be a valid time of format <seconds>.<nanos>",
+                                )
+                            })
+                            .collect();
+
+                        let (seconds, nanos) = (times[0], times[1]);
+                        (seconds * 1_000_000_000) + nanos
+                    }
+                    make_json_column!(Time64NanosecondBuilder, rows, col_idx, parse_time)
+                }
+                dt @ DataType::Timestamp(TimeUnit::Nanosecond, _tz) => {
+                    fn parse_timestamp(s: &str) -> i64 {
+                        let times: Vec<i64> = s
+                            .splitn(2, '.')
+                            .map(|v| {
+                                v.parse().expect(
+                                    "value should be a valid timestamp of format <seconds since epoch>.<nanos>",
+                                )
+                            })
+                            .collect();
+
+                        let (seconds, nanos) = (times[0], times[1]);
+                        (seconds * 1_000_000_000) + nanos
+                    }
+                    let mut arr = TimestampNanosecondBuilder::with_capacity(rows.len())
+                        .with_data_type(dt.clone());
+                    make_json_column_using!(arr, rows, col_idx, parse_timestamp)
+                }
+                dt => unreachable!(
+                    "programming error: invalid arrow datatype '{dt}' from json result"
+                ),
+            };
+            columns.push(col);
+        }
+
+        let record_batch = RecordBatch::try_new(Arc::new(schema), columns)?;
+        Ok(record_batch)
+    }
+
+    fn ipc_to_arrow(self) -> Result<RecordBatch> {
+        let mut buf = Vec::new();
+        base64_engine.decode_vec(
+            self.rowset_base64
+                .expect("rowset_base64 should exist in query result"),
+            &mut buf,
+        )?;
+        let mut buf = Cursor::new(buf);
+        let reader = StreamReader::try_new(&mut buf, None)?;
+        let batch = reader
+            .into_iter()
+            .next()
+            .expect("ipc stream reader iterator should return at-least one batch")?;
+
+        let expected_schema =
+            snowflake_to_arrow_schema(self.rowtype.expect("rowtype should exist in query result"));
+        let actual_schema = batch.schema();
+
+        let mut columns = Vec::with_capacity(expected_schema.fields.len());
+
+        for (col_idx, (expected_field, actual_field)) in expected_schema
+            .fields
+            .iter()
+            .zip(actual_schema.fields.iter())
+            .enumerate()
+        {
+            let col = batch.column(col_idx);
+
+            let col: ArrayRef = match (expected_field.data_type(), actual_field.data_type()) {
+                (dt @ DataType::Decimal128(_, _), DataType::Int8) => {
+                    make_ipc_column!(col, Int8Array, |r| r as i128, Decimal128Builder, dt)
+                }
+                (dt @ DataType::Decimal128(_, _), DataType::Int16) => {
+                    make_ipc_column!(col, Int16Array, |r| r as i128, Decimal128Builder, dt)
+                }
+                (dt @ DataType::Decimal128(_, _), DataType::Int32) => {
+                    make_ipc_column!(col, Int32Array, |r| r as i128, Decimal128Builder, dt)
+                }
+                (dt @ DataType::Decimal128(_, _), DataType::Int64) => {
+                    make_ipc_column!(col, Int64Array, |r| r as i128, Decimal128Builder, dt)
+                }
+                (dt @ DataType::Time64(TimeUnit::Nanosecond), DataType::Int64) => {
+                    make_ipc_column!(col, Int64Array, |r| r, Time64NanosecondBuilder, dt)
+                }
+                (dt @ DataType::Timestamp(TimeUnit::Nanosecond, _tz), DataType::Struct(_)) => {
+                    let rows: &StructArray = col.as_any().downcast_ref().unwrap();
+                    let seconds = rows
+                        .column_by_name("epoch")
+                        .expect("column 'epoch' should exist in time struct")
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap();
+                    let nanos = rows
+                        .column_by_name("fraction")
+                        .expect("column 'fraction' should exist in time struct")
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap();
+                    let mut arr = TimestampNanosecondBuilder::with_capacity(rows.len())
+                        .with_data_type(dt.clone());
+                    (0..rows.len()).into_iter().for_each(|row_idx| {
+                        if rows.is_null(row_idx) {
+                            arr.append_null();
+                        } else {
+                            let t = seconds.value(row_idx) * 1_000_000_000;
+                            let t = t + nanos.value(row_idx) as i64;
+                            arr.append_value(t);
+                        }
+                    });
+                    Arc::new(arr.finish())
+                }
+                (expected, actual) if expected == actual => Arc::clone(col),
+                (expected, actual) => unreachable!(
+                    "programming error: conversion from '{actual}' to '{expected}' not supported for snowflake"
+                ),
+            };
+
+            columns.push(col);
+        }
+
+        // let batch = RecordBatch::try_new(actual_schema, columns)?;
+        let batch = RecordBatch::try_new(Arc::new(expected_schema), columns)?;
+        Ok(batch)
+    }
+}
+
+impl TryFrom<QueryData> for RecordBatch {
+    type Error = SnowflakeError;
+
+    fn try_from(data: QueryData) -> Result<Self, Self::Error> {
+        match &data
+            .query_result_format
+            .expect("query_result_format should exist in query result")
+        {
+            QueryResultFormat::Json => data.json_to_arrow(),
+            QueryResultFormat::Arrow => data.ipc_to_arrow(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryDataRowType {
+    name: String,
+
+    #[serde(rename = "type")]
+    r#type: String,
+
+    precision: Option<i64>,
+    scale: Option<i64>,
+
+    nullable: bool,
+}
+
+pub struct Query {
+    pub sql: String,
+}
+
+impl Query {
+    pub async fn exec(self, client: &SnowflakeClient, session: &Session) -> Result<RecordBatch> {
+        if !session.token.is_valid() {
+            // TODO: session.refresh_token()
+            // For now just let the query go and return the error from the
+            // snowflake server.
+        }
+
+        let res: QueryResponse = client
+            .execute(
+                QUERY_ENDPOINT,
+                &QueryParams {
+                    request_id: RequestId::new(),
+                },
+                &QueryBody {
+                    sql_text: self.sql,
+                    ..Default::default()
+                },
+                Some(&session.token),
+            )
+            .await?;
+
+        if !res.success {
+            return Err(SnowflakeError::QueryError {
+                code: res.code.unwrap_or_default(),
+                message: res.message.unwrap_or_default(),
+            });
+        }
+
+        // TODO: Check if total == returned else fetch more?
+        res.data.try_into()
+    }
+}

--- a/crates/snowflake_connector/src/req.rs
+++ b/crates/snowflake_connector/src/req.rs
@@ -1,0 +1,132 @@
+use std::time::Duration;
+
+use reqwest::{
+    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+    Client, IntoUrl, Url,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::{
+    auth::Token,
+    errors::{Result, SnowflakeError},
+};
+
+const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+const BODY_CONTENT_TYPE: &str = "application/json";
+const REQ_ACCEPT: &str = "application/snowflake";
+
+#[derive(Debug)]
+pub struct RequestId(Uuid);
+
+impl RequestId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Serialize for RequestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = Uuid::encode_buffer();
+        serializer.serialize_str(self.0.hyphenated().encode_lower(&mut buf))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SnowflakeClientBuilder {
+    timeout: Option<Duration>,
+    connect_timeout: Option<Duration>,
+}
+
+impl SnowflakeClientBuilder {
+    #[allow(unused)]
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    #[allow(unused)]
+    pub fn connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.connect_timeout = Some(connect_timeout);
+        self
+    }
+
+    pub fn build<U: IntoUrl>(self, base_url: U) -> Result<SnowflakeClient> {
+        let mut default_headers = HeaderMap::new();
+        default_headers.insert(CONTENT_TYPE, HeaderValue::from_static(BODY_CONTENT_TYPE));
+        default_headers.insert(ACCEPT, HeaderValue::from_static(REQ_ACCEPT));
+
+        let mut builder = Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .default_headers(default_headers);
+
+        if let Some(timeout) = self.timeout {
+            builder = builder.timeout(timeout);
+        }
+
+        if let Some(connect_timeout) = self.connect_timeout {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+
+        let client = builder.build()?;
+        Ok(SnowflakeClient {
+            base_url: base_url.into_url()?,
+            inner: client,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SnowflakeClient {
+    base_url: Url,
+    inner: Client,
+}
+
+impl SnowflakeClient {
+    pub fn builder() -> SnowflakeClientBuilder {
+        SnowflakeClientBuilder::default()
+    }
+
+    pub async fn execute<P, B, R>(
+        &self,
+        url: &str,
+        params: &P,
+        body: &B,
+        token: Option<&Token>,
+    ) -> Result<R>
+    where
+        P: Serialize,
+        B: Serialize,
+        R: DeserializeOwned,
+    {
+        let url = self
+            .base_url
+            .join(url)
+            .map_err(|e| SnowflakeError::UrlParseError(Box::new(e)))?;
+
+        let mut req = self.inner.post(url).query(&params).json(&body);
+        if let Some(token) = token {
+            let val = format!("Snowflake Token=\"{}\"", token.value());
+            req = req.header(
+                AUTHORIZATION,
+                HeaderValue::from_str(&val)
+                    .expect("snowflake returned token must be a valid header value"),
+            );
+        }
+
+        let res = req.send().await?;
+        if !res.status().is_success() {
+            return Err(SnowflakeError::HttpError(res.status()));
+        }
+
+        let res = res.text().await?;
+        info!(%res, "response");
+
+        let res: R = serde_json::from_str(&res)?;
+        Ok(res)
+    }
+}


### PR DESCRIPTION
This is a basic snowflake client that lets us connect to snowflake using the default username-password authentication.

Currently simple sync queries are functional. More functionality will be added as required.

Both JSON and Arrow formats are supported even though the client currently forces to use the Arrow format.