### PR TITLE
chore: Filter logs from env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4159,6 +4168,15 @@ checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -5639,12 +5657,16 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/crates/logutil/Cargo.toml
+++ b/crates/logutil/Cargo.toml
@@ -7,4 +7,4 @@ edition = {workspace = true}
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json"] }
+tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json", "env-filter"] }


### PR DESCRIPTION
Enables the "env-filter" feature for tracing, allowing setting the `RUST_LOG` env var to filter logs.

Also sets h2 to INFO by default since it prints so much stuff at DEBUG levels.