### PR TITLE
feat: Implement MySQL virtual catalog

### DIFF
--- a/testdata/sqllogictests_mysql/external_database.slt
+++ b/testdata/sqllogictests_mysql/external_database.slt
@@ -32,5 +32,26 @@ SELECT count(*) FROM external_database.glaredb_test.bikeshare_stations;
 ----
 102
 
+# Ensure we can query into the virtual schema.
+
+query T
+SELECT * FROM external_database.virtual_catalog.schemata WHERE schema_name = 'glaredb_test';
+----
+glaredb_test
+
+query TT
+SELECT table_schema, table_name
+	FROM external_database.virtual_catalog.tables
+	WHERE table_name = 'bikeshare_stations';
+----
+glaredb_test  bikeshare_stations
+
+query TT
+SELECT table_schema, table_name
+	FROM external_database.virtual_catalog.tables
+	WHERE table_schema = 'glaredb_test' AND table_name = 'bikeshare_stations';
+----
+glaredb_test  bikeshare_stations
+
 statement ok
 DROP DATABASE external_database;


### PR DESCRIPTION
Also includes some minor refactoring with bigquery and mysql sources.

Refactorings include seperating connection params from table access for bigquery and mysql.

Apparently there was a huge indentation change from `cargo fmt` that makes the diff bigger than it is. Sorry about that!
Rest assured, all the changes pertain to MySQL.