### PR TITLE
fix: Filter out CTEs when building table providers

### DIFF
--- a/testdata/sqllogictests/views.slt
+++ b/testdata/sqllogictests/views.slt
@@ -112,3 +112,13 @@ create view invalid2(a, b, c) as select 1, 2;
 statement error
 create view invalid_body as select * from this_table_doesnt_exist;
 
+# View/CTE name conflict (#968)
+#
+# `external_datasources` makes use of a CTE named 'datasources'. Creating a view
+# of the same name that referenced it previously resulted in a stack overflow.
+
+statement ok
+create view datasources as select * from glare_catalog.external_datasources;
+
+statement ok
+select * from datasources;


### PR DESCRIPTION
Late planning with views/CTEs with the same name would result in a stack overflow. There's still chances of stack overflows, but this should prevent the most common cases.

Closes https://github.com/GlareDB/glaredb/issues/968