### PR TITLE
chore: Enable thin lto for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = ["crates/*"]
 
+[profile.release]
+lto = "thin"
+
 [patch.crates-io]
 object_store = { git = "https://github.com/glaredb/arrow-rs.git", branch = "content-length" }

--- a/flake.nix
+++ b/flake.nix
@@ -198,12 +198,23 @@
             cargoExtraArgs = "--bin glaredb";
           } // common-build-args);
 
+          # GlareDB binary using the release profile.
+          #
+          # This is a separate target since enabling LTO can cause build times
+          # to go up.
+          glaredb-bin-release = craneLib.buildPackage ({
+            inherit cargoArtifacts;
+            pname = "glaredb-release";
+            cargoExtraArgs = "--release --bin glaredb";
+          } // common-build-args);
+
+
           # GlareDB image.
           glaredb-image = mkContainer {
             name = "glaredb";
             contents = [
               pkgs.openssh
-              packages.glaredb-bin
+              packages.glaredb-bin-release
               # Generated certs used for SSL connections in pgsrv. GlareDB
               # proper does not currently use certs.
               generated-certs


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/787