### PR TITLE
feat: Allow column aliases in views

### DIFF
--- a/crates/metastore/proto/catalog.proto
+++ b/crates/metastore/proto/catalog.proto
@@ -132,5 +132,8 @@ message ViewEntry {
   // The sql statement for materializing the view.
   string sql = 2;
 
-  // next: 3
+  // Output column aliases. If length of zero, no aliases have been defined.
+  repeated string columns = 3;
+
+  // next: 4
 }

--- a/crates/metastore/proto/service.proto
+++ b/crates/metastore/proto/service.proto
@@ -71,6 +71,7 @@ message CreateView {
   string name = 2;
   string sql = 3;
   bool or_replace = 4;
+  repeated string columns = 5;
 }
 
 message CreateExternalTable {

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -548,6 +548,7 @@ impl State {
                             external: false,
                         },
                         sql: create_view.sql,
+                        columns: create_view.columns,
                     };
 
                     let policy = if create_view.or_replace {
@@ -836,6 +837,7 @@ impl BuiltinCatalog {
                         external: false,
                     },
                     sql: view.sql.to_string(),
+                    columns: Vec::new(),
                 }),
             );
             schema_objects
@@ -941,6 +943,7 @@ mod tests {
                     name: i.to_string(),
                     sql: format!("select {i}"),
                     or_replace: false,
+                    columns: Vec::new(),
                 })
             })
             .collect();
@@ -1030,6 +1033,7 @@ mod tests {
                     name: "bowser".to_string(),
                     sql: "select 1".to_string(),
                     or_replace: false,
+                    columns: Vec::new(),
                 })],
             )
             .await
@@ -1070,6 +1074,7 @@ mod tests {
                 name: "peach".to_string(),
                 sql: "select 1".to_string(),
                 or_replace: false,
+                columns: Vec::new(),
             })],
         )
         .await
@@ -1083,6 +1088,7 @@ mod tests {
                 name: "peach".to_string(),
                 sql: "select 2".to_string(),
                 or_replace: false,
+                columns: Vec::new(),
             })],
         )
         .await
@@ -1101,6 +1107,7 @@ mod tests {
                 name: "wario".to_string(),
                 sql: "select 1".to_string(),
                 or_replace: false,
+                columns: Vec::new(),
             })],
         )
         .await
@@ -1114,6 +1121,7 @@ mod tests {
                 name: "wario".to_string(),
                 sql: "select 2".to_string(),
                 or_replace: false,
+                columns: Vec::new(),
             })],
         )
         .await
@@ -1127,6 +1135,7 @@ mod tests {
                 name: "wario".to_string(),
                 sql: "select 3".to_string(),
                 or_replace: true,
+                columns: Vec::new(),
             })],
         )
         .await
@@ -1156,6 +1165,7 @@ mod tests {
                     name: "bowser".to_string(),
                     sql: "select 1".to_string(),
                     or_replace: false,
+                    columns: Vec::new(),
                 })],
             )
             .await
@@ -1170,6 +1180,7 @@ mod tests {
                     name: "bowser".to_string(),
                     sql: "select 1".to_string(),
                     or_replace: false,
+                    columns: Vec::new(),
                 })],
             )
             .await
@@ -1184,6 +1195,7 @@ mod tests {
                     name: "bowser".to_string(),
                     sql: "select 1".to_string(),
                     or_replace: false,
+                    columns: Vec::new(),
                 })],
             )
             .await

--- a/crates/metastore/src/types/catalog.rs
+++ b/crates/metastore/src/types/catalog.rs
@@ -315,6 +315,7 @@ impl TryFrom<TableEntry> for catalog::TableEntry {
 pub struct ViewEntry {
     pub meta: EntryMeta,
     pub sql: String,
+    pub columns: Vec<String>,
 }
 
 impl TryFrom<catalog::ViewEntry> for ViewEntry {
@@ -324,6 +325,7 @@ impl TryFrom<catalog::ViewEntry> for ViewEntry {
         Ok(ViewEntry {
             meta,
             sql: value.sql,
+            columns: value.columns,
         })
     }
 }
@@ -333,6 +335,7 @@ impl From<ViewEntry> for catalog::ViewEntry {
         catalog::ViewEntry {
             meta: Some(value.meta.into()),
             sql: value.sql,
+            columns: value.columns,
         }
     }
 }

--- a/crates/metastore/src/types/service.rs
+++ b/crates/metastore/src/types/service.rs
@@ -191,6 +191,7 @@ pub struct CreateView {
     pub name: String,
     pub sql: String,
     pub or_replace: bool,
+    pub columns: Vec<String>,
 }
 
 impl TryFrom<service::CreateView> for CreateView {
@@ -202,6 +203,7 @@ impl TryFrom<service::CreateView> for CreateView {
             name: value.name,
             sql: value.sql,
             or_replace: value.or_replace,
+            columns: value.columns,
         })
     }
 }
@@ -213,6 +215,7 @@ impl From<CreateView> for service::CreateView {
             name: value.name,
             sql: value.sql,
             or_replace: value.or_replace,
+            columns: value.columns,
         }
     }
 }

--- a/crates/sqlexec/src/metastore.rs
+++ b/crates/sqlexec/src/metastore.rs
@@ -554,6 +554,7 @@ mod tests {
                     name: "mario".to_string(),
                     sql: "select 1".to_string(),
                     or_replace: false,
+                    columns: Vec::new(),
                 })],
             )
             .await

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -411,7 +411,7 @@ impl<'a> SessionDispatcher<'a> {
     async fn dispatch_view(&self, view: &ViewEntry) -> Result<Arc<dyn TableProvider>> {
         let plan = self
             .ctx
-            .late_view_plan(&view.sql)
+            .late_view_plan(&view.sql, &view.columns)
             .await
             .map_err(|e| DispatchError::LatePlanning(Box::new(e)))?;
         Ok(Arc::new(ViewTable::try_new(plan, None)?))

--- a/crates/sqlexec/src/planner/errors.rs
+++ b/crates/sqlexec/src/planner/errors.rs
@@ -37,6 +37,9 @@ pub enum PlanError {
     #[error("Invalid view statement: {msg}")]
     InvalidViewStatement { msg: &'static str },
 
+    #[error("Invalid number of column aliases for view body; sql: {sql}, aliases: {aliases:?}")]
+    InvalidNumberOfAliasesForView { sql: String, aliases: Vec<String> },
+
     #[error("An ssh connection is not supported datasource for CREATE EXTERNAL TABLE. An ssh connection must be provided as an optional ssh_tunnel with another connection type")]
     ExternalTableWithSsh,
 

--- a/crates/sqlexec/src/planner/logical_plan.rs
+++ b/crates/sqlexec/src/planner/logical_plan.rs
@@ -157,8 +157,8 @@ pub struct CreateTableAs {
 #[derive(Clone, Debug)]
 pub struct CreateView {
     pub view_name: OwnedTableReference,
-    pub num_columns: usize,
     pub sql: String,
+    pub columns: Vec<String>,
     pub or_replace: bool,
 }
 

--- a/testdata/sqllogictests/views.slt
+++ b/testdata/sqllogictests/views.slt
@@ -42,6 +42,19 @@ select * from with_values order by 1;
 1  2
 3  4
 
+# Alias querying a table.
+
+statement ok
+create external table t1 from debug options (table_type = 'never_ending');
+
+statement ok
+create view view_t1 as select * from t1 limit 1;
+
+query I
+select count(*) from view_t1;
+----
+1
+
 # Replace views
 
 statement ok
@@ -69,3 +82,33 @@ query I
 select * from my_view;
 ----
 3
+
+statement ok
+drop view my_view;
+
+# Views with column aliases.
+
+statement ok
+create view aliased_view(a, b) as select 1, 2;
+
+query II
+select b, a from aliased_view;
+----
+2 1
+
+statement ok
+drop view aliased_view;
+
+# Invalid number of aliases.
+
+statement error
+create view invalid1(a) as select 1, 2;
+
+statement error
+create view invalid2(a, b, c) as select 1, 2;
+
+# Invalid view body
+
+statement error
+create view invalid_body as select * from this_table_doesnt_exist;
+


### PR DESCRIPTION
Allows view definitions like

```
create view my_view(a, b) as select 1, 2;
```

Also checks that what's being provided as a view body produces a valid plan.