### PR TITLE
chore: Specify branch instead of revision for datafusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,8 +1341,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1390,8 +1390,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1404,8 +1404,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1421,8 +1421,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1432,8 +1432,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1444,13 +1444,13 @@ dependencies = [
  "hashbrown 0.13.1",
  "itertools",
  "log",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1468,6 +1468,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy_static",
+ "libc",
  "md-5",
  "paste",
  "petgraph",
@@ -1480,8 +1481,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1491,8 +1492,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "22.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=463ec307#463ec3074318c5bf31a6a1377ab5f01159d8a2ce"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#7aad6c7f45657f6594552e0244aa141a76d7448d"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 lto = "thin"
 
 [workspace.dependencies]
-datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "463ec307" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "main" }
 
 [patch.crates-io]
 object_store = { git = "https://github.com/glaredb/arrow-rs.git", branch = "content-length" }


### PR DESCRIPTION
Dependabot doesn't update revisions.

cc @vrongmeal