### PR TITLE
build(deps): bump datafusion from `06e9f53` to `90775b4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c107a57b5913d852da9d5a40e280e4695f2258b5b87733c13b770c63a7117287"
+checksum = "218ca81dd088b102c0fd6687c72e73fad1ba93d2ef7b3cf9a1043b04b2c39dbf"
 dependencies = [
  "ahash 0.8.2",
  "arrow-arith",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace6aa3d5617c5d03041a05e01c6819428a8ddf49dd0b055df9b40fef9d96094"
+checksum = "d49309fa2299ec34a709cfc9f487c41ecaead96d1ab70e21857466346bbbd690"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a04520692cc674e6afd7682f213ca41f9b13ff1873f63a5a2857a590b87b3"
+checksum = "e7a27466d897d99654357a6d95dc0a26931d9e4306e60c14fc31a894edb86579"
 dependencies = [
  "ahash 0.8.2",
  "arrow-buffer",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c875bcb9530ec403998fb0b2dc6d180a7c64563ca4bc22b90eafb84b113143"
+checksum = "9405b78106a9d767c7b97c78a70ee1b23ee51a74f5188a821a716d9a85d1af2b"
 dependencies = [
  "half",
  "num",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d6e18281636c8fc0b93be59834da6bf9a72bb70fd0c98ddfdaf124da466c28"
+checksum = "be0ec5a79a87783dc828b7ff8f89f62880b3f553bc5f5b932a82f4a1035024b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197dab0963a236ff8e7c82e2272535745955ac1321eb740c29f2f88b353f54e"
+checksum = "350d8e55c3b2d602a0a04389bcc1da40167657143a9922a7103190603e7b7692"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb68113d6ecdbe8bba48b2c4042c151bf9e1c61244e45072a50250a6fc59bafe"
+checksum = "c6f710d98964d2c069b8baf566130045e79e11baa105623f038a6c942f805681"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab4bbf2dd3078facb5ce0a9641316a64f42bfd8cf357e6775c8a5e6708e3a8d"
+checksum = "9c99787cb8fabc187285da9e7182d22f2b80ecfac61ca0a42c4299e9eecdf903"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c5b650d23746a494665d914a7fa3d21d939153cff9d53bdebe39bffa88f263"
+checksum = "91c95a58ce63f60d80d7a3a1222d65df0bc060b71d31353c34a8118c2a6eae7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c6fce28e5011e30acc7466b5efcb8ed0197c396240bd2b10e167f275a3c208"
+checksum = "4141e6488610cc144e841da3de5f5371488f3cf5bc6bc7b3e752c64e7639c31b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20a421f19799d8b93eb8edde5217e910fa1e2d6ceb3c529f000e57b6db144c0"
+checksum = "940191a3c636c111c41e816325b0941484bf904c46de72cd9553acd1afd24d33"
 dependencies = [
  "ahash 0.8.2",
  "arrow-array",
@@ -310,15 +310,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc85923d8d6662cc66ac6602c7d1876872e671002d60993dfdf492a6badeae92"
+checksum = "18c41d058b2895a12f46dfafc306ee3529ad9660406be0ab8a7967d5e27c417e"
 
 [[package]]
 name = "arrow-select"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ab6613ce65b61d85a3410241744e84e48fbab0fe06e1251b4429d21b3470fd"
+checksum = "9fcbdda2772b7e712e77444f3a71f4ee517095aceb993b35de71de41c70d9b4f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3008641239e884aefba66d8b8532da6af40d14296349fcc85935de4ba67b89e"
+checksum = "7081c34f4b534ad320a03db79d58e38972041bb7c65686b98bbcc2f9a67a9cee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -339,7 +339,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -1341,8 +1341,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1390,8 +1390,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1404,8 +1404,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1421,8 +1421,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1432,8 +1432,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1449,8 +1449,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1481,8 +1481,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1492,8 +1492,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "23.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+version = "24.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?branch=main#90775b4832fcc066d41025bc3ab29a5d8b8fbccf"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3483,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbd51311f8d9ff3d2697b1522b18a588782e097d313a1a278b0faf2ccf2d3f6"
+checksum = "b0a1e6fa27f09ebddba280f5966ef435f3ac4d74cfc3ffe370fd3fd59c2e004d"
 dependencies = [
  "ahash 0.8.2",
  "arrow-array",
@@ -5749,7 +5749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/crates/datasource_mongodb/src/builder.rs
+++ b/crates/datasource_mongodb/src/builder.rs
@@ -117,11 +117,8 @@ impl ArrayBuilder for RecordStructBuilder {
         let builders = std::mem::take(&mut self.builders);
         let arrays = builders.into_iter().map(|mut b| b.finish());
 
-        let pairs: Vec<(Field, Arc<dyn Array>)> = fields
-            .into_iter()
-            .map(|f| f.as_ref().clone())
-            .zip(arrays)
-            .collect();
+        let pairs: Vec<(Arc<Field>, Arc<dyn Array>)> =
+            fields.into_iter().map(Arc::clone).zip(arrays).collect();
 
         let array: StructArray = pairs.into();
 
@@ -129,14 +126,10 @@ impl ArrayBuilder for RecordStructBuilder {
     }
 
     fn finish_cloned(&self) -> ArrayRef {
-        let fields = self.fields.clone();
         let arrays: Vec<Arc<dyn Array>> = self.builders.iter().map(|b| b.finish_cloned()).collect();
 
-        let pairs: Vec<(Field, Arc<dyn Array>)> = fields
-            .into_iter()
-            .map(|f| f.as_ref().clone())
-            .zip(arrays)
-            .collect();
+        let pairs: Vec<(Arc<Field>, Arc<dyn Array>)> =
+            self.fields.iter().map(Arc::clone).zip(arrays).collect();
 
         let array: StructArray = pairs.into();
 

--- a/crates/snowflake_connector/src/query.rs
+++ b/crates/snowflake_connector/src/query.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, fmt::Debug, io::Cursor, sync::Arc, vec};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    io::{BufReader, Cursor},
+    sync::Arc,
+    vec,
+};
 
 use datafusion::{
     arrow::{
@@ -236,7 +242,7 @@ macro_rules! make_json_column {
 
 pub enum RecordBatchIter {
     Stream {
-        reader: StreamReader<Cursor<Vec<u8>>>,
+        reader: StreamReader<BufReader<Cursor<Vec<u8>>>>,
         schema: SchemaRef,
         type_metas: Arc<Vec<SnowflakeTypeMeta>>,
     },


### PR DESCRIPTION
## Breaking changes to datafusion:

- Instead of `From<Vec<(Field, Arc<dyn Array>)>>` it's now `From<Vec<(Arc<Field>, Arc<dyn Array>)>>` which essentially avoids `Field::clone`.
- No `csv::Reader::new`, now have to use `csv::ReaderBuilder`
- `StreamReader::new` creates a buffered reader by default now