### PR TITLE
feat: Support temporary tables

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
 [alias]
 dev = "run --bin glaredb --"
-xtask = "run --quiet --package xtask --"
+xtask = "run --package xtask --"
+x = "run --quiet --package xtask --"

--- a/crates/datafusion_planner/src/expr/subquery.rs
+++ b/crates/datafusion_planner/src/expr/subquery.rs
@@ -36,7 +36,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
         let old_outer_query_schema =
             planner_context.set_outer_query_schema(Some(input_schema.clone()));
         let sub_plan = self
-            .query_to_plan_with_schema(subquery, planner_context)
+            .query_to_plan_with_context(subquery, planner_context)
             .await?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
@@ -60,7 +60,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
         let old_outer_query_schema =
             planner_context.set_outer_query_schema(Some(input_schema.clone()));
         let sub_plan = self
-            .query_to_plan_with_schema(subquery, planner_context)
+            .query_to_plan_with_context(subquery, planner_context)
             .await?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
@@ -87,7 +87,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
         let old_outer_query_schema =
             planner_context.set_outer_query_schema(Some(input_schema.clone()));
         let sub_plan = self
-            .query_to_plan_with_schema(subquery, planner_context)
+            .query_to_plan_with_context(subquery, planner_context)
             .await?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);

--- a/crates/datafusion_planner/src/query.rs
+++ b/crates/datafusion_planner/src/query.rs
@@ -30,8 +30,16 @@ use datafusion::sql::sqlparser::parser::ParserError::ParserError;
 impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
     /// Generate a logical plan from an SQL query
     pub async fn query_to_plan(&mut self, query: Query) -> Result<LogicalPlan> {
-        self.query_to_plan_with_schema(query, &mut PlannerContext::new())
+        self.query_to_plan_with_context(query, &mut PlannerContext::new())
             .await
+    }
+
+    pub async fn query_to_plan_with_context(
+        &mut self,
+        query: Query,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        self.query_to_plan_with_schema(query, planner_context).await
     }
 
     /// Generate a logic plan from an SQL query.
@@ -64,7 +72,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                 // create logical plan & pass backreferencing CTEs
                 // CTE expr don't need extend outer_query_schema
                 let logical_plan = self
-                    .query_to_plan_with_schema(*cte.query, &mut planner_context.clone())
+                    .query_to_plan_with_context(*cte.query, &mut planner_context.clone())
                     .await?;
 
                 // Each `WITH` block can change the column names in the last

--- a/crates/datafusion_planner/src/relation/mod.rs
+++ b/crates/datafusion_planner/src/relation/mod.rs
@@ -98,7 +98,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                 subquery, alias, ..
             } => {
                 let logical_plan = self
-                    .query_to_plan_with_schema(*subquery, planner_context)
+                    .query_to_plan_with_context(*subquery, planner_context)
                     .await?;
                 (logical_plan, alias)
             }

--- a/crates/datafusion_planner/src/set_expr.rs
+++ b/crates/datafusion_planner/src/set_expr.rs
@@ -66,7 +66,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                     }
                 }
             }
-            SetExpr::Query(q) => self.query_to_plan_with_schema(*q, planner_context).await,
+            SetExpr::Query(q) => self.query_to_plan_with_context(*q, planner_context).await,
             _ => Err(DataFusionError::NotImplemented(format!(
                 "Query {set_expr} not implemented yet"
             ))),

--- a/crates/datafusion_planner/src/statement.rs
+++ b/crates/datafusion_planner/src/statement.rs
@@ -1,9 +1,14 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use datafusion::{
-    common::{DataFusionError, Result, ToDFSchema},
-    logical_expr::{Analyze, Explain, LogicalPlan, PlanType, ToStringifiedPlan},
-    sql::sqlparser::ast::Statement,
+    common::{DFField, DFSchema, DataFusionError, OwnedTableReference, Result, ToDFSchema},
+    logical_expr::{
+        builder::project, Analyze, Explain, ExprSchemable, LogicalPlan, PlanType, ToStringifiedPlan,
+    },
+    sql::{
+        planner::PlannerContext,
+        sqlparser::ast::{self, Query, SetExpr, Statement},
+    },
 };
 
 use crate::planner::{AsyncContextProvider, SqlQueryPlanner};
@@ -45,5 +50,83 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                 logical_optimization_succeeded: false,
             }))
         }
+    }
+
+    pub async fn insert_to_source_plan(
+        &mut self,
+        table_name: &OwnedTableReference,
+        columns: &Vec<String>,
+        source: Box<Query>,
+    ) -> Result<LogicalPlan> {
+        // Do a table lookup to verify the table exists
+        let provider = self
+            .schema_provider
+            .get_table_provider(table_name.clone())
+            .await?;
+        let arrow_schema = (*provider.schema()).clone();
+        let table_schema = DFSchema::try_from(arrow_schema)?;
+
+        let fields = if columns.is_empty() {
+            // Empty means we're inserting into all columns of the table
+            table_schema.fields().clone()
+        } else {
+            let fields = columns
+                .iter()
+                .map(|c| Ok(table_schema.field_with_unqualified_name(c)?.clone()))
+                .collect::<Result<Vec<DFField>>>()?;
+            // Validate no duplicate fields
+            let table_schema =
+                DFSchema::new_with_metadata(fields, table_schema.metadata().clone())?;
+            table_schema.fields().clone()
+        };
+
+        // infer types for Values clause... other types should be resolvable the regular way
+        let mut prepare_param_data_types = BTreeMap::new();
+        if let SetExpr::Values(ast::Values { rows, .. }) = (*source.body).clone() {
+            for row in rows.iter() {
+                for (idx, val) in row.iter().enumerate() {
+                    if let ast::Expr::Value(ast::Value::Placeholder(name)) = val {
+                        let name = name.replace('$', "").parse::<usize>().map_err(|_| {
+                            DataFusionError::Plan(format!("Can't parse placeholder: {name}"))
+                        })? - 1;
+                        let field = fields.get(idx).ok_or_else(|| {
+                            DataFusionError::Plan(format!(
+                                "Placeholder ${} refers to a non existent column",
+                                idx + 1
+                            ))
+                        })?;
+                        let dt = field.field().data_type().clone();
+                        let _ = prepare_param_data_types.insert(name, dt);
+                    }
+                }
+            }
+        }
+        let prepare_param_data_types = prepare_param_data_types.into_values().collect();
+
+        // Projection
+        let mut planner_context =
+            PlannerContext::new().with_prepare_param_data_types(prepare_param_data_types);
+        let source = self
+            .query_to_plan_with_context(*source, &mut planner_context)
+            .await?;
+        if fields.len() != source.schema().fields().len() {
+            Err(DataFusionError::Plan(
+                "Column count doesn't match insert query!".to_owned(),
+            ))?;
+        }
+        let exprs = fields
+            .iter()
+            .zip(source.schema().fields().iter())
+            .map(|(target_field, source_field)| {
+                let expr =
+                    datafusion::logical_expr::Expr::Column(source_field.unqualified_column())
+                        .cast_to(target_field.data_type(), source.schema())?
+                        .alias(target_field.name());
+                Ok(expr)
+            })
+            .collect::<Result<Vec<datafusion::logical_expr::Expr>>>()?;
+
+        let source = project(source, exprs)?;
+        Ok(source)
     }
 }

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -265,12 +265,17 @@ static TABLE_FORMAT_OPTS: Lazy<FormatOptions> = Lazy::new(|| {
         .with_null("NULL")
 });
 
-async fn print_stream(stream: SendableRecordBatchStream, mode: OutputMode) -> Result<()> {
+async fn process_stream(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
     let batches = stream
         .collect::<Vec<_>>()
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;
+    Ok(batches)
+}
+
+async fn print_stream(stream: SendableRecordBatchStream, mode: OutputMode) -> Result<()> {
+    let batches = process_stream(stream).await?;
 
     fn write_json<F: JsonFormat>(batches: &[RecordBatch]) -> Result<()> {
         let stdout = std::io::stdout();

--- a/crates/metastore/src/builtins.rs
+++ b/crates/metastore/src/builtins.rs
@@ -31,6 +31,9 @@ pub const INTERNAL_SCHEMA: &str = "glare_catalog";
 pub const INFORMATION_SCHEMA: &str = "information_schema";
 pub const POSTGRES_SCHEMA: &str = "pg_catalog";
 
+/// Schema to store temporary objects (only valid for current session).
+pub const CURRENT_SESSION_SCHEMA: &str = "current_session";
+
 /// A schema that only exists in external databases.
 ///
 /// This is used to dispatch to a "view" that internally fetches schema and
@@ -252,6 +255,11 @@ pub static SCHEMA_POSTGRES: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
     oid: 16388,
 });
 
+pub static SCHEMA_CURRENT_SESSION: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
+    name: CURRENT_SESSION_SCHEMA,
+    oid: 16389,
+});
+
 impl BuiltinSchema {
     pub fn builtins() -> Vec<&'static BuiltinSchema> {
         vec![
@@ -259,6 +267,7 @@ impl BuiltinSchema {
             &SCHEMA_DEFAULT,
             &SCHEMA_INFORMATION,
             &SCHEMA_POSTGRES,
+            &SCHEMA_CURRENT_SESSION,
         ]
     }
 }

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -74,6 +74,12 @@ pub enum ExecError {
         conn_id: uuid::Uuid,
     },
 
+    #[error("Duplicate object name: '{0}' already exists")]
+    DuplicateObjectName(String),
+
+    #[error("Missing {typ}: '{name}' not found")]
+    MissingObject { typ: &'static str, name: String },
+
     #[error(transparent)]
     Metastore(#[from] metastore::errors::MetastoreError),
 

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -144,6 +144,10 @@ impl<'a> PartialContextProvider<'a> {
             }
         }
     }
+    /// Get the table provider if available in the cache.
+    pub fn table_provider(&self, name: TableReference<'_>) -> Option<Arc<dyn TableProvider>> {
+        self.providers.get(&name).cloned()
+    }
 }
 
 #[async_trait]

--- a/testdata/sqllogictests/aggregates.slt
+++ b/testdata/sqllogictests/aggregates.slt
@@ -5,10 +5,8 @@
 # Built-in aggregates should match the behavior of Postgres.
 # See: https://www.postgresql.org/docs/8.2/functions-aggregate.html
 
-halt
-
 statement ok
-create table t_aggs (a smallint, b real, c text);
+create temp table t_aggs (a smallint, b real, c text);
 
 statement ok
 insert into t_aggs values (1, 1.0, '1'), (2, 2.0, '2'), (3, 3.0, '3'), (4, 4.0, '4');

--- a/testdata/sqllogictests/cast/double_float_cast.slt
+++ b/testdata/sqllogictests/cast/double_float_cast.slt
@@ -6,25 +6,22 @@ create schema double_float_cast;
 statement ok
 set search_path = double_float_cast;
 
-# TODO: Casting, correctly parsing '::'
-halt
-
 query I
 select '1e308'::float;
 ----
-inf
+Infinity
 
 query I
 select '1e310'::double;
 ----
-inf
+Infinity
 
 query I
 select '-1e308'::float;
 ----
--inf
+-Infinity
 
 query I
 select '-1e310'::double;
 ----
--inf
+-Infinity

--- a/testdata/sqllogictests/cast/timestamp_data_cast.slt
+++ b/testdata/sqllogictests/cast/timestamp_data_cast.slt
@@ -1,8 +1,5 @@
 # Timestamp date cast.
 
-# Unsupported in new catalog (for now).
-halt
-
 statement ok
 create schema timestamp_date_cast;
 
@@ -10,22 +7,17 @@ statement ok
 set search_path = timestamp_date_cast;
 
 statement ok
-create table test as
-select '2021-02-04 19:30:00'::timestamp t;
-
-# TODO: Missing these casts.
-halt
+create view test as
+	select '2021-02-04 19:30:00'::timestamp t;
 
 query I
-select *
-from test
-where (t::date) = '2021-02-04'::date;
+select * from test
+	where (t::date) = '2021-02-04'::date;
 ----
 2021-02-04 19:30:00
 
 query I
-select *
-from test
-where (t::date) = '2021-02-04';
+select * from test
+	where (t::date) = '2021-02-04';
 ----
 2021-02-04 19:30:00

--- a/testdata/sqllogictests/joins/full_outer/full_outer_join.slt
+++ b/testdata/sqllogictests/joins/full_outer/full_outer_join.slt
@@ -6,16 +6,14 @@ create schema full_outer_join;
 statement ok
 set search_path = full_outer_join;
 
-halt
-
 statement ok
-CREATE TABLE integers(i INTEGER, j INTEGER)
+CREATE TEMP TABLE integers(i INTEGER, j INTEGER)
 
 statement ok
 INSERT INTO integers VALUES (1, 1), (3, 3)
 
 statement ok
-CREATE TABLE integers2(k INTEGER, l INTEGER)
+CREATE TEMP TABLE integers2(k INTEGER, l INTEGER)
 
 statement ok
 INSERT INTO integers2 VALUES (1, 10), (2, 20)
@@ -28,15 +26,13 @@ SELECT i, j, k, l FROM integers FULL OUTER JOIN integers2 ON integers.i=integers
 3	3	NULL	NULL
 NULL	NULL	2	20
 
-# TODO: Missing last row (bug in datafusion?)
-# # equality join with additional non-equality predicate
-# query IIII
-# SELECT i, j, k, l FROM integers FULL OUTER JOIN integers2 ON integers.i=integers2.k AND integers.j > integers2.l ORDER BY 1, 2, 3, 4
-# ----
-# 1	1	NULL	NULL
-# 3	3	NULL	NULL
-# NULL	NULL	1	10
-# NULL	NULL	2	20
+query IIII
+SELECT i, j, k, l FROM integers FULL OUTER JOIN integers2 ON integers.i=integers2.k AND integers.j > integers2.l ORDER BY 1, 2, 3, 4
+----
+1	1	NULL	NULL
+3	3	NULL	NULL
+NULL	NULL	1	10
+NULL	NULL	2	20
 
 # equality join with varchar values
 query IIIT

--- a/testdata/sqllogictests/joins/full_outer/full_outer_join_complex.slt
+++ b/testdata/sqllogictests/joins/full_outer/full_outer_join_complex.slt
@@ -6,16 +6,14 @@ create schema full_outer_join_complex;
 statement ok
 set search_path = full_outer_join_complex;
 
-halt
-
 statement ok
-CREATE TABLE integers(i INTEGER, j INTEGER)
+CREATE TEMP TABLE integers(i INTEGER, j INTEGER)
 
 statement ok
 INSERT INTO integers VALUES (1, 1)
 
 statement ok
-CREATE TABLE integers2(k INTEGER, l INTEGER)
+CREATE TEMP TABLE integers2(k INTEGER, l INTEGER)
 
 statement ok
 INSERT INTO integers2 VALUES (1, 10)

--- a/testdata/sqllogictests/joins/inner_join/inner_join.slt
+++ b/testdata/sqllogictests/joins/inner_join/inner_join.slt
@@ -6,16 +6,14 @@ create schema inner_join;
 statement ok
 set search_path = inner_join;
 
-halt
-
 statement ok
-CREATE TABLE test (a INTEGER, b INTEGER);
+CREATE TEMP TABLE test (a INTEGER, b INTEGER);
 
 statement ok
 INSERT INTO test VALUES (11, 1), (12, 2), (13, 3)
 
 statement ok
-CREATE TABLE test2 (b INTEGER, c INTEGER);
+CREATE TEMP TABLE test2 (b INTEGER, c INTEGER);
 
 statement ok
 INSERT INTO test2 VALUES (1, 10), (1, 20), (2, 30)
@@ -28,10 +26,8 @@ SELECT a, test.b, c FROM test, test2 WHERE test.b = test2.b ORDER BY c;
 11	1	20
 12	2	30
 
-# TODO: This succeeds.
-# # ambiguous reference to column
-# statement error
-# SELECT b FROM test, test2 WHERE test.b > test2.b;
+statement error
+SELECT b FROM test, test2 WHERE test.b > test2.b;
 
 # simple cross product + multiple join conditions
 query III

--- a/testdata/sqllogictests/joins/inner_join/using_join.slt
+++ b/testdata/sqllogictests/joins/inner_join/using_join.slt
@@ -6,17 +6,15 @@ create schema using_join;
 statement ok
 set search_path = using_join;
 
-halt
-
 # create tables
 statement ok
-CREATE TABLE t1 (a INTEGER, b INTEGER, c INTEGER)
+CREATE TEMP TABLE t1 (a INTEGER, b INTEGER, c INTEGER)
 
 statement ok
 INSERT INTO t1 VALUES (1,2,3)
 
 statement ok
-CREATE TABLE t2 (a INTEGER, b INTEGER, c INTEGER)
+CREATE TEMP TABLE t2 (a INTEGER, b INTEGER, c INTEGER)
 
 statement ok
 INSERT INTO t2 VALUES (1,2,3), (2,2,4), (1,3,4)
@@ -52,13 +50,11 @@ SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING(a,b,c)
 ----
 1	2	3
 
-# TODO: Field not found
-# # USING columns can be used without requiring a table specifier
-# query I
-# SELECT a+1 FROM t1 JOIN t2 USING(a) ORDER BY a
-# ----
-# 2
-# 2
+query I
+SELECT a+1 FROM t1 JOIN t2 USING(a) ORDER BY a
+----
+2
+2
 
 statement error
 SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING(a+b)
@@ -72,22 +68,16 @@ SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING(d)
 statement error
 SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING(t1.a)
 
-# TODO: We only get '1 2 3' back.
-# query IIII
-# SELECT * FROM t1 JOIN t2 USING(a,b)
-# ----
-# 1	2	3	3
+query IIII
+SELECT * FROM t1 JOIN t2 USING(a,b)
+----
+1	2	3	3
 
-# TODO: Succeeds for us.
-# # CONTROVERSIAL:
-# # we do not allow this because it is ambiguous: "b" can be bind to both "t1.b" or "t2.b" and this would give
-# # different results SQLite allows this, PostgreSQL does not
-# statement error
-# SELECT * FROM t1 JOIN t2 USING(a) JOIN t2 t2b USING (b);
+statement error
+SELECT * FROM t1 JOIN t2 USING(a) JOIN t2 t2b USING (b);
 
-# # this is the same, but now with a duplicate potential binding on the RHS
-# statement error
-# select * from (values (1)) tbl(i) join ((values (1)) tbl2(i) join  (values (1)) tbl3(i) on tbl2.i=tbl3.i) using (i)
+statement error
+select * from (values (1)) tbl(i) join ((values (1)) tbl2(i) join  (values (1)) tbl3(i) on tbl2.i=tbl3.i) using (i)
 
 # a chain with the same column name is allowed though!
 query IIIIIII

--- a/testdata/sqllogictests/joins/join_on_aggregates.slt
+++ b/testdata/sqllogictests/joins/join_on_aggregates.slt
@@ -6,29 +6,30 @@ create schema join_on_aggregates;
 statement ok
 set search_path = join_on_aggregates;
 
-halt
-
 statement ok
-CREATE TABLE integers(i INTEGER)
+CREATE TEMP TABLE integers(i INTEGER)
 
 statement ok
 INSERT INTO integers VALUES (1), (2), (3), (NULL)
 
 # test join on ungrouped aggregates
-query RR
-SELECT * FROM (SELECT SUM(i) AS x FROM integers) a, (SELECT SUM(i) AS x FROM integers) b WHERE a.x=b.x;
-----
-6.000000	6.000000
+#
+# TODO: Functions like `SUM`, `MIN`, `MAX` return float and not decimals.
+# query RR
+# SELECT * FROM (SELECT SUM(i) AS x FROM integers) a, (SELECT SUM(i) AS x FROM integers) b WHERE a.x=b.x;
+# ----
+# 6.000000	6.000000
 
 # Test join on aggregates with GROUP BY
 statement ok
-CREATE TABLE groups(i INTEGER, j INTEGER)
+CREATE TEMP TABLE groups(i INTEGER, j INTEGER)
 
 statement ok
 INSERT INTO groups VALUES (1, 1), (2, 1), (3, 2), (NULL, 2)
 
-query IRII
-SELECT a.j,a.x,a.y,b.y FROM (SELECT j, MIN(i) AS y, SUM(i) AS x FROM groups GROUP BY j) a, (SELECT j, MIN(i) AS y, SUM(i) AS x FROM groups GROUP BY j) b WHERE a.j=b.j AND a.x=b.x ORDER BY a.j;
-----
-1	3.000000	1	1
-2	3.000000	3	3
+# TODO: Functions like `SUM`, `MIN`, `MAX` return float and not decimals.
+# query IRII
+# SELECT a.j,a.x,a.y,b.y FROM (SELECT j, MIN(i) AS y, SUM(i) AS x FROM groups GROUP BY j) a, (SELECT j, MIN(i) AS y, SUM(i) AS x FROM groups GROUP BY j) b WHERE a.j=b.j AND a.x=b.x ORDER BY a.j;
+# ----
+# 1	3.000000	1	1
+# 2	3.000000	3	3

--- a/testdata/sqllogictests/simple.slt
+++ b/testdata/sqllogictests/simple.slt
@@ -16,14 +16,12 @@ select * from (values (1, 2, 3), (3, 4, 5))
 1 2 3
 3 4 5
 
-halt
-
 statement ok
-create table t1 (a smallint, b smallint)
+create temp table t1 (a smallint, b smallint)
 
 # Table already exists.
 statement error
-create table t1 (a smallint, b smallint)
+create temp table t1 (a smallint, b smallint)
 
 statement ok
 insert into t1 values (1, 2), (3, 4), (5, 6)
@@ -92,7 +90,7 @@ select * from t1 where a >= 3;
 5 6
 
 statement ok
-create table t2 (b smallint, c smallint);
+create temp table t2 (b smallint, c smallint);
 
 statement ok
 insert into t2 values (7, 8), (9, 10), (11, 12);

--- a/testdata/sqllogictests/temp_table.slt
+++ b/testdata/sqllogictests/temp_table.slt
@@ -1,0 +1,65 @@
+# Temporary tables
+
+statement ok
+create temp table abc (a int, b int, c int);
+
+query III
+select * from abc;
+----
+
+query T
+select schema_name from glare_catalog.tables
+	where table_name = 'abc';
+----
+current_session
+
+# Another table with the same name as temp table but in another schema should
+# be ok.
+statement ok
+create external table abc from debug options ( table_type = 'never_ending' );
+
+query T rowsort
+select schema_name from glare_catalog.tables
+	where table_name = 'abc';
+----
+current_session
+public
+
+# Another temp table with same name not allowed.
+statement error
+create temp table abc (x int);
+
+# Insert into table
+statement ok
+insert into abc values (9, 8, 7);
+
+query III rowsort
+select a, b, c from current_session.abc limit 1;
+----
+9	8	7
+
+query III rowsort
+select a, b, c from abc limit 1;
+----
+9	8	7
+
+# Query external table by specifying schema.
+query III
+select a, b, c from public.abc limit 1;
+----
+1	2	3
+
+# TODO: Inserting from external table also causes the same error as non-matching
+# schemas when doing `INSERT INTO abc(a, b) ...`.
+halt
+
+# Insert from another table
+statement ok
+insert into abc select a, b, c from public.abc limit 2;
+
+query III
+select a, b, c from abc;
+----
+9	8	7
+1	2	3
+1	2	3

--- a/testdata/sqllogictests/topn/topn_basic.slt
+++ b/testdata/sqllogictests/topn/topn_basic.slt
@@ -6,10 +6,8 @@ create schema topn_basic;
 statement ok
 set search_path = topn_basic;
 
-halt
-
 statement ok
-CREATE TABLE test (b INTEGER);
+CREATE TEMP TABLE test (b INTEGER);
 
 statement ok
 INSERT INTO test VALUES (22), (2), (7);

--- a/testdata/sqllogictests/topn/topn_nulls_first.slt
+++ b/testdata/sqllogictests/topn/topn_nulls_first.slt
@@ -6,11 +6,8 @@ create schema topn_nulls_first;
 statement ok
 set search_path = topn_nulls_first;
 
-# TODO: Table created with non-nullable field.
-halt
-
 statement ok
-CREATE TABLE integers(i INTEGER)
+CREATE TEMP TABLE integers(i INTEGER)
 
 statement ok
 INSERT INTO integers VALUES (1), (NULL)

--- a/testdata/sqllogictests/window/basic_window.slt
+++ b/testdata/sqllogictests/window/basic_window.slt
@@ -1,8 +1,5 @@
 # Most basic window function
 
-# Missing date support with new catalog.
-halt
-
 statement ok
 create schema basic_window;
 
@@ -10,9 +7,7 @@ statement ok
 set search_path = basic_window;
 
 statement ok
-CREATE TABLE empsalary (depname varchar, empno bigint, salary int, enroll_date date)
-
-halt
+CREATE TEMP TABLE empsalary (depname varchar, empno bigint, salary int, enroll_date date)
 
 statement ok
 INSERT INTO empsalary VALUES ('develop', 10, 5200, '2007-08-01'), ('sales', 1, 5000, '2006-10-01'), ('personnel', 5, 3500, '2007-12-10'), ('sales', 4, 4800, '2007-08-08'), ('personnel', 2, 3900, '2006-12-23'), ('develop', 7, 4200, '2008-01-01'), ('develop', 9, 4500, '2008-01-01'), ('sales', 3, 4800, '2007-08-01'), ('develop', 8, 6000, '2006-10-01'), ('develop', 11, 5200, '2007-08-15')
@@ -47,20 +42,19 @@ SELECT sum(salary) OVER (PARTITION BY depname ORDER BY salary) ss FROM empsalary
 9600
 14600
 
-# TODO: row_number
-# query I
-# SELECT row_number() OVER (PARTITION BY depname ORDER BY salary) rn FROM empsalary ORDER BY depname, rn
-# ----
-# 1
-# 2
-# 3
-# 4
-# 5
-# 1
-# 2
-# 1
-# 2
-# 3
+query I
+SELECT row_number() OVER (PARTITION BY depname ORDER BY salary) rn FROM empsalary ORDER BY depname, rn
+----
+1
+2
+3
+4
+5
+1
+2
+1
+2
+3
 
 # first_value
 query II
@@ -77,27 +71,25 @@ SELECT empno, first_value(empno) OVER (PARTITION BY depname ORDER BY empno) fv F
 3	1
 4	1
 
-# TODO: Incorrect results
-# # last_value
-# query III
-# SELECT depname, empno,
-# 	last_value(empno) OVER (
-# 		PARTITION BY depname ORDER BY empno ASC
-# 		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
-# 		) fv
-# FROM empsalary
-# ORDER BY 1, 2
-# ----
-# develop	7	11
-# develop	8	11
-# develop	9	11
-# develop	10	11
-# develop	11	11
-# personnel	2	5
-# personnel	5	5
-# sales	1	4
-# sales	3	4
-# sales	4	4
+query III
+SELECT depname, empno,
+	last_value(empno) OVER (
+		PARTITION BY depname ORDER BY empno ASC
+		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+		) fv
+FROM empsalary
+ORDER BY 1, 2
+----
+develop	7	11
+develop	8	11
+develop	9	11
+develop	10	11
+develop	11	11
+personnel	2	5
+personnel	5	5
+sales	1	4
+sales	3	4
+sales	4	4
 
 # rank_dense
 query TII

--- a/testdata/sqllogictests/window/evil_window.slt
+++ b/testdata/sqllogictests/window/evil_window.slt
@@ -20,7 +20,7 @@ where negative <> positive
 ----
 
 statement ok
-CREATE TABLE empsalary (depname varchar, empno bigint, salary int, enroll_date date)
+CREATE TEMP TABLE empsalary (depname varchar, empno bigint, salary int, enroll_date date)
 
 statement ok
 INSERT INTO empsalary VALUES ('develop', 10, 5200, '2007-08-01'), ('sales', 1, 5000, '2006-10-01'), ('personnel', 5, 3500, '2007-12-10'), ('sales', 4, 4800, '2007-08-08'), ('personnel', 2, 3900, '2006-12-23'), ('develop', 7, 4200, '2008-01-01'), ('develop', 9, 4500, '2008-01-01'), ('sales', 3, 4800, '2007-08-01'), ('develop', 8, 6000, '2006-10-01'), ('develop', 11, 5200, '2007-08-15')

--- a/testdata/sqllogictests/window/over_grouping.slt
+++ b/testdata/sqllogictests/window/over_grouping.slt
@@ -6,10 +6,8 @@ create schema over_grouping;
 statement ok
 set search_path = over_grouping;
 
-halt
-
 statement ok
-create table image  (
+create temp table image  (
     id          smallint primary key,
     width       int not null,
     height      integer not null

--- a/testdata/sqllogictests/window/scalar_window.slt
+++ b/testdata/sqllogictests/window/scalar_window.slt
@@ -6,7 +6,7 @@ create schema scalar_window;
 statement ok
 set search_path = scalar_window;
 
-# TODO: Missing function (row_number)
+# TODO: "OVER ()" has null schema (empty fields).
 halt
 
 query I


### PR DESCRIPTION
A couple of things to note here, I haven't used the `CatalogProvider` or `SchemaProvider`, instead just resolved the table myself. This is technically what is happening internally but there's more projection stuff that I am missing out on which makes the following query fail:

```
glaredb=> insert into abc (a, c) values (2, 4.678);
ERROR:  Error during planning: Inserting query must have the same schema with the table.
```

If we insert into all columns, this works:

```
glaredb=> insert into abc (a, b, c) values (2, 'abc', 4.678);
INSERT
```

Also need to refine `glare_catalog.tables` result (add oid there).