### PR TITLE
fix: Object names are parsed depending on their quote_style

### DIFF
--- a/crates/snowflake_connector/src/lib.rs
+++ b/crates/snowflake_connector/src/lib.rs
@@ -97,15 +97,6 @@ pub struct Connection {
     session: Session,
 }
 
-macro_rules! query_fn {
-    ($fn:ident, $rt:ty) => {
-        pub async fn $fn(&self, sql: String, bindings: Vec<QueryBindParameter>) -> Result<$rt> {
-            let q = Query { sql, bindings };
-            q.$fn(&self.client, &self.session).await
-        }
-    };
-}
-
 impl Connection {
     pub fn builder(account_name: String, login_name: String) -> ConnectionBuilder {
         ConnectionBuilder::new(account_name, login_name)
@@ -115,7 +106,17 @@ impl Connection {
         self.session.close(&self.client).await
     }
 
-    query_fn! {exec_sync, ()}
+    pub async fn exec_sync(&self, sql: String, bindings: Vec<QueryBindParameter>) -> Result<()> {
+        let q = Query { sql, bindings };
+        q.exec_sync(&self.client, &self.session).await
+    }
 
-    query_fn! {query_sync, QueryResult}
+    pub async fn query_sync(
+        &self,
+        sql: String,
+        bindings: Vec<QueryBindParameter>,
+    ) -> Result<QueryResult> {
+        let q = Query { sql, bindings };
+        q.query_sync(&self.client, &self.session).await
+    }
 }

--- a/crates/sqlexec/src/planner/logical_plan.rs
+++ b/crates/sqlexec/src/planner/logical_plan.rs
@@ -1,5 +1,6 @@
 use crate::errors::{internal, Result};
 use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use datafusion::common::OwnedTableReference;
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::sqlparser::ast;
@@ -142,7 +143,7 @@ pub struct CreateTable {
 
 #[derive(Clone, Debug)]
 pub struct CreateExternalTable {
-    pub table_name: String,
+    pub table_name: OwnedTableReference,
     pub if_not_exists: bool,
     pub table_options: TableOptions,
 }
@@ -162,13 +163,13 @@ pub struct CreateView {
 
 #[derive(Clone, Debug)]
 pub struct AlterTableRename {
-    pub name: String,
-    pub new_name: String,
+    pub name: OwnedTableReference,
+    pub new_name: OwnedTableReference,
 }
 
 #[derive(Clone, Debug)]
 pub struct DropTables {
-    pub names: Vec<String>,
+    pub names: Vec<OwnedTableReference>,
     pub if_exists: bool,
 }
 
@@ -187,7 +188,7 @@ pub struct DropSchemas {
 
 #[derive(Clone, Debug)]
 pub struct DropDatabase {
-    pub name: String,
+    pub names: Vec<String>,
     pub if_exists: bool,
 }
 
@@ -224,13 +225,13 @@ impl From<VariablePlan> for LogicalPlan {
 
 #[derive(Clone, Debug)]
 pub struct SetVariable {
-    pub variable: ast::ObjectName,
+    pub variable: String,
     pub values: Vec<ast::Expr>,
 }
 
 impl SetVariable {
     /// Try to convert the value into a string.
-    pub fn try_into_string(&self) -> Result<String> {
+    pub fn try_value_into_string(&self) -> Result<String> {
         let expr_to_string = |expr: &ast::Expr| {
             Ok(match expr {
                 ast::Expr::Identifier(_) | ast::Expr::CompoundIdentifier(_) => expr.to_string(),

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -235,10 +235,9 @@ impl Session {
     }
 
     pub(crate) fn set_variable(&mut self, plan: SetVariable) -> Result<()> {
-        let key = plan.variable.to_string().to_lowercase();
         self.ctx
             .get_session_vars_mut()
-            .set(&key, plan.try_into_string()?.as_str())?;
+            .set(&plan.variable, plan.try_value_into_string()?.as_str())?;
         Ok(())
     }
 

--- a/scripts/cleanup-snowflake-dataset.sh
+++ b/scripts/cleanup-snowflake-dataset.sh
@@ -7,7 +7,7 @@ set -e
 GIT_BRANCH="$1"
 
 SNOWFLAKE_DB=$(./scripts/get-sanitized-name.sh "$GIT_BRANCH")
-SNOWFLAKE_DB="glaredb_test_$BQ_DATASET"
+SNOWFLAKE_DB="glaredb_test_$SNOWFLAKE_DB"
 
 # This will be recognized by SnowSQL
 export SNOWSQL_PWD="$SNOWFLAKE_PASSWORD"

--- a/testdata/sqllogictests/alter.slt
+++ b/testdata/sqllogictests/alter.slt
@@ -21,6 +21,9 @@ create external table t1 from debug options (table_type = 'never_ending');
 statement error
 alter table t1 rename to t2;
 
+statement ok
+drop table if exists t1, t2;
+
 # Tests alter database
 
 statement ok
@@ -42,3 +45,6 @@ alter database d1 rename to d2;
 
 statement error
 alter database default rename to hello;
+
+statement ok
+drop database if exists d1, d2;

--- a/testdata/sqllogictests/drop.slt
+++ b/testdata/sqllogictests/drop.slt
@@ -23,6 +23,33 @@ query TTT
 select database_name, external, datasource from glare_catalog.databases where database_name='drop_db';
 ----
 
+# Test dropping multiple databases
+
+statement ok
+create external database drop_db1 from debug;
+
+statement ok
+create external database drop_db2 from debug;
+
+query T
+select a from drop_db1.public.never_ending LIMIT 1;
+----
+1
+
+query T rowsort
+select b from drop_db2.public.never_ending LIMIT 1;
+----
+2
+
+statement ok
+drop database drop_db1, drop_db2;
+
+statement error
+select a from drop_db1.public.never_ending LIMIT 1;
+
+statement error
+select b from drop_db2.public.never_ending LIMIT 1;
+
 # Test dropping empty schema
 
 statement ok
@@ -114,6 +141,33 @@ drop table drop_table.test;
 
 statement ok
 drop table if exists drop_table.test;
+
+# Test dropping multiple tables
+
+statement ok
+create external table drop_table1 from debug options ( table_type = 'never_ending' );
+
+statement ok
+create external table drop_table2 from debug options ( table_type = 'never_ending' );
+
+query T
+select a from drop_table1 limit 1;
+----
+1
+
+query T
+select b from drop_table2 limit 1;
+----
+2
+
+statement ok
+drop table drop_table1, drop_table2;
+
+statement error
+select a from drop_table1 limit 1;
+
+statement error
+select b from drop_table2 limit 1;
 
 query TT
 select schema_name, table_name from glare_catalog.tables where schema_name='drop_table' and table_name='test';

--- a/testdata/sqllogictests/object_names.slt
+++ b/testdata/sqllogictests/object_names.slt
@@ -1,0 +1,92 @@
+# Tests for creating external databases and tables
+
+# Table names
+
+statement ok
+CREATE EXTERNAL TABLE obj_name_table FROM debug OPTIONS ( table_type = 'never_ending' );
+
+statement error
+CREATE EXTERNAL TABLE Obj_Name_Table FROM debug OPTIONS ( table_type = 'never_ending' );
+
+statement ok
+CREATE EXTERNAL TABLE "Obj_Name_Table" FROM debug OPTIONS ( table_type = 'never_ending' );
+
+query TTT rowsort
+SELECT * FROM "Obj_Name_Table" LIMIT 1;
+----
+1 2 3
+
+query TTT rowsort
+SELECT * FROM Obj_Name_Table LIMIT 1;
+----
+1 2 3
+
+statement error
+ALTER TABLE "Obj_Name_Table" RENAME TO "obj_name_table";
+
+statement ok
+DROP TABLE Obj_Name_Table;
+
+statement ok
+ALTER TABLE "Obj_Name_Table" RENAME TO "obj_name_table";
+
+statement error
+DROP TABLE "Obj_Name_Table";
+
+statement error
+SELECT * FROM "Obj_Name_Table" LIMIT 1;
+
+query TTT
+SELECT * FROM Obj_Name_Table LIMIT 1;
+----
+1 2 3
+
+statement ok
+DROP TABLE "obj_name_table";
+
+# Database names
+
+statement ok
+CREATE EXTERNAL DATABASE obj_name_database FROM debug;
+
+statement error
+CREATE EXTERNAL DATABASE Obj_Name_Database FROM debug;
+
+statement ok
+CREATE EXTERNAL DATABASE "Obj_Name_Database" FROM debug;
+
+query TTT rowsort
+SELECT * FROM "Obj_Name_Database".public.Never_Ending LIMIT 1;
+----
+1 2 3
+
+query TTT rowsort
+SELECT * FROM Obj_Name_Database.public.Never_Ending LIMIT 1;
+----
+1 2 3
+
+statement error
+ALTER DATABASE "Obj_Name_Database" RENAME TO "obj_name_database";
+
+statement ok
+DROP DATABASE Obj_Name_Database;
+
+statement ok
+ALTER DATABASE "Obj_Name_Database" RENAME TO "obj_name_database";
+
+statement error
+DROP DATABASE "Obj_Name_Database";
+
+statement error
+SELECT * FROM "Obj_Name_Database".public.Never_Ending LIMIT 1;
+
+statement error
+SELECT * FROM "Obj_Name_Database.public.Never_Ending" LIMIT 1;
+
+query TTT
+SELECT * FROM Obj_Name_Database.public.Never_Ending LIMIT 1;
+----
+1 2 3
+
+statement ok
+DROP DATABASE "obj_name_database";

--- a/testdata/sqllogictests/vars.slt
+++ b/testdata/sqllogictests/vars.slt
@@ -32,6 +32,16 @@ show datestyle;
 ----
 ISO
 
+query T
+show transaction_isolation;
+----
+read uncommitted
+
+query T
+show transaction isolation level;
+----
+read uncommitted
+
 # Update vars
 
 statement ok


### PR DESCRIPTION
For an object specified with quotes, it's considered case-sensitive else it's converted to lower-case.

Fixes a bug in `DROP TABLE`.

_WIP: Need to extend this for views and schemas._

Fixes: #908