### PR TITLE
refactor: remove unnecessary async from `QueryResultRowIter::next`

### DIFF
--- a/crates/datasource_snowflake/src/lib.rs
+++ b/crates/datasource_snowflake/src/lib.rs
@@ -113,8 +113,7 @@ WHERE
             .await?;
 
         let mut fields = Vec::new();
-        let mut res = res.into_row_iter();
-        while let Some(row) = res.next().await {
+        for row in res.into_row_iter() {
             let row = row?;
             let col_name = match row.get_column_by_name("COLUMN_NAME").unwrap()? {
                 // Convert the column name to lowercase since we every name

--- a/crates/snowflake_connector/src/query.rs
+++ b/crates/snowflake_connector/src/query.rs
@@ -498,22 +498,26 @@ impl QueryResultRowIter {
         Ok(Some(QueryResultRow {
             schema: self.schema.clone(),
             row,
-            cols: curr_batch.columns(),
+            cols: curr_batch.columns().to_vec(),
         }))
     }
+}
 
-    pub async fn next(&mut self) -> Option<Result<QueryResultRow>> {
+impl Iterator for QueryResultRowIter {
+    type Item = Result<QueryResultRow>;
+
+    fn next(&mut self) -> Option<Self::Item> {
         self.next_row().transpose()
     }
 }
 
-pub struct QueryResultRow<'a> {
+pub struct QueryResultRow {
     schema: SchemaRef,
     row: usize,
-    cols: &'a [ArrayRef],
+    cols: Vec<ArrayRef>,
 }
 
-impl<'a> QueryResultRow<'a> {
+impl QueryResultRow {
     pub fn get_column(&self, col_idx: usize) -> Option<Result<ScalarValue>> {
         fn get_scalar(col: &ArrayRef, row_idx: usize) -> Result<ScalarValue> {
             let scalar = ScalarValue::try_from_array(&col, row_idx)?;


### PR DESCRIPTION
Refactor `QueryResultRowIter` to implement the `Iterator` trait.