### PR TITLE
feat: Add functions for reading data sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "env_logger",
  "paste",
  "rstest",
+ "sqlbuiltins",
 ]
 
 [[package]]
@@ -1635,7 +1636,6 @@ dependencies = [
  "decimal",
  "futures",
  "gcp-bigquery-client",
- "metastore",
  "metastoreproto",
  "mongodb",
  "mysql_async",
@@ -2998,6 +2998,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "prost-types",
+ "sqlbuiltins",
  "thiserror",
  "tokio",
  "tonic",
@@ -5119,6 +5120,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlbuiltins"
+version = "0.0.12"
+dependencies = [
+ "async-trait",
+ "datafusion",
+ "datasources",
+ "futures",
+ "logutil",
+ "metastoreproto",
+ "object_store",
+ "once_cell",
+ "pgrepr",
+ "regex",
+ "serde_json",
+ "sqlparser 0.34.0",
+ "telemetry",
+ "thiserror",
+ "tokio",
+ "tokio-postgres",
+ "tonic",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "sqlexec"
 version = "0.0.12"
 dependencies = [
@@ -5135,6 +5161,7 @@ dependencies = [
  "pgrepr",
  "regex",
  "serde_json",
+ "sqlbuiltins",
  "sqlparser 0.34.0",
  "telemetry",
  "tempfile",

--- a/crates/datafusion_planner/Cargo.toml
+++ b/crates/datafusion_planner/Cargo.toml
@@ -29,6 +29,7 @@ unicode_expressions = []
 datafusion = { workspace = true }
 async-trait = "0.1.68"
 async-recursion = "1.0.4"
+sqlbuiltins = {path = "../sqlbuiltins"}
 
 [dev-dependencies]
 ctor = "0.2.2"

--- a/crates/datafusion_planner/src/planner.rs
+++ b/crates/datafusion_planner/src/planner.rs
@@ -40,6 +40,7 @@ use datafusion::logical_expr::logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use datafusion::logical_expr::utils::find_column_exprs;
 use datafusion::logical_expr::TableSource;
 use datafusion::logical_expr::{col, AggregateUDF, Expr, ScalarUDF, SubqueryAlias};
+use sqlbuiltins::functions::TableFunc;
 
 use crate::utils::make_decimal_type;
 
@@ -58,6 +59,12 @@ pub trait AsyncContextProvider: Send + Sync {
     async fn get_aggregate_meta(&mut self, name: &str) -> Option<Arc<AggregateUDF>>;
     /// Getter for system/user-defined variable type
     async fn get_variable_type(&mut self, variable_names: &[String]) -> Option<DataType>;
+
+    /// Get a table returning function.
+    ///
+    /// Note that this accepts a table reference since these functions are
+    /// namespaced similiarly to tables.
+    fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>>;
 
     /// Get configuration options
     fn options(&self) -> &ConfigOptions;

--- a/crates/datafusion_planner/src/relation/mod.rs
+++ b/crates/datafusion_planner/src/relation/mod.rs
@@ -63,7 +63,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                             })?;
 
                         let provider = func
-                            .create_table_provider(&scalars)
+                            .create_provider(scalars)
                             .await
                             .map_err(|e| DataFusionError::Plan(e.to_string()))?;
 

--- a/crates/datafusion_planner/src/relation/mod.rs
+++ b/crates/datafusion_planner/src/relation/mod.rs
@@ -15,12 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::planner::{AsyncContextProvider, SqlQueryPlanner};
 use async_recursion::async_recursion;
 use datafusion::common::{DataFusionError, Result};
-use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder};
+use datafusion::datasource::DefaultTableSource;
+use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
+use datafusion::scalar::ScalarValue;
 use datafusion::sql::planner::PlannerContext;
-use datafusion::sql::sqlparser::ast::TableFactor;
+use datafusion::sql::sqlparser::ast;
 
 mod join;
 
@@ -29,28 +33,68 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
     #[async_recursion]
     async fn create_relation(
         &mut self,
-        relation: TableFactor,
+        relation: ast::TableFactor,
         planner_context: &mut PlannerContext,
     ) -> Result<LogicalPlan> {
         let (plan, alias) = match relation {
-            TableFactor::Table { name, alias, .. } => {
+            ast::TableFactor::Table {
+                name, alias, args, ..
+            } => {
                 // normalize name and alias
                 let table_ref = self.object_name_to_table_reference(name)?;
-                let table_name = table_ref.to_string();
-                let cte = planner_context.get_cte(&table_name);
-                let plan = if let Some(cte_plan) = cte {
-                    cte_plan.clone()
-                } else {
-                    let provider = self
-                        .schema_provider
-                        .get_table_provider(table_ref.clone())
-                        .await?;
-                    let plan_builder = LogicalPlanBuilder::scan(table_ref, provider, None)?;
-                    plan_builder.build()?
-                };
-                (plan, alias)
+
+                match args {
+                    Some(args) => {
+                        // Table factor has arguments, look up table returning
+                        // function.
+
+                        let scalars = args
+                            .into_iter()
+                            .map(|arg| self.get_constant_function_arg(arg))
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        let func = self
+                            .schema_provider
+                            .get_table_func(table_ref.clone())
+                            .ok_or_else(|| {
+                                DataFusionError::Plan(format!(
+                                    "Missing table function: '{table_ref}'"
+                                ))
+                            })?;
+
+                        let provider = func
+                            .create_table_provider(&scalars)
+                            .await
+                            .map_err(|e| DataFusionError::Plan(e.to_string()))?;
+
+                        let source = Arc::new(DefaultTableSource::new(provider));
+
+                        let plan_builder = LogicalPlanBuilder::scan(table_ref, source, None)?;
+                        let plan = plan_builder.build()?;
+
+                        (plan, alias)
+                    }
+                    None => {
+                        // No arguments provided. Just a basic table.
+
+                        let table_name = table_ref.to_string();
+
+                        let cte = planner_context.get_cte(&table_name);
+                        let plan = if let Some(cte_plan) = cte {
+                            cte_plan.clone()
+                        } else {
+                            let provider = self
+                                .schema_provider
+                                .get_table_provider(table_ref.clone())
+                                .await?;
+                            let plan_builder = LogicalPlanBuilder::scan(table_ref, provider, None)?;
+                            plan_builder.build()?
+                        };
+                        (plan, alias)
+                    }
+                }
             }
-            TableFactor::Derived {
+            ast::TableFactor::Derived {
                 subquery, alias, ..
             } => {
                 let logical_plan = self
@@ -58,7 +102,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                     .await?;
                 (logical_plan, alias)
             }
-            TableFactor::NestedJoin {
+            ast::TableFactor::NestedJoin {
                 table_with_joins,
                 alias,
             } => (
@@ -77,6 +121,27 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
             self.apply_table_alias(plan, alias)
         } else {
             Ok(plan)
+        }
+    }
+
+    /// Get a constant expression literal from a function argument.
+    fn get_constant_function_arg(&mut self, arg: ast::FunctionArg) -> Result<ScalarValue> {
+        match arg {
+            ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(expr)) => match expr {
+                ast::Expr::Value(v) => match self.parse_value(v, &[]) {
+                    Ok(Expr::Literal(lit)) => Ok(lit),
+                    Ok(_) => Err(DataFusionError::NotImplemented(
+                        "Non-constant function argument".to_string(),
+                    )),
+                    Err(e) => Err(e),
+                },
+                _ => Err(DataFusionError::NotImplemented(
+                    "Non-constant function argument".to_string(),
+                )),
+            },
+            _ => Err(DataFusionError::NotImplemented(
+                "Named arguments for functions".to_string(),
+            )),
         }
     }
 }

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -17,7 +17,6 @@ datafusion = { workspace = true }
 decimal = { path = "../decimal" }
 futures = "0.3.28"
 gcp-bigquery-client = "0.16.7"
-metastore = { path = "../metastore" }
 metastoreproto = { path = "../metastoreproto" }
 mongodb = "2.5.0"
 mysql_async = { version = "0.32.2", default-features = false, features = ["default-rustls"] }

--- a/crates/datasources/src/common/listing.rs
+++ b/crates/datasources/src/common/listing.rs
@@ -18,7 +18,6 @@ use datafusion::{
     physical_plan::{memory::MemoryExec, ExecutionPlan},
     scalar::ScalarValue,
 };
-use metastore::builtins::{VIRTUAL_CATALOG_SCHEMATA_TABLE, VIRTUAL_CATALOG_TABLES_TABLE};
 
 use super::errors::{DatasourceCommonError, Result};
 
@@ -60,8 +59,8 @@ pub enum VirtualCatalogTable {
 impl Display for VirtualCatalogTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Self::Schemata => VIRTUAL_CATALOG_SCHEMATA_TABLE,
-            Self::Tables => VIRTUAL_CATALOG_TABLES_TABLE,
+            Self::Schemata => "schemata",
+            Self::Tables => "tables",
         };
         f.write_str(s)
     }
@@ -72,8 +71,8 @@ impl FromStr for VirtualCatalogTable {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let catalog = match s {
-            VIRTUAL_CATALOG_SCHEMATA_TABLE => Self::Schemata,
-            VIRTUAL_CATALOG_TABLES_TABLE => Self::Tables,
+            "schemata" => Self::Schemata,
+            "tables" => Self::Tables,
             other => {
                 return Err(DatasourceCommonError::UnknownVirtualCatalogTable(
                     other.to_owned(),

--- a/crates/metastore/Cargo.toml
+++ b/crates/metastore/Cargo.toml
@@ -8,6 +8,7 @@ edition = {workspace = true}
 [dependencies]
 logutil = {path = "../logutil"}
 metastoreproto = { path = "../metastoreproto" }
+sqlbuiltins = { path = "../sqlbuiltins" }
 object_store_util = {path = "../object_store_util"}
 pgrepr = {path = "../pgrepr"}
 tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }

--- a/crates/metastore/src/builtins.rs
+++ b/crates/metastore/src/builtins.rs
@@ -17,6 +17,7 @@ use datafusion::arrow::datatypes::{DataType, Field as ArrowField, Schema as Arro
 use metastoreproto::types::options::InternalColumnDefinition;
 use once_cell::sync::Lazy;
 use pgrepr::oid::FIRST_GLAREDB_BUILTIN_ID;
+use std::sync::Arc;
 
 /// The default catalog that exists in all GlareDB databases.
 pub const DEFAULT_CATALOG: &str = "default";
@@ -147,6 +148,28 @@ pub static GLARE_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     ]),
 });
 
+pub static GLARE_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    schema: INTERNAL_SCHEMA,
+    name: "functions",
+    columns: InternalColumnDefinition::from_tuples([
+        ("oid", DataType::UInt32, false),
+        ("schema_oid", DataType::UInt32, false),
+        ("function_name", DataType::Utf8, false),
+        ("function_type", DataType::Utf8, false), // table, scalar, aggregate
+        (
+            "parameters",
+            DataType::List(Arc::new(ArrowField::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        (
+            "parameter_types",
+            DataType::List(Arc::new(ArrowField::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        ("builtin", DataType::Boolean, false),
+    ]),
+});
+
 pub static GLARE_SESSION_QUERY_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "session_query_metrics",
@@ -195,6 +218,7 @@ impl BuiltinTable {
             &GLARE_VIEWS,
             &GLARE_TABLES,
             &GLARE_COLUMNS,
+            &GLARE_FUNCTIONS,
             &GLARE_SESSION_QUERY_METRICS,
             &GLARE_SSH_KEYS,
         ]

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -9,8 +9,8 @@ use crate::validation::{
     validate_database_tunnel_support, validate_object_name, validate_table_tunnel_support,
 };
 use metastoreproto::types::catalog::{
-    CatalogEntry, CatalogState, DatabaseEntry, EntryMeta, EntryType, FunctionEntry, SchemaEntry,
-    TableEntry, TunnelEntry, ViewEntry,
+    CatalogEntry, CatalogState, DatabaseEntry, EntryMeta, EntryType, FunctionEntry, FunctionType,
+    SchemaEntry, TableEntry, TunnelEntry, ViewEntry,
 };
 use metastoreproto::types::options::{
     DatabaseOptions, DatabaseOptionsInternal, TableOptions, TunnelOptions,
@@ -1056,6 +1056,7 @@ impl BuiltinCatalog {
                         builtin: true,
                         external: false,
                     },
+                    func_type: FunctionType::TableReturning,
                 }),
             );
             schema_objects

--- a/crates/metastore/src/errors.rs
+++ b/crates/metastore/src/errors.rs
@@ -9,12 +9,13 @@ pub enum MetastoreError {
     #[error("Invalid object name length: {length}, max: {max}")]
     InvalidNameLength { length: usize, max: usize },
 
-    #[error("Duplicate object names found during load; name {name}, schema: {schema}, first: {first}, second: {second}")]
+    #[error("Duplicate object names in the '{object_namespace}' namespace found during load; name {name}, schema: {schema}, first: {first}, second: {second}")]
     DuplicateNameFoundDuringLoad {
         name: String,
         schema: u32,
         first: u32,
         second: u32,
+        object_namespace: &'static str,
     },
 
     #[error("Builtin object persisted when it shouldn't have been: {0:?}")]

--- a/crates/metastoreproto/proto/catalog.proto
+++ b/crates/metastoreproto/proto/catalog.proto
@@ -54,6 +54,7 @@ message CatalogEntry {
     TableEntry table = 3;
     ViewEntry view = 4;
     TunnelEntry tunnel = 5;
+    FunctionEntry function = 6;
   }
 }
 
@@ -75,6 +76,8 @@ message EntryMeta {
     VIEW = 4;
     // Tunnel to connect with datasources.
     TUNNEL = 5;
+    // Function entry.
+    FUNCTION = 6;
   }
 
   // Type of the entry.
@@ -147,3 +150,8 @@ message TunnelEntry {
   options.TunnelOptions options = 2;
   // next: 3
 }
+
+// Function entries are not currently persisted since the only functions
+// available are builtins. We can change this however we need and not have to
+// worry about backwards compatability.
+message FunctionEntry { EntryMeta meta = 1; }

--- a/crates/metastoreproto/proto/catalog.proto
+++ b/crates/metastoreproto/proto/catalog.proto
@@ -154,4 +154,15 @@ message TunnelEntry {
 // Function entries are not currently persisted since the only functions
 // available are builtins. We can change this however we need and not have to
 // worry about backwards compatability.
-message FunctionEntry { EntryMeta meta = 1; }
+message FunctionEntry {
+  enum FunctionType {
+    // Unknown catalog entry. We should error if this is encountered.
+    UNKNOWN = 0;
+    AGGREGATE = 1;
+    SCALAR = 2;
+    TABLE_RETURNING = 3;
+  }
+
+  EntryMeta meta = 1;
+  FunctionType func_type = 2;
+}

--- a/crates/metastoreproto/src/types/catalog.rs
+++ b/crates/metastoreproto/src/types/catalog.rs
@@ -52,6 +52,7 @@ pub enum CatalogEntry {
     Table(TableEntry),
     View(ViewEntry),
     Tunnel(TunnelEntry),
+    Function(FunctionEntry),
 }
 
 impl CatalogEntry {
@@ -62,6 +63,7 @@ impl CatalogEntry {
             CatalogEntry::View(_) => EntryType::View,
             CatalogEntry::Table(_) => EntryType::Table,
             CatalogEntry::Tunnel(_) => EntryType::Tunnel,
+            CatalogEntry::Function(_) => EntryType::Function,
         }
     }
 
@@ -73,6 +75,7 @@ impl CatalogEntry {
             CatalogEntry::View(view) => &view.meta,
             CatalogEntry::Table(table) => &table.meta,
             CatalogEntry::Tunnel(tunnel) => &tunnel.meta,
+            CatalogEntry::Function(func) => &func.meta,
         }
     }
 
@@ -84,6 +87,7 @@ impl CatalogEntry {
             CatalogEntry::View(view) => &mut view.meta,
             CatalogEntry::Table(table) => &mut table.meta,
             CatalogEntry::Tunnel(tunnel) => &mut tunnel.meta,
+            CatalogEntry::Function(func) => &mut func.meta,
         }
     }
 }
@@ -97,6 +101,7 @@ impl TryFrom<catalog::catalog_entry::Entry> for CatalogEntry {
             catalog::catalog_entry::Entry::Table(v) => CatalogEntry::Table(v.try_into()?),
             catalog::catalog_entry::Entry::View(v) => CatalogEntry::View(v.try_into()?),
             catalog::catalog_entry::Entry::Tunnel(v) => CatalogEntry::Tunnel(v.try_into()?),
+            catalog::catalog_entry::Entry::Function(v) => CatalogEntry::Function(v.try_into()?),
         })
     }
 }
@@ -117,6 +122,7 @@ impl TryFrom<CatalogEntry> for catalog::CatalogEntry {
             CatalogEntry::View(v) => catalog::catalog_entry::Entry::View(v.into()),
             CatalogEntry::Table(v) => catalog::catalog_entry::Entry::Table(v.try_into()?),
             CatalogEntry::Tunnel(v) => catalog::catalog_entry::Entry::Tunnel(v.into()),
+            CatalogEntry::Function(v) => catalog::catalog_entry::Entry::Function(v.into()),
         };
         Ok(catalog::CatalogEntry { entry: Some(ent) })
     }
@@ -129,6 +135,7 @@ pub enum EntryType {
     Table,
     View,
     Tunnel,
+    Function,
 }
 
 impl EntryType {
@@ -139,6 +146,7 @@ impl EntryType {
             EntryType::Table => "table",
             EntryType::View => "view",
             EntryType::Tunnel => "tunnel",
+            EntryType::Function => "function",
         }
     }
 }
@@ -164,6 +172,7 @@ impl TryFrom<catalog::entry_meta::EntryType> for EntryType {
             catalog::entry_meta::EntryType::Table => EntryType::Table,
             catalog::entry_meta::EntryType::View => EntryType::View,
             catalog::entry_meta::EntryType::Tunnel => EntryType::Tunnel,
+            catalog::entry_meta::EntryType::Function => EntryType::Function,
         })
     }
 }
@@ -176,6 +185,7 @@ impl From<EntryType> for catalog::entry_meta::EntryType {
             EntryType::Table => catalog::entry_meta::EntryType::Table,
             EntryType::View => catalog::entry_meta::EntryType::View,
             EntryType::Tunnel => catalog::entry_meta::EntryType::Tunnel,
+            EntryType::Function => catalog::entry_meta::EntryType::Function,
         }
     }
 }
@@ -370,6 +380,27 @@ impl From<TunnelEntry> for catalog::TunnelEntry {
         catalog::TunnelEntry {
             meta: Some(value.meta.into()),
             options: Some(value.options.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+pub struct FunctionEntry {
+    pub meta: EntryMeta,
+}
+
+impl TryFrom<catalog::FunctionEntry> for FunctionEntry {
+    type Error = ProtoConvError;
+    fn try_from(value: catalog::FunctionEntry) -> Result<Self, Self::Error> {
+        let meta: EntryMeta = value.meta.required("meta")?;
+        Ok(FunctionEntry { meta })
+    }
+}
+
+impl From<FunctionEntry> for catalog::FunctionEntry {
+    fn from(value: FunctionEntry) -> Self {
+        catalog::FunctionEntry {
+            meta: Some(value.meta.into()),
         }
     }
 }

--- a/crates/sqlbuiltins/Cargo.toml
+++ b/crates/sqlbuiltins/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sqlexec"
+name = "sqlbuiltins"
 version = {workspace = true}
 edition = {workspace = true}
 
@@ -8,11 +8,8 @@ edition = {workspace = true}
 [dependencies]
 logutil = {path = "../logutil"}
 pgrepr = {path = "../pgrepr"}
-metastore = {path = "../metastore"}
 metastoreproto = { path = "../metastoreproto" }
-datafusion_planner = { path = "../datafusion_planner" }
 telemetry = {path = "../telemetry"}
-sqlbuiltins = {path = "../sqlbuiltins"}
 datasources = {path = "../datasources"}
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -29,6 +26,3 @@ tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
 tokio-postgres = "0.7.8"
 once_cell = "1.17.2"
 
-[dev-dependencies]
-tempfile = "3"
-tower = "0.4"

--- a/crates/sqlbuiltins/src/errors.rs
+++ b/crates/sqlbuiltins/src/errors.rs
@@ -1,0 +1,18 @@
+use datafusion::{arrow::datatypes::DataType, scalar::ScalarValue};
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuiltinError {
+    #[error("Invalid number of arguments.")]
+    InvalidNumArgs,
+
+    #[error("Unexpected argument for function. Got '{scalar}', need value of type '{expected}'")]
+    UnexpectedArg {
+        scalar: ScalarValue,
+        expected: DataType,
+    },
+
+    #[error(transparent)]
+    Access(Box<dyn std::error::Error + Send + Sync>),
+}
+
+pub type Result<T, E = BuiltinError> = std::result::Result<T, E>;

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -1,0 +1,127 @@
+//! Builtin table returning functions.
+use crate::errors::{BuiltinError, Result};
+use async_trait::async_trait;
+use datafusion::{
+    arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema},
+    datasource::TableProvider,
+    scalar::ScalarValue,
+};
+use datasources::postgres::{PostgresAccessor, PostgresTableAccess};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Builtin table returning functions available for all sessions.
+pub static BUILTIN_TABLE_FUNCS: Lazy<BuiltinTableFuncs> = Lazy::new(|| BuiltinTableFuncs::new());
+
+#[derive(Debug, Clone)]
+pub struct TableFuncParameter {
+    pub name: &'static str,
+    pub typ: DataType,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableFuncParamaters {
+    pub params: &'static [TableFuncParameter],
+}
+
+pub struct BuiltinTableFuncs {
+    funcs: HashMap<String, Arc<dyn TableFunc>>,
+}
+
+impl BuiltinTableFuncs {
+    pub fn new() -> BuiltinTableFuncs {
+        let funcs: Vec<Arc<dyn TableFunc>> = vec![Arc::new(ReadPostgres)];
+        let funcs: HashMap<String, Arc<dyn TableFunc>> = funcs
+            .into_iter()
+            .map(|f| (f.name().to_string(), f))
+            .collect();
+
+        BuiltinTableFuncs { funcs }
+    }
+
+    pub fn find_function(&self, name: &str) -> Option<Arc<dyn TableFunc>> {
+        self.funcs.get(name).cloned()
+    }
+
+    pub fn iter_funcs(&self) -> impl Iterator<Item = &Arc<dyn TableFunc>> {
+        self.funcs.iter().map(|(_, f)| f)
+    }
+}
+
+#[async_trait]
+pub trait TableFunc: Sync + Send {
+    fn name(&self) -> &str;
+
+    fn parameters(&self) -> &[TableFuncParamaters];
+
+    async fn create_table_provider(&self, args: &[ScalarValue]) -> Result<Arc<dyn TableProvider>>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReadPostgres;
+
+#[async_trait]
+impl TableFunc for ReadPostgres {
+    fn name(&self) -> &str {
+        "read_postgres"
+    }
+
+    fn parameters(&self) -> &[TableFuncParamaters] {
+        const PARAMS: &'static [TableFuncParamaters] = &[TableFuncParamaters {
+            params: &[
+                TableFuncParameter {
+                    name: "connection_str",
+                    typ: DataType::Utf8,
+                },
+                TableFuncParameter {
+                    name: "schema",
+                    typ: DataType::Utf8,
+                },
+                TableFuncParameter {
+                    name: "table",
+                    typ: DataType::Utf8,
+                },
+            ],
+        }];
+
+        PARAMS
+    }
+
+    async fn create_table_provider(&self, args: &[ScalarValue]) -> Result<Arc<dyn TableProvider>> {
+        match args.len() {
+            3 => {
+                let conn_str = string_from_scalar(&args[0])?;
+                let schema = string_from_scalar(&args[1])?;
+                let table = string_from_scalar(&args[2])?;
+
+                let access = PostgresAccessor::connect(conn_str, None)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?;
+                let prov = access
+                    .into_table_provider(
+                        PostgresTableAccess {
+                            schema: schema.clone(),
+                            name: table.clone(),
+                        },
+                        true,
+                    )
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?;
+
+                Ok(Arc::new(prov))
+            }
+            _ => Err(BuiltinError::InvalidNumArgs),
+        }
+    }
+}
+
+fn string_from_scalar(val: &ScalarValue) -> Result<&String> {
+    match val {
+        ScalarValue::Utf8(Some(s)) => Ok(s),
+        other => Err(BuiltinError::UnexpectedArg {
+            scalar: other.clone(),
+            expected: DataType::Utf8,
+        }),
+    }
+}

--- a/crates/sqlbuiltins/src/lib.rs
+++ b/crates/sqlbuiltins/src/lib.rs
@@ -1,0 +1,8 @@
+//! Builtin sql objects.
+//!
+//! This crate provides the implementation of various builtin sql objects
+//! (particularly functions). These live outside the `sqlexec` crate to allow
+//! it to be imported into both `sqlexec` and `metastore`.
+
+pub mod errors;
+pub mod functions;

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -16,9 +16,12 @@ use datafusion::logical_expr::TableSource;
 use datafusion::sql::TableReference;
 use datafusion_planner::planner::AsyncContextProvider;
 use metastore::builtins::DEFAULT_CATALOG;
+use metastoreproto::types::catalog::CatalogEntry;
 use sqlbuiltins::functions::TableFunc;
+use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::error;
 
 /// Partial context provider with table providers required to fulfill a single
 /// query.
@@ -40,8 +43,8 @@ impl<'a> PartialContextProvider<'a> {
         })
     }
 
-    // Find a table provider the given reference, taking into account the
-    // session's search path.
+    /// Find a table provider the given reference, taking into account the
+    /// session's search path.
     async fn table_for_reference(
         &self,
         reference: TableReference<'_>,
@@ -83,6 +86,61 @@ impl<'a> PartialContextProvider<'a> {
             } => {
                 let table = dispatcher.dispatch_access(catalog, schema, table).await?;
                 Ok(table)
+            }
+        }
+    }
+
+    /// Find a table function with the given reference, taking into account the
+    /// session's search path.
+    fn table_function_for_reference(
+        &self,
+        reference: TableReference<'_>,
+    ) -> Option<Arc<dyn TableFunc>> {
+        let catalog = self.ctx.get_session_catalog();
+
+        let resolve_func = |schema, name| {
+            match catalog.resolve_entry(DEFAULT_CATALOG, schema, name) {
+                Some(CatalogEntry::Function(func)) => {
+                    if func.meta.builtin {
+                        if let Some(func_impl) = BUILTIN_TABLE_FUNCS.find_function(&func.meta.name)
+                        {
+                            Some(func_impl)
+                        } else {
+                            // This can happen if we're in the middle of
+                            // a deploy and builtin functions were
+                            // added/removed.
+                            error!(name = %func.meta.name, "missing builtin function impl");
+                            None
+                        }
+                    } else {
+                        // We only have builtin functions right now.
+                        None
+                    }
+                }
+                _ => None,
+            }
+        };
+
+        match &reference {
+            TableReference::Bare { table } => {
+                for schema in self.ctx.implicit_search_path_iter() {
+                    if let Some(func_impl) = resolve_func(schema, table) {
+                        return Some(func_impl);
+                    }
+                }
+                None
+            }
+            TableReference::Partial { schema, table } => resolve_func(schema, table),
+            TableReference::Full {
+                catalog,
+                schema,
+                table,
+            } => {
+                if catalog == DEFAULT_CATALOG {
+                    resolve_func(schema, table)
+                } else {
+                    None
+                }
             }
         }
     }
@@ -134,7 +192,7 @@ impl<'a> AsyncContextProvider for PartialContextProvider<'a> {
     }
 
     fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>> {
-        unimplemented!()
+        self.table_function_for_reference(name)
     }
 
     fn options(&self) -> &ConfigOptions {

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -16,6 +16,7 @@ use datafusion::logical_expr::TableSource;
 use datafusion::sql::TableReference;
 use datafusion_planner::planner::AsyncContextProvider;
 use metastore::builtins::DEFAULT_CATALOG;
+use sqlbuiltins::functions::TableFunc;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -130,6 +131,10 @@ impl<'a> AsyncContextProvider for PartialContextProvider<'a> {
 
     async fn get_aggregate_meta(&mut self, _name: &str) -> Option<Arc<AggregateUDF>> {
         None
+    }
+
+    fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>> {
+        unimplemented!()
     }
 
     fn options(&self) -> &ConfigOptions {

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -27,7 +27,7 @@ use metastore::builtins::{
 };
 use metastore::session::SessionCatalog;
 use metastoreproto::types::catalog::{
-    CatalogEntry, DatabaseEntry, EntryMeta, EntryType, FunctionType, TableEntry, ViewEntry,
+    CatalogEntry, DatabaseEntry, EntryMeta, EntryType, TableEntry, ViewEntry,
 };
 use metastoreproto::types::options::{
     DatabaseOptions, DatabaseOptionsBigQuery, DatabaseOptionsDebug, DatabaseOptionsMongo,
@@ -36,7 +36,6 @@ use metastoreproto::types::options::{
     TableOptionsLocal, TableOptionsMongo, TableOptionsMysql, TableOptionsPostgres, TableOptionsS3,
     TableOptionsSnowflake, TunnelOptions,
 };
-use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::error;

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -1,6 +1,8 @@
 //! Adapter types for dispatching to table sources.
 use crate::context::SessionContext;
-use datafusion::arrow::array::{BooleanBuilder, StringBuilder, UInt32Builder, UInt64Builder};
+use datafusion::arrow::array::{
+    BooleanBuilder, ListBuilder, StringBuilder, UInt32Builder, UInt64Builder,
+};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::MemTable;
 use datafusion::datasource::TableProvider;
@@ -19,12 +21,13 @@ use datasources::object_store::s3::{S3Accessor, S3TableAccess};
 use datasources::postgres::{PostgresAccessor, PostgresTableAccess};
 use datasources::snowflake::{SnowflakeAccessor, SnowflakeDbConnection, SnowflakeTableAccess};
 use metastore::builtins::{
-    DEFAULT_CATALOG, GLARE_COLUMNS, GLARE_DATABASES, GLARE_SCHEMAS, GLARE_SESSION_QUERY_METRICS,
-    GLARE_SSH_KEYS, GLARE_TABLES, GLARE_TUNNELS, GLARE_VIEWS, VIRTUAL_CATALOG_SCHEMA,
+    DEFAULT_CATALOG, GLARE_COLUMNS, GLARE_DATABASES, GLARE_FUNCTIONS, GLARE_SCHEMAS,
+    GLARE_SESSION_QUERY_METRICS, GLARE_SSH_KEYS, GLARE_TABLES, GLARE_TUNNELS, GLARE_VIEWS,
+    VIRTUAL_CATALOG_SCHEMA,
 };
 use metastore::session::SessionCatalog;
 use metastoreproto::types::catalog::{
-    CatalogEntry, DatabaseEntry, EntryMeta, EntryType, TableEntry, ViewEntry,
+    CatalogEntry, DatabaseEntry, EntryMeta, EntryType, FunctionType, TableEntry, ViewEntry,
 };
 use metastoreproto::types::options::{
     DatabaseOptions, DatabaseOptionsBigQuery, DatabaseOptionsDebug, DatabaseOptionsMongo,
@@ -33,6 +36,7 @@ use metastoreproto::types::options::{
     TableOptionsLocal, TableOptionsMongo, TableOptionsMysql, TableOptionsPostgres, TableOptionsS3,
     TableOptionsSnowflake, TunnelOptions,
 };
+use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::error;
@@ -471,6 +475,8 @@ impl<'a> SystemTableDispatcher<'a> {
             Arc::new(self.build_glare_views())
         } else if GLARE_SCHEMAS.matches(schema, name) {
             Arc::new(self.build_glare_schemas())
+        } else if GLARE_FUNCTIONS.matches(schema, name) {
+            Arc::new(self.build_glare_functions())
         } else if GLARE_SESSION_QUERY_METRICS.matches(schema, name) {
             Arc::new(self.build_session_query_metrics())
         } else if GLARE_SSH_KEYS.matches(schema, name) {
@@ -769,6 +775,57 @@ impl<'a> SystemTableDispatcher<'a> {
                 Arc::new(view_name.finish()),
                 Arc::new(builtin.finish()),
                 Arc::new(sql.finish()),
+            ],
+        )
+        .unwrap();
+
+        MemTable::try_new(arrow_schema, vec![vec![batch]]).unwrap()
+    }
+
+    fn build_glare_functions(&self) -> MemTable {
+        let arrow_schema = Arc::new(GLARE_FUNCTIONS.arrow_schema());
+
+        let mut oid = UInt32Builder::new();
+        let mut schema_oid = UInt32Builder::new();
+        let mut function_name = StringBuilder::new();
+        let mut function_type = StringBuilder::new();
+        let mut parameters = ListBuilder::new(StringBuilder::new());
+        let mut parameter_types = ListBuilder::new(StringBuilder::new());
+        let mut builtin = BooleanBuilder::new();
+
+        for func in self
+            .catalog()
+            .iter_entries()
+            .filter(|ent| ent.entry_type() == EntryType::Function)
+        {
+            let ent = match func.entry {
+                CatalogEntry::Function(ent) => ent,
+                other => panic!("unexpected catalog entry: {:?}", other), // Bug
+            };
+
+            oid.append_value(func.oid);
+            schema_oid.append_value(ent.meta.parent);
+            function_name.append_value(&ent.meta.name);
+            function_type.append_value(ent.func_type.as_str());
+
+            // TODO: Actually get parameter info.
+            const EMPTY: [Option<&'static str>; 0] = [];
+            parameters.append_value(EMPTY);
+            parameter_types.append_value(EMPTY);
+
+            builtin.append_value(func.builtin);
+        }
+
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(oid.finish()),
+                Arc::new(schema_oid.finish()),
+                Arc::new(function_name.finish()),
+                Arc::new(function_type.finish()),
+                Arc::new(parameters.finish()),
+                Arc::new(parameter_types.finish()),
+                Arc::new(builtin.finish()),
             ],
         )
         .unwrap();

--- a/testdata/sqllogictests_bigquery/read.slt
+++ b/testdata/sqllogictests_bigquery/read.slt
@@ -1,0 +1,6 @@
+# Tests for the `read_*` function.
+
+query I
+SELECT count(*) FROM read_bigquery('${GCP_SERVICE_ACCOUNT_KEY}', '${GCP_PROJECT_ID}', '${BIGQUERY_DATASET_ID}', 'bikeshare_stations');
+----
+102

--- a/testdata/sqllogictests_mongodb/read.slt
+++ b/testdata/sqllogictests_mongodb/read.slt
@@ -1,0 +1,6 @@
+# Tests for the `read_*` function.
+
+query I
+SELECT count(*) FROM read_mongodb('${MONGO_CONN_STRING}', 'test', 'bikeshare_stations');
+----
+102

--- a/testdata/sqllogictests_mysql/read.slt
+++ b/testdata/sqllogictests_mysql/read.slt
@@ -1,0 +1,6 @@
+# Tests for the `read_*` function.
+
+query I
+SELECT count(*) FROM read_mongodb('${MYSQL_CONN_STRING}', 'glaredb_test', 'bikeshare_stations');
+----
+102

--- a/testdata/sqllogictests_mysql/read.slt
+++ b/testdata/sqllogictests_mysql/read.slt
@@ -1,6 +1,6 @@
 # Tests for the `read_*` function.
 
 query I
-SELECT count(*) FROM read_mongodb('${MYSQL_CONN_STRING}', 'glaredb_test', 'bikeshare_stations');
+SELECT count(*) FROM read_mysql('${MYSQL_CONN_STRING}', 'glaredb_test', 'bikeshare_stations');
 ----
 102

--- a/testdata/sqllogictests_postgres/read.slt
+++ b/testdata/sqllogictests_postgres/read.slt
@@ -1,4 +1,4 @@
-# Tests for the `read_postgres` function.
+# Tests for the `read_*` function.
 
 query I
 SELECT count(*) FROM read_postgres('${POSTGRES_CONN_STRING}', 'public', 'bikeshare_stations');

--- a/testdata/sqllogictests_postgres/read_postgres.slt
+++ b/testdata/sqllogictests_postgres/read_postgres.slt
@@ -1,0 +1,6 @@
+# Tests for the `read_postgres` function.
+
+query I
+SELECT count(*) FROM read_postgres('${POSTGRES_CONN_STRING}', 'public', 'bikeshare_stations');
+----
+102

--- a/testdata/sqllogictests_snowflake/read.slt
+++ b/testdata/sqllogictests_snowflake/read.slt
@@ -1,6 +1,6 @@
 # Tests for the `read_*` function.
 
 query I
-SELECT count(*) FROM read_snowflake('hmpfscx-xo23956', '${SNOWFLAKE_USERNAME}', '${SNOWFLAKE_PASSWORD}', '${SNOWFLAKE_DATABASE}', 'compute_wh', 'account_admin', 'public', 'bikeshare_stations');
+SELECT count(*) FROM read_snowflake('hmpfscx-xo23956', '${SNOWFLAKE_USERNAME}', '${SNOWFLAKE_PASSWORD}', '${SNOWFLAKE_DATABASE}', 'compute_wh', 'accountadmin', 'public', 'bikeshare_stations');
 ----
 102

--- a/testdata/sqllogictests_snowflake/read.slt
+++ b/testdata/sqllogictests_snowflake/read.slt
@@ -1,0 +1,6 @@
+# Tests for the `read_*` function.
+
+query I
+SELECT count(*) FROM read_snowflake('hmpfscx-xo23956', '${SNOWFLAKE_USERNAME}', '${SNOWFLAKE_PASSWORD}', '${SNOWFLAKE_DATABASE}', 'compute_wh', 'account_admin', 'public', 'bikeshare_stations');
+----
+102


### PR DESCRIPTION
Adds table returning functions that allow for reading from external data
sources. These are meant to be used as an alternative to `CREATE EXTERANL
TABLE/DATABASE ...`.

What this looks like:

``` sql
select * from read_postgres('postgres://postgres:postgres@localhost/postgres', 'public', 'users)
```

These functions can be used anywhere in a query where a table identifier would
be used.

The list of supported functions can be found by querying the
`glare_catalog.functions` table:

``` text
> select function_name, function_type from glare_catalog.functions;
+----------------+---------------+
| function_name  | function_type |
+----------------+---------------+
| read_mongodb   | table         |
| read_mysql     | table         |
| read_bigquery  | table         |
| read_snowflake | table         |
| read_postgres  | table         |
+----------------+---------------+
```

Notable omissions are the functions for reading files from object storage, but
those should be added in soon.

# Code changes

Adds `sqlbuiltins` crate which provided the list and implementations for these
table functions. I did not move everything over yet, but I plan to move the
content of `metastore/src/builtins.rs` into this crate. I pulled this into its
own crate since both `metastore` and `sqlexec` need to reference this stuff,
whether that's for building the catalog, or executing the function itself.

The primary type of interest in this PR is the `TableFunc` trait. It's pretty
simple in that it's able to accept scalar arguments and return a
`TableProvider`. During sql planning, we'll do a lookup for a function by its
name, and create the table provider using the (constant) args provided. The
resulting logical plan is as if the table function was just another table.

# Docs

To come...

A very brief rundown for function args:

```
read_postgres(connection_str, schema, table)
read_bigquery(gcp_service_account_key, project_id, dataset_id, table_id)
read_mongodb(connection_str, database, collection)
read_mysql(connection_str, schema, table)
read_snowflake(account, username, password, database, warehouse, role, schema, table)
```

It might also be interesting the explore auto-generating docs from the json
output of the `glare_catalog.functions`:

``` text
% ./glaredb local --mode json --query 'select * from glare_catalog.functions'
[{"oid":16507,"schema_oid":16386,"function_name":"read_snowflake","function_type":"table","parameters":[],"parameter_types":[],"builtin":true},
{"oid":16506,"schema_oid":16386,"function_name":"read_postgres","function_type":"table","parameters":[],"parameter_types":[],"builtin":true},
{"oid":16508,"schema_oid":16386,"function_name":"read_mysql","function_type":"table","parameters":[],"parameter_types":[],"builtin":true},
{"oid":16505,"schema_oid":16386,"function_name":"read_mongodb","function_type":"table","parameters":[],"parameter_types":[],"builtin":true},
{"oid":16509,"schema_oid":16386,"function_name":"read_bigquery","function_type":"table","parameters":[],"parameter_types":[],"builtin":true}]
```

(Note `parameters` and `parameter_types` not currently writting to this table)
