### PR TITLE
fix: Return SSH keys with user name in comment

### DIFF
--- a/crates/datasource_common/src/errors.rs
+++ b/crates/datasource_common/src/errors.rs
@@ -18,6 +18,9 @@ pub enum DatasourceCommonError {
     #[error("Unknown virtual catalog table: {0}")]
     UnknownVirtualCatalogTable(String),
 
+    #[error("Invalid SSH connection string: {0}")]
+    SshConnectionParseError(String),
+
     #[error(transparent)]
     ListingErrBoxed(#[from] Box<dyn std::error::Error + Sync + Send>),
 

--- a/crates/datasource_common/src/ssh.rs
+++ b/crates/datasource_common/src/ssh.rs
@@ -1,8 +1,10 @@
+use std::fmt::Display;
+use std::fs::Permissions;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::os::unix::prelude::PermissionsExt;
+use std::str::FromStr;
 use std::time::Duration;
-use std::{fmt::Write, fs::Permissions};
 
 use openssh::{ForwardType, KnownHosts, Session, SessionBuilder};
 use ssh_key::{LineEnding, PrivateKey};
@@ -48,28 +50,98 @@ impl SshKey {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct SshConnectionParameters {
+    pub host: String,
+    pub port: Option<u16>,
+    pub user: String,
+}
+
+impl FromStr for SshConnectionParameters {
+    type Err = DatasourceCommonError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        use DatasourceCommonError::SshConnectionParseError;
+
+        let s = match s.strip_prefix("ssh://") {
+            None => {
+                return Err(SshConnectionParseError(format!(
+                    "connection string should start with `ssh://`: {s}"
+                )))
+            }
+            Some(s) => s,
+        };
+
+        let (user, address) = match s.split_once('@') {
+            None => {
+                return Err(SshConnectionParseError(format!(
+                    "connection string should have the format `ssh://user@address`: {s}"
+                )))
+            }
+            Some((user, address)) => (user, address),
+        };
+
+        if user.is_empty() {
+            return Err(SshConnectionParseError(format!(
+                "user cannot be empty: {s}"
+            )));
+        }
+
+        if address.is_empty() {
+            return Err(SshConnectionParseError(format!(
+                "address cannot be empty: {s}"
+            )));
+        }
+
+        // Find the `:` and split on it.
+        let (host, port) = match address.rsplit_once(':') {
+            None => (address.to_owned(), None),
+            Some((host, port)) => {
+                let port: u16 = port.parse().map_err(|_e| {
+                    SshConnectionParseError(format!("port should be a valid number: {port}"))
+                })?;
+                (host.to_owned(), Some(port))
+            }
+        };
+
+        if host.is_empty() {
+            return Err(SshConnectionParseError(format!(
+                "host cannot be empty: {s}"
+            )));
+        }
+
+        Ok(Self {
+            host,
+            port,
+            user: user.to_owned(),
+        })
+    }
+}
+
 #[derive(Debug)]
 pub enum SshConnection {
     ConnectionString(String),
-    Parameters {
-        host: String,
-        port: Option<u16>,
-        user: String,
-    },
+    Parameters(SshConnectionParameters),
+}
+
+impl Display for SshConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionString(s) => write!(f, "{s}"),
+            Self::Parameters(SshConnectionParameters { host, port, user }) => {
+                write!(f, "ssh://{user}@{host}")?;
+                if let Some(port) = port {
+                    write!(f, ":{port}")?;
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 impl SshConnection {
     pub fn connection_string(&self) -> String {
-        match self {
-            Self::ConnectionString(s) => s.to_owned(),
-            Self::Parameters { host, port, user } => {
-                let mut conn_str = format!("ssh://{user}@{host}");
-                if let Some(port) = port {
-                    write!(&mut conn_str, ":{port}").unwrap();
-                }
-                conn_str
-            }
-        }
+        format!("{self}")
     }
 }
 
@@ -167,7 +239,7 @@ impl SshTunnelAccess {
 
 #[cfg(test)]
 mod tests {
-    use crate::ssh::{SshConnection, SshKey, SshTunnelAccess};
+    use crate::ssh::{SshConnection, SshConnectionParameters, SshKey, SshTunnelAccess};
 
     #[tokio::test]
     async fn validate_temp_keyfile() {
@@ -185,26 +257,76 @@ mod tests {
     }
 
     #[test]
-    fn connection_string() {
+    fn display_connection_string() {
         let conn_str = SshConnection::ConnectionString("ssh://prod@127.0.0.1:5432".to_string())
             .connection_string();
         assert_eq!(&conn_str, "ssh://prod@127.0.0.1:5432");
 
-        let conn_str = SshConnection::Parameters {
+        let conn_str = SshConnection::Parameters(SshConnectionParameters {
             host: "127.0.0.1".to_string(),
             port: Some(5432),
             user: "prod".to_string(),
-        };
+        });
         let conn_str = conn_str.connection_string();
         assert_eq!(&conn_str, "ssh://prod@127.0.0.1:5432");
 
         // Missing port.
-        let conn_str = SshConnection::Parameters {
+        let conn_str = SshConnection::Parameters(SshConnectionParameters {
             host: "127.0.0.1".to_string(),
             port: None,
             user: "prod".to_string(),
-        };
+        });
         let conn_str = conn_str.connection_string();
         assert_eq!(&conn_str, "ssh://prod@127.0.0.1");
+    }
+
+    #[test]
+    fn parse_connection_string() {
+        // Valid
+        let test_cases = vec![
+            (
+                "ssh://user@host.com",
+                SshConnectionParameters {
+                    host: "host.com".to_string(),
+                    port: None,
+                    user: "user".to_string(),
+                },
+            ),
+            (
+                "ssh://user@host.com:1234",
+                SshConnectionParameters {
+                    host: "host.com".to_string(),
+                    port: Some(1234),
+                    user: "user".to_string(),
+                },
+            ),
+            (
+                "ssh://user@127.0.0.1:1234",
+                SshConnectionParameters {
+                    host: "127.0.0.1".to_string(),
+                    port: Some(1234),
+                    user: "user".to_string(),
+                },
+            ),
+        ];
+        for (s, v) in test_cases {
+            let s: SshConnectionParameters = s.parse().unwrap();
+            assert_eq!(s, v);
+        }
+
+        // Invalid
+        let test_cases = vec![
+            "random string",
+            "user@host.com",          // doesn't start with `ssh://`
+            "ssh://user_at_host.com", // missing `@`
+            "ssh://@host.com",        // empty user
+            "ssh://user@",            // empty address
+            "ssh://user@:1234",       // empty host
+            "ssh://host.com:abc",     // invalid port
+        ];
+        for s in test_cases {
+            s.parse::<SshConnectionParameters>()
+                .expect_err("invalid ssh connection string should error");
+        }
     }
 }

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -7,7 +7,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::datasource::ViewTable;
 use datasource_bigquery::{BigQueryAccessor, BigQueryTableAccess};
 use datasource_common::listing::{VirtualCatalogTable, VirtualCatalogTableProvider, VirtualLister};
-use datasource_common::ssh::SshKey;
+use datasource_common::ssh::{SshConnectionParameters, SshKey};
 use datasource_debug::{DebugTableType, DebugVirtualLister};
 use datasource_mongodb::{MongoAccessor, MongoTableAccessInfo};
 use datasource_mysql::{MysqlAccessor, MysqlTableAccess};
@@ -830,7 +830,9 @@ impl<'a> SystemTableDispatcher<'a> {
                     TunnelOptions::Ssh(ssh_options) => {
                         let key = SshKey::from_bytes(&ssh_options.ssh_key)?;
                         let key = key.public_key()?;
-                        println!("key = '{key}'");
+                        let conn_params: SshConnectionParameters =
+                            ssh_options.connection_string.parse()?;
+                        let key = format!("{} {}", key, conn_params.user);
                         public_key.append_value(key);
                     }
                     _ => unreachable!(),

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -17,7 +17,7 @@ use datafusion::sql::sqlparser::ast::AlterTableOperation;
 use datafusion::sql::sqlparser::ast::{self, Ident, ObjectType};
 use datafusion::sql::TableReference;
 use datasource_bigquery::{BigQueryAccessor, BigQueryTableAccess};
-use datasource_common::ssh::{SshConnection, SshKey};
+use datasource_common::ssh::{SshConnection, SshConnectionParameters, SshKey};
 use datasource_debug::DebugTableType;
 use datasource_mongodb::{MongoAccessor, MongoDbConnection, MongoProtocol};
 use datasource_mysql::{MysqlAccessor, MysqlDbConnection, MysqlTableAccess};
@@ -1027,7 +1027,7 @@ fn get_ssh_conn_str(m: &mut BTreeMap<String, OptionValue>) -> Result<String> {
                 None => None,
             };
             let user = remove_required_opt(m, "user")?;
-            SshConnection::Parameters { host, port, user }
+            SshConnection::Parameters(SshConnectionParameters { host, port, user })
         }
     };
     Ok(conn.connection_string())


### PR DESCRIPTION
```
glaredb=> select public_key from glare_catalog.ssh_keys;
                                           public_key
-------------------------------------------------------------------------------------------------
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJyqQCFazwqxPo3lxCfcQ//ylVgDAzhNjWf7qFirc+YV sean
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMuOdSkFcbIWnMl6wHkfkuCRCj4DOH6nW6qcYztl/osP linuxserver.io
(2 rows)
```