### PR TITLE
feat: Add current_user, current_schema, and current_database functions

### DIFF
--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -148,6 +148,10 @@ impl ProtocolHandler {
             .read_proxy_key_val(&mut framed, &GLAREDB_MEMORY_LIMIT_BYTES_KEY, &params)
             .await?;
 
+        // Standard postgres params. These values are used only for informational purposes.
+        let user_name = params.get("user").cloned().unwrap_or_default();
+        let database_name = params.get("database").cloned().unwrap_or_default();
+
         // Handle password
         framed
             .send(BackendMessage::AuthenticationCleartextPassword)
@@ -166,8 +170,10 @@ impl ProtocolHandler {
             .engine
             .new_session(
                 user_id,
+                user_name,
                 conn_id,
                 db_id,
+                database_name,
                 max_datasource_count,
                 memory_limit_bytes,
             )

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -13,8 +13,13 @@ use uuid::Uuid;
 pub struct SessionInfo {
     /// Database id that this session is connected to.
     pub database_id: Uuid,
-    /// ID of the user who initiated the connection.
+    // Name of the database we're connected to.
+    pub database_name: String,
+    /// ID of the user who initiated the connection. This maps to a user account
+    /// on Cloud.
     pub user_id: Uuid,
+    /// Name of the (database) user.
+    pub user_name: String,
     /// Unique connection id.
     pub conn_id: Uuid,
     // Max datasource count allowed.
@@ -42,11 +47,14 @@ impl Engine {
     }
 
     /// Create a new session with the given id.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_session(
         &self,
         user_id: Uuid,
+        user_name: String,
         conn_id: Uuid,
         database_id: Uuid,
+        database_name: String,
         max_datasource_count: usize,
         memory_limit_bytes: usize,
     ) -> Result<Session> {
@@ -54,7 +62,9 @@ impl Engine {
 
         let info = Arc::new(SessionInfo {
             database_id,
+            database_name,
             user_id,
+            user_name,
             conn_id,
             max_datasource_count,
             memory_limit_bytes,

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -184,7 +184,7 @@ impl<'a> ContextProvider for PartialContextProvider<'a> {
             .map(|f| Arc::new(f.build_scalar_udf(self.ctx)))
         {
             Some(func) => Some(func),
-            None => PgFunctionBuilder::try_from_name(name, true),
+            None => PgFunctionBuilder::try_from_name(self.ctx, name, true),
         }
     }
 

--- a/testdata/sqllogictests/functions/postgres.slt
+++ b/testdata/sqllogictests/functions/postgres.slt
@@ -1,0 +1,33 @@
+# Postgres function compatibility
+#
+# Some of these depend on connection values set in the slt runner (e.g. user == 'glaredb')
+#
+# Also note that some of these having special cases when parsing. For example
+# `select current_user;` parses as expected, but `select current_user();` does
+# not.
+#
+# See <https://github.com/sqlparser-rs/sqlparser-rs/pull/561>
+
+statement ok
+set search_path = public;
+
+query T
+select current_schema();
+----
+public
+
+query T
+select current_user;
+----
+glaredb
+
+query T
+select current_database();
+----
+glaredb
+
+query T
+select current_catalog;
+----
+glaredb
+


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/949

Also removes a unit test for checking resolving to pg functions work. The pg function stuff now relies on having a session context passed to it, and it's not currently suitable to be constructed in tests (too many dependencies required).

SLT tests were added, which I think helps cover the gap left from removing the unit test.