### PR TITLE
chore: Remove setting version to "pre-release"

### DIFF
--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -17,7 +17,7 @@ use tracing::info;
 
 #[derive(Parser)]
 #[clap(name = "GlareDB")]
-#[clap(version = "pre-release")]
+#[clap(version)]
 #[clap(about = "CLI for GlareDB", long_about = None)]
 struct Cli {
     /// Log verbosity.


### PR DESCRIPTION
Now `--version` will just return the version specified in the root Cargo.toml.