### PR TITLE
chore: Run ssh tunnel tests separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,8 @@ jobs:
           # Prepare SLT (MongoDB)
           export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
 
-          cargo xtask test -- --test sqllogictests -- -v
+          cargo xtask test -- --test sqllogictests -- -v --exclude '*/tunnels/ssh'
+          cargo xtask test -- --test sqllogictests -- -v '*/tunnels/ssh'
 
       - name: Protocol Tests
         run: ./scripts/protocol-test.sh

--- a/crates/testing/tests/sqllogictests/hooks.rs
+++ b/crates/testing/tests/sqllogictests/hooks.rs
@@ -146,7 +146,7 @@ SELECT public_key
                 Err(anyhow!("container not started yet"))
             }
         }
-        let deadline = Instant::now() + Duration::from_secs(120);
+        let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
             if check_container(container_id).await.is_ok() {
                 return Ok(());


### PR DESCRIPTION
Hopefully this will let us narrow down why these tests occasionally fail. Right now all the logs are intermingled so hard to see what's what.

Also reduces container start timeout to 30s since that should be more than enough time.