### PR TITLE
chore: Remove storing columns directly on external tables

### DIFF
--- a/crates/metastore/proto/catalog.proto
+++ b/crates/metastore/proto/catalog.proto
@@ -31,7 +31,6 @@ syntax = "proto3";
 
 package metastore.catalog;
 
-import "arrow.proto";
 import "options.proto";
 
 // The state of the catalog at some version.
@@ -120,8 +119,7 @@ message SchemaEntry {
 message TableEntry {
   EntryMeta meta = 1;
 
-  // Columns in the table.
-  repeated ColumnDefinition columns = 2;
+  reserved 2; // Column fields
 
   options.TableOptions options = 3;
 
@@ -135,19 +133,4 @@ message ViewEntry {
   string sql = 2;
 
   // next: 3
-}
-
-message ColumnDefinition {
-  // Name of the column in the table.
-  string name = 1;
-
-  // Field is nullable.
-  bool nullable = 2;
-
-  // Arrow type for the field.
-  //
-  // Note this will likely need to be expanded for complex types.
-  arrow.ArrowType arrow_type = 3;
-
-  // next: 4
 }

--- a/crates/metastore/proto/options.proto
+++ b/crates/metastore/proto/options.proto
@@ -12,6 +12,25 @@ syntax = "proto3";
 
 package metastore.options;
 
+import "arrow.proto";
+
+// Some options allow us to know the columns in tables upfront (particularly the
+// internal table options).
+message InternalColumnDefinition {
+  // Name of the column in the table.
+  string name = 1;
+
+  // Field is nullable.
+  bool nullable = 2;
+
+  // Arrow type for the field.
+  //
+  // Note this will likely need to be expanded for complex types.
+  arrow.ArrowType arrow_type = 3;
+
+  // next: 4
+}
+
 // Database options
 
 message DatabaseOptions {
@@ -69,7 +88,10 @@ message TableOptions {
   // next: 11
 }
 
-message TableOptionsInternal {}
+message TableOptionsInternal {
+  // Columns in the table.
+  repeated InternalColumnDefinition columns = 1;
+}
 
 message TableOptionsDebug { string table_type = 1; }
 

--- a/crates/metastore/proto/service.proto
+++ b/crates/metastore/proto/service.proto
@@ -76,8 +76,7 @@ message CreateExternalTable {
   string name = 2;
   options.TableOptions options = 3;
   bool if_not_exists = 4;
-  repeated catalog.ColumnDefinition columns = 5;
-  // next: 7
+  // next: 5
 }
 
 message CreateExternalDatabase {
@@ -88,14 +87,14 @@ message CreateExternalDatabase {
 }
 
 message AlterTableRename {
-    string schema = 1;
-    string name = 2;
-    string new_name = 3;
+  string schema = 1;
+  string name = 2;
+  string new_name = 3;
 }
 
 message AlterDatabaseRename {
-    string name = 1;
-    string new_name = 2;
+  string name = 1;
+  string new_name = 2;
 }
 
 message MutateRequest {

--- a/crates/metastore/src/builtins.rs
+++ b/crates/metastore/src/builtins.rs
@@ -13,7 +13,7 @@
 //! database node will be able to see it, but will not be able to execute
 //! appropriately. We can revisit this if this isn't acceptable long-term.
 
-use crate::types::catalog::ColumnDefinition;
+use crate::types::options::InternalColumnDefinition;
 use datafusion::arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use once_cell::sync::Lazy;
 use pgrepr::oid::FIRST_GLAREDB_BUILTIN_ID;
@@ -66,13 +66,13 @@ impl BuiltinDatabase {
 pub struct BuiltinTable {
     pub schema: &'static str,
     pub name: &'static str,
-    pub columns: Vec<ColumnDefinition>,
+    pub columns: Vec<InternalColumnDefinition>,
 }
 
 pub static GLARE_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "databases",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("oid", DataType::UInt32, false),
         ("database_name", DataType::Utf8, false),
         ("builtin", DataType::Boolean, false),
@@ -84,7 +84,7 @@ pub static GLARE_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static GLARE_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "schemas",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("oid", DataType::UInt32, false),
         ("database_oid", DataType::UInt32, false),
         ("database_name", DataType::Utf8, false),
@@ -96,7 +96,7 @@ pub static GLARE_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static GLARE_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "tables",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("oid", DataType::UInt32, false),
         ("database_oid", DataType::UInt32, false),
         ("schema_oid", DataType::UInt32, false),
@@ -111,7 +111,7 @@ pub static GLARE_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static GLARE_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "views",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("oid", DataType::UInt32, false),
         ("database_oid", DataType::UInt32, false),
         ("schema_oid", DataType::UInt32, false),
@@ -125,7 +125,7 @@ pub static GLARE_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static GLARE_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "columns",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("schema_oid", DataType::UInt32, false),
         ("table_oid", DataType::UInt32, false),
         ("table_name", DataType::Utf8, false),
@@ -139,7 +139,7 @@ pub static GLARE_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static GLARE_SESSION_QUERY_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "session_query_metrics",
-    columns: ColumnDefinition::from_tuples([
+    columns: InternalColumnDefinition::from_tuples([
         ("query_text", DataType::Utf8, false),
         ("result_type", DataType::Utf8, false),
         ("execution_status", DataType::Utf8, false),

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -489,7 +489,6 @@ impl State {
                             external: true,
                         },
                         options: create_ext.options,
-                        columns: create_ext.columns,
                     };
 
                     self.try_insert_entry_for_schema(
@@ -720,8 +719,7 @@ impl BuiltinCatalog {
                         builtin: true,
                         external: false,
                     },
-                    options: TableOptions::new_internal(),
-                    columns: table.columns.clone(),
+                    options: TableOptions::new_internal(table.columns.clone()),
                 }),
             );
             schema_objects
@@ -1048,7 +1046,6 @@ mod tests {
                 table_type: String::new(),
             }),
             if_not_exists: true,
-            columns: Vec::new(),
         });
         let _ = db
             .try_mutate(state.version, vec![mutation.clone(), mutation])

--- a/crates/metastore/src/types/service.rs
+++ b/crates/metastore/src/types/service.rs
@@ -1,6 +1,5 @@
 use super::{FromOptionalField, ProtoConvError};
 use crate::proto::service;
-use crate::types::catalog::ColumnDefinition;
 use crate::types::options::{DatabaseOptions, TableOptions};
 use proptest_derive::Arbitrary;
 
@@ -218,7 +217,6 @@ pub struct CreateExternalTable {
     pub name: String,
     pub options: TableOptions,
     pub if_not_exists: bool,
-    pub columns: Vec<ColumnDefinition>,
 }
 
 impl TryFrom<service::CreateExternalTable> for CreateExternalTable {
@@ -230,11 +228,6 @@ impl TryFrom<service::CreateExternalTable> for CreateExternalTable {
             name: value.name,
             options: value.options.required("options")?,
             if_not_exists: value.if_not_exists,
-            columns: value
-                .columns
-                .into_iter()
-                .map(|col| col.try_into())
-                .collect::<Result<_, _>>()?,
         })
     }
 }
@@ -245,13 +238,8 @@ impl TryFrom<CreateExternalTable> for service::CreateExternalTable {
         Ok(service::CreateExternalTable {
             schema: value.schema,
             name: value.name,
-            options: Some(value.options.into()),
+            options: Some(value.options.try_into()?),
             if_not_exists: value.if_not_exists,
-            columns: value
-                .columns
-                .into_iter()
-                .map(|col| col.try_into())
-                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -18,7 +18,6 @@ use futures::future::BoxFuture;
 use metastore::builtins::DEFAULT_CATALOG;
 use metastore::builtins::POSTGRES_SCHEMA;
 use metastore::session::SessionCatalog;
-use metastore::types::catalog::ColumnDefinition;
 use metastore::types::service::{self, Mutation};
 use pgrepr::format::Format;
 use pgrepr::types::arrow_to_pg_type;
@@ -139,22 +138,12 @@ impl SessionContext {
         }
 
         let (_, schema, name) = self.resolve_object_reference(plan.table_name.into())?;
-        let columns = plan
-            .columns
-            .into_iter()
-            .map(|field| ColumnDefinition {
-                name: field.name().to_owned(),
-                nullable: field.is_nullable(),
-                arrow_type: field.data_type().to_owned(),
-            })
-            .collect();
         self.mutate_catalog([Mutation::CreateExternalTable(
             service::CreateExternalTable {
                 schema,
                 name,
                 options: plan.table_options,
                 if_not_exists: plan.if_not_exists,
-                columns,
             },
         )])
         .await?;

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -264,7 +264,7 @@ impl<'a> SessionDispatcher<'a> {
 
     async fn dispatch_external_table(&self, table: &TableEntry) -> Result<Arc<dyn TableProvider>> {
         match &table.options {
-            TableOptions::Internal(TableOptionsInternal {}) => unimplemented!(),
+            TableOptions::Internal(TableOptionsInternal { .. }) => unimplemented!(), // Purposely unimplemented.
             TableOptions::Debug(TableOptionsDebug { table_type }) => {
                 let provider = DebugTableType::from_str(table_type)?;
                 Ok(provider.into_table_provider())
@@ -615,7 +615,12 @@ impl<'a> SystemTableDispatcher<'a> {
                 other => panic!("unexpected entry type: {:?}", other), // Bug
             };
 
-            for (i, col) in ent.columns.iter().enumerate() {
+            let cols = match ent.get_internal_columns() {
+                Some(cols) => cols,
+                None => continue,
+            };
+
+            for (i, col) in cols.iter().enumerate() {
                 schema_oid.append_value(
                     table
                         .parent_entry

--- a/crates/sqlexec/src/planner/logical_plan.rs
+++ b/crates/sqlexec/src/planner/logical_plan.rs
@@ -145,7 +145,6 @@ pub struct CreateExternalTable {
     pub table_name: String,
     pub if_not_exists: bool,
     pub table_options: TableOptions,
-    pub columns: Vec<Field>,
 }
 
 #[derive(Clone, Debug)]

--- a/testdata/sqllogictests/debug.slt
+++ b/testdata/sqllogictests/debug.slt
@@ -27,12 +27,3 @@ create external table error_table from debug options (table_type = 'error_during
 statement error
 select * from error_table;
 
-# validate external column catalog info
-query TITTT
-select column_name, column_ordinal, data_type, is_nullable
-    from glare_catalog.columns c
-    join glare_catalog.tables t
-    on c.table_oid = t.oid
-    where t.table_name = 'error_table';
-----
-a 0 Int32 f


### PR DESCRIPTION
Closes #857

Instead these should/will be stored on the table options. Currently this just has columns for the internal tables, I didn't feel like we needed to keep the columns for the other data sources since we have the virtual catalog now.

In the future, if we think storing column info is worth it, we can lazily load and store the column info using the virtual catalog.