### PR TITLE
chore: Update snowflake parameter names to keep them consistent

### DIFF
--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -120,12 +120,12 @@ impl<'a> SessionPlanner<'a> {
                 DatabaseOptions::Mongo(DatabaseOptionsMongo { connection_string })
             }
             DatabaseOptions::SNOWFLAKE => {
-                let account_name = remove_required_opt(m, "account_name")?;
-                let login_name = remove_required_opt(m, "login_name")?;
+                let account_name = remove_required_opt(m, "account")?;
+                let login_name = remove_required_opt(m, "username")?;
                 let password = remove_required_opt(m, "password")?;
-                let database_name = remove_required_opt(m, "database_name")?;
+                let database_name = remove_required_opt(m, "database")?;
                 let warehouse = remove_required_opt(m, "warehouse")?;
-                let role_name = remove_optional_opt(m, "role_name")?;
+                let role_name = remove_optional_opt(m, "role")?;
                 SnowflakeAccessor::validate_external_database(SnowflakeDbConnection {
                     account_name: account_name.clone(),
                     login_name: login_name.clone(),
@@ -248,14 +248,14 @@ impl<'a> SessionPlanner<'a> {
                 })
             }
             TableOptions::SNOWFLAKE => {
-                let account_name = remove_required_opt(m, "account_name")?;
-                let login_name = remove_required_opt(m, "login_name")?;
+                let account_name = remove_required_opt(m, "account")?;
+                let login_name = remove_required_opt(m, "username")?;
                 let password = remove_required_opt(m, "password")?;
-                let database_name = remove_required_opt(m, "database_name")?;
+                let database_name = remove_required_opt(m, "database")?;
                 let warehouse = remove_required_opt(m, "warehouse")?;
-                let role_name = remove_optional_opt(m, "role_name")?;
-                let schema_name = remove_required_opt(m, "schema_name")?;
-                let table_name = remove_required_opt(m, "table_name")?;
+                let role_name = remove_optional_opt(m, "role")?;
+                let schema_name = remove_required_opt(m, "schema")?;
+                let table_name = remove_required_opt(m, "table")?;
 
                 let conn_params = SnowflakeDbConnection {
                     account_name: account_name.clone(),

--- a/testdata/sqllogictests_snowflake/basic.slt
+++ b/testdata/sqllogictests_snowflake/basic.slt
@@ -4,14 +4,14 @@ statement ok
 CREATE EXTERNAL TABLE basic
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = '${SNOWFLAKE_PASSWORD}',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'public',
-		table_name = 'bikeshare_stations'
+		role = 'accountadmin',
+		schema = 'public',
+		table = 'bikeshare_stations'
 	);
 
 include ../sqllogictests_datasources_common/include/basic.slti

--- a/testdata/sqllogictests_snowflake/datatypes.slt
+++ b/testdata/sqllogictests_snowflake/datatypes.slt
@@ -4,12 +4,12 @@ statement ok
 CREATE EXTERNAL DATABASE datatypes
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = '${SNOWFLAKE_PASSWORD}',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
+		role = 'accountadmin',
 	);
 
 query TRRR

--- a/testdata/sqllogictests_snowflake/external_database.slt
+++ b/testdata/sqllogictests_snowflake/external_database.slt
@@ -4,12 +4,12 @@ statement ok
 CREATE EXTERNAL DATABASE external_db
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = '${SNOWFLAKE_PASSWORD}',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
+		role = 'accountadmin',
 	);
 
 query I

--- a/testdata/sqllogictests_snowflake/external_table.slt
+++ b/testdata/sqllogictests_snowflake/external_table.slt
@@ -4,14 +4,14 @@ statement ok
 CREATE EXTERNAL TABLE external_table
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = '${SNOWFLAKE_PASSWORD}',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'public',
-		table_name = 'bikeshare_stations'
+		role = 'accountadmin',
+		schema = 'public',
+		table = 'bikeshare_stations'
 	);
 
 query I

--- a/testdata/sqllogictests_snowflake/large_table.slt
+++ b/testdata/sqllogictests_snowflake/large_table.slt
@@ -4,14 +4,14 @@ statement ok
 CREATE EXTERNAL TABLE large_table
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = '${SNOWFLAKE_PASSWORD}',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'public',
-		table_name = 'bikeshare_trips'
+		role = 'accountadmin',
+		schema = 'public',
+		table = 'bikeshare_trips'
 	);
 
 include ../sqllogictests_datasources_common/include/large_table.slti

--- a/testdata/sqllogictests_snowflake/validation.slt
+++ b/testdata/sqllogictests_snowflake/validation.slt
@@ -6,26 +6,26 @@ statement error
 CREATE EXTERNAL DATABASE validation
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = 'incorrect-password',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
+		role = 'accountadmin',
 	);
 
 statement error
 CREATE EXTERNAL TABLE validation
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = 'incorrect-password',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'public',
-		table_name = 'datatypes',
+		role = 'accountadmin',
+		schema = 'public',
+		table = 'datatypes',
 	);
 
 # Incorrect schema/table name
@@ -34,26 +34,26 @@ statement error
 CREATE EXTERNAL TABLE validation
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = 'incorrect-password',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'public',
-		table_name = 'incorrect_table',
+		role = 'accountadmin',
+		schema = 'public',
+		table = 'incorrect_table',
 	);
 
 statement error
 CREATE EXTERNAL TABLE validation
 	FROM snowflake
 	OPTIONS (
-		account_name = 'hmpfscx-xo23956',
-		login_name = '${SNOWFLAKE_USERNAME}',
+		account = 'hmpfscx-xo23956',
+		username = '${SNOWFLAKE_USERNAME}',
 		password = 'incorrect-password',
-		database_name = '${SNOWFLAKE_DATABASE}',
+		database = '${SNOWFLAKE_DATABASE}',
 		warehouse = 'compute_wh',
-		role_name = 'accountadmin',
-		schema_name = 'incorrect_schema',
-		table_name = 'datatypes',
+		role = 'accountadmin',
+		schema = 'incorrect_schema',
+		table = 'datatypes',
 	);


### PR DESCRIPTION
- `account_name` -> `account`
- `login_name` -> `username`
- `database_name` -> `database`
- `role_name` -> `role`
- `table_name` -> `table`
- `schema_name` -> `schema`

Fixes: #929