### PR TITLE
fix: Implement retries for snowflake connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesutil"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytes",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_bigquery"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_common"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_debug"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_mongodb"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_mysql"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_object_store"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_postgres"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "datasource_snowflake"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "glaredb"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "ioutil"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytes",
 ]
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "logutil"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "metastore"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_util"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "pgprototest"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "pgrepr"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytes",
  "chrono",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "pgsrv"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "repr"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "chrono",
  "dtoa",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "slt_runner"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4926,7 +4926,7 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snowflake_connector"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4983,7 +4983,7 @@ dependencies = [
 
 [[package]]
 name = "sqlexec"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "datafusion",
  "datasource_bigquery",
@@ -5214,7 +5214,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "segment",
  "serde_json",


### PR DESCRIPTION
Currently a max of 3 retries (hard-coded).

Fixes: #919