### PR TITLE
feat: Add local client commands to specify output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1023,17 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
 
 [[package]]
 name = "comfy-table"
@@ -2302,6 +2324,7 @@ version = "0.0.11"
 dependencies = [
  "anyhow",
  "clap",
+ "colored",
  "datafusion",
  "futures",
  "logutil",
@@ -2388,6 +2411,15 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -25,3 +25,4 @@ tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
 rustyline = "11.0.0"
 once_cell = "1.17.1"
 futures = "0.3.28"
+colored = "2.0.0"

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -1,5 +1,13 @@
 use crate::util::{ensure_spill_path, MetastoreMode};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use colored::Colorize;
+use datafusion::arrow::csv::writer::WriterBuilder as CsvWriterBuilder;
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::json::writer::{
+    JsonFormat, LineDelimited as JsonLineDelimted, Writer as JsonWriter,
+};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::display::FormatOptions;
 use datafusion::arrow::util::pretty;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -8,51 +16,127 @@ use once_cell::sync::Lazy;
 use pgrepr::format::Format;
 use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
-use sqlexec::engine::Engine;
-use sqlexec::engine::TrackedSession;
+use sqlexec::engine::{Engine, TrackedSession};
 use sqlexec::parser;
 use sqlexec::session::ExecutionResult;
-use sqlexec::session::Session;
+use std::fmt::Write as _;
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 use telemetry::Tracker;
 use uuid::Uuid;
 
-/// Run a single session locally.
-pub struct LocalEngine {
-    engine: Engine,
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputMode {
+    Table,
+    Json,
+    Ndjson,
+    Csv,
 }
 
-impl LocalEngine {
-    pub async fn connect(
-        metastore_addr: Option<String>,
-        local_file_path: Option<PathBuf>,
-        spill_path: Option<PathBuf>,
-    ) -> Result<Self> {
-        ensure_spill_path(spill_path.as_ref())?;
+#[derive(Debug, Clone, Parser)]
+pub struct LocalClientOpts {
+    /// Address to the Metastore.
+    ///
+    /// If not provided, an in-process metastore will be started.
+    #[clap(short, long, value_parser)]
+    pub metastore_addr: Option<String>,
+
+    /// Path to spill temporary files to.
+    #[clap(long, value_parser)]
+    pub spill_path: Option<PathBuf>,
+
+    /// Local file path to store database catalog (for a local persistent
+    /// store).
+    #[clap(short = 'f', long, value_parser)]
+    pub local_file_path: Option<PathBuf>,
+
+    /// Display output mode.
+    #[arg(long, value_enum, default_value_t=OutputMode::Table)]
+    pub mode: OutputMode,
+}
+
+impl LocalClientOpts {
+    fn help_string() -> Result<String> {
+        let pairs = [
+            ("\\help", "Show this help text"),
+            (
+                "\\mode MODE",
+                "Set the output mode [table, json, ndjson, csv]",
+            ),
+            ("\\open PATH", "Open a database at the given path"),
+            ("\\quit", "Quit this session"),
+        ];
+
+        let mut buf = String::new();
+        for (cmd, help) in pairs {
+            writeln!(&mut buf, "{cmd: <15} {help}")?;
+        }
+
+        Ok(buf)
+    }
+}
+
+pub struct LocalSession {
+    sess: TrackedSession,
+    _engine: Engine, // Avoid dropping
+    opts: LocalClientOpts,
+}
+
+impl LocalSession {
+    pub async fn connect(opts: LocalClientOpts) -> Result<Self> {
+        if opts.metastore_addr.is_some() && opts.local_file_path.is_some() {
+            return Err(anyhow!(
+                "Cannot specify both a metastore address and a local file path"
+            ));
+        }
+
+        ensure_spill_path(opts.spill_path.as_ref())?;
 
         // Connect to metastore.
-        let mode = MetastoreMode::new_from_options(metastore_addr, local_file_path, true)?;
+        let mode = MetastoreMode::new_from_options(
+            opts.metastore_addr.clone(),
+            opts.local_file_path.clone(),
+            true,
+        )?;
         let metastore_client = mode.into_client().await?;
-
         let tracker = Arc::new(Tracker::Nop);
+        let engine = Engine::new(metastore_client, tracker, opts.spill_path.clone()).await?;
 
-        let engine = Engine::new(metastore_client, tracker, spill_path).await?;
-
-        Ok(LocalEngine { engine })
+        Ok(LocalSession {
+            sess: engine
+                .new_session(
+                    Uuid::nil(),
+                    "glaredb".to_string(),
+                    Uuid::nil(),
+                    Uuid::nil(),
+                    "glaredb".to_string(),
+                    0,
+                    0,
+                    0,
+                )
+                .await?,
+            _engine: engine,
+            opts,
+        })
     }
 
-    pub async fn run(self) -> Result<()> {
-        println!("GlareDB ({})", env!("CARGO_PKG_VERSION"));
-
-        let mut sess = self.new_session().await?;
+    pub async fn run_interactive(mut self) -> Result<()> {
+        println!("GlareDB (v{})", env!("CARGO_PKG_VERSION"));
+        let info = match (&self.opts.metastore_addr, &self.opts.local_file_path) {
+            (Some(addr), None) => format!("Persisting catalog on remote metastore: {addr}"),
+            (None, Some(path)) => format!("Persisting catalog at path: {}", path.display()),
+            (None, None) => "Using in-memory catalog".to_string(),
+            _ => unreachable!(),
+        };
+        println!("{}", info.bold());
 
         let mut rl = DefaultEditor::new()?;
         loop {
             let readline = rl.readline("> ");
             match readline {
                 Ok(line) => {
-                    if let Err(e) = execute(&mut sess, &line).await {
+                    if let Err(e) = self.execute(&line).await {
                         println!("ERROR: {e}");
                     }
                 }
@@ -65,74 +149,149 @@ impl LocalEngine {
         Ok(())
     }
 
-    pub async fn execute_one(self, query: &str) -> Result<()> {
-        let mut sess = self.new_session().await?;
-        execute(&mut sess, query).await?;
+    pub async fn execute_one(mut self, query: &str) -> Result<()> {
+        self.execute(query).await?;
         Ok(())
     }
 
-    async fn new_session(&self) -> Result<TrackedSession> {
-        let sess = self
-            .engine
-            .new_session(
-                Uuid::nil(),
-                "glaredb".to_string(),
-                Uuid::nil(),
-                Uuid::nil(),
-                "glaredb".to_string(),
-                0,
-                0,
-                0,
-            )
-            .await?;
-        Ok(sess)
+    async fn execute(&mut self, text: &str) -> Result<()> {
+        if is_client_cmd(text) {
+            self.handle_client_cmd(text).await?;
+            return Ok(());
+        }
+
+        const UNNAMED: String = String::new();
+
+        let statements = parser::parse_sql(text)?;
+        for stmt in statements {
+            self.sess
+                .prepare_statement(UNNAMED, Some(stmt), Vec::new())
+                .await?;
+            let prepared = self.sess.get_prepared_statement(&UNNAMED)?;
+            let num_fields = prepared.output_fields().map(|f| f.len()).unwrap_or(0);
+            self.sess.bind_statement(
+                UNNAMED,
+                &UNNAMED,
+                Vec::new(),
+                vec![Format::Text; num_fields],
+            )?;
+            let result = self.sess.execute_portal(&UNNAMED, 0).await?;
+
+            match result {
+                ExecutionResult::Query { stream, .. }
+                | ExecutionResult::ShowVariable { stream } => {
+                    print_stream(stream, self.opts.mode).await?
+                }
+                other => println!("{:?}", other),
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_client_cmd(&mut self, text: &str) -> Result<()> {
+        let mut ss = text.split_whitespace();
+        let cmd = ss.next().unwrap();
+        let val = ss.next();
+
+        match (cmd, val) {
+            ("\\help", None) => {
+                print!("{}", LocalClientOpts::help_string()?);
+            }
+            ("\\mode", Some(val)) => {
+                self.opts.mode = OutputMode::from_str(val, true)
+                    .map_err(|s| anyhow!("Unable to set output mode: {s}"))?;
+            }
+            ("\\open", Some(path)) => {
+                let new_opts = LocalClientOpts {
+                    local_file_path: Some(PathBuf::from(path)),
+                    metastore_addr: None,
+                    ..self.opts.clone()
+                };
+                let new_sess = LocalSession::connect(new_opts).await?;
+                println!("Created new session. New database path: {path}");
+                *self = new_sess;
+            }
+            ("\\quit", None) => std::process::exit(0),
+            (cmd, _) => return Err(anyhow!("Unable to handle client command: {cmd}")),
+        }
+
+        Ok(())
     }
 }
 
-static FORMAT_OPTS: Lazy<FormatOptions> = Lazy::new(|| {
+static TABLE_FORMAT_OPTS: Lazy<FormatOptions> = Lazy::new(|| {
     FormatOptions::default()
         .with_display_error(false)
         .with_null("NULL")
 });
 
-const UNNAMED: String = String::new();
-
-async fn execute(sess: &mut Session, text: &str) -> Result<()> {
-    let statements = parser::parse_sql(text)?;
-
-    for stmt in statements {
-        sess.prepare_statement(UNNAMED, Some(stmt), Vec::new())
-            .await?;
-        let prepared = sess.get_prepared_statement(&UNNAMED)?;
-        let num_fields = prepared.output_fields().map(|f| f.len()).unwrap_or(0);
-        sess.bind_statement(
-            UNNAMED,
-            &UNNAMED,
-            Vec::new(),
-            vec![Format::Text; num_fields],
-        )?;
-        let result = sess.execute_portal(&UNNAMED, 0).await?;
-
-        match result {
-            ExecutionResult::Query { stream, .. } | ExecutionResult::ShowVariable { stream } => {
-                print_stream(stream).await?
-            }
-            other => println!("{:?}", other),
-        }
-    }
-
-    Ok(())
-}
-
-async fn print_stream(stream: SendableRecordBatchStream) -> Result<()> {
+async fn print_stream(stream: SendableRecordBatchStream, mode: OutputMode) -> Result<()> {
     let batches = stream
         .collect::<Vec<_>>()
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;
 
-    let disp = pretty::pretty_format_batches_with_options(&batches, &FORMAT_OPTS)?;
-    println!("{disp}");
+    fn write_json<F: JsonFormat>(batches: &[RecordBatch]) -> Result<()> {
+        let stdout = std::io::stdout();
+        let buf = std::io::BufWriter::new(stdout);
+        let mut writer = JsonWriter::<_, F>::new(buf);
+        writer.write_batches(batches)?;
+        writer.finish()?;
+        let mut buf = writer.into_inner();
+        buf.flush()?;
+        Ok(())
+    }
+
+    match mode {
+        OutputMode::Table => {
+            let disp = pretty::pretty_format_batches_with_options(&batches, &TABLE_FORMAT_OPTS)?;
+            println!("{disp}");
+        }
+        OutputMode::Csv => {
+            let stdout = std::io::stdout();
+            let buf = std::io::BufWriter::new(stdout);
+            let mut writer = CsvWriterBuilder::new().has_headers(true).build(buf);
+            for batch in batches {
+                writer.write(&batch)?; // CSV writer flushes per write.
+            }
+        }
+        OutputMode::Json => write_json::<JsonArrayNewLines>(&batches)?,
+        OutputMode::Ndjson => write_json::<JsonLineDelimted>(&batches)?,
+    }
 
     Ok(())
+}
+
+fn is_client_cmd(s: &str) -> bool {
+    s.starts_with('\\')
+}
+
+/// Produces JSON output as a single JSON array with new lines between objects.
+///
+/// ```json
+/// [{"foo":1},
+/// {"bar":1}]
+/// ```
+#[derive(Debug, Default)]
+pub struct JsonArrayNewLines {}
+
+impl JsonFormat for JsonArrayNewLines {
+    fn start_stream<W: Write>(&self, writer: &mut W) -> Result<(), ArrowError> {
+        writer.write_all(b"[")?;
+        Ok(())
+    }
+
+    fn start_row<W: Write>(&self, writer: &mut W, is_first_row: bool) -> Result<(), ArrowError> {
+        if !is_first_row {
+            writer.write_all(b",\n")?;
+        }
+        Ok(())
+    }
+
+    fn end_stream<W: Write>(&self, writer: &mut W) -> Result<(), ArrowError> {
+        writer.write_all(b"]\n")?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
New `mode` option for specify output formatting:

```
      --mode <MODE>
          Display output mode

          [default: table]
          [possible values: table, json, ndjson, csv]
```

Table (default):

```
% ./glaredb local --query "select * from (values (1, 'hello'), (2, 'world'), (3, '!'))"
+---------+---------+
| column1 | column2 |
+---------+---------+
| 1       | hello   |
| 2       | world   |
| 3       | !       |
+---------+---------+
```

Json:

```
% ./glaredb local --mode json --query "select * from (values (1, 'hello'), (2, 'world'), (3, '!'))"
[{"column1":1,"column2":"hello"},
{"column1":2,"column2":"world"},
{"column1":3,"column2":"!"}]
```

This can also be set during interactive sessions:

```
% ./glaredb local
GlareDB (v0.0.11)
Using in-memory catalog
> \help
\help           Show this help text
\mode MODE      Set the output mode [table, json, ndjson, csv]
\open PATH      Open a database at the given path
\quit           Quit this session
> select 1 as a, 2 as b;
+---+---+
| a | b |
+---+---+
| 1 | 2 |
+---+---+
> \mode json
> select 1 as a, 2 as b;
[{"a":1,"b":2}]
>
```