### PR TITLE
feat(cli): add highlighting & multiline sql support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -664,7 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
  "cc",
  "cfg-if",
  "constant_time_eq 0.2.5",
@@ -1006,17 +1012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "clipboard-win"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
-dependencies = [
- "error-code",
- "str-buf",
- "winapi",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1212,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1733,31 +1754,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -1864,12 +1864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,16 +1930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "error-code"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
 ]
 
 [[package]]
@@ -2285,11 +2269,12 @@ dependencies = [
  "logutil",
  "metastore",
  "metastoreproto",
+ "nu-ansi-term 0.47.0",
  "object_store",
  "once_cell",
  "pgrepr",
  "pgsrv",
- "rustyline",
+ "reedline",
  "sqlexec",
  "telemetry",
  "tokio",
@@ -3237,27 +3222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "static_assertions",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3239,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
+dependencies = [
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4136,16 +4109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4224,26 @@ dependencies = [
  "getrandom 0.2.8",
  "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "reedline"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d763be5efcabcd27d6e804d126661215aa0a2d898c13c0aa1c953c6652fcec"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools",
+ "nu-ansi-term 0.47.0",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4470,7 +4453,7 @@ version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "borsh",
  "bytecheck",
  "byteorder",
@@ -4628,29 +4611,6 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "rustyline"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "clipboard-win",
- "dirs-next",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
 ]
 
 [[package]]
@@ -4953,6 +4913,27 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5263,12 +5244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,6 +5251,15 @@ checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -5852,7 +5836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "serde",
@@ -6074,6 +6058,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -23,7 +23,8 @@ clap = { version = "4.3.1", features = ["derive"] }
 tracing = "0.1"
 uuid = { version = "1.3.3", features = ["v4", "fast-rng", "macro-diagnostics"] }
 tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
-rustyline = "11.0.0"
 once_cell = "1.17.2"
 futures = "0.3.28"
 colored = "2.0.0"
+reedline = "0.19.1"
+nu-ansi-term = "0.47.0"

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -1,0 +1,115 @@
+use std::io::{self};
+
+use nu_ansi_term::{Color, Style};
+
+use reedline::{Highlighter, StyledText};
+use sqlexec::export::sqlparser::dialect::GenericDialect;
+use sqlexec::export::sqlparser::keywords::Keyword;
+use sqlexec::export::sqlparser::tokenizer::{Token, Tokenizer};
+
+pub(crate) struct SQLHighlighter {}
+
+fn colorize_sql(query: &str, st: &mut StyledText) -> std::io::Result<()> {
+    let dialect = GenericDialect;
+
+    let mut tokenizer = Tokenizer::new(&dialect, query);
+
+    let tokens = tokenizer.tokenize().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Failed to tokenize SQL: {}", e),
+        )
+    });
+
+    // the tokenizer will error if the final character is an unescaped quote
+    // such as `select * from read_csv("
+    // in this case we will try to find the quote and colorize the rest of the query
+    // otherwise we will return the error
+    if let Err(err) = tokens {
+        let pos = query.find(&['\'', '"'][..]);
+        match pos {
+            None => return Err(err),
+            Some(pos) => {
+                let (s1, s2) = query.split_at(pos);
+                colorize_sql(s1, st)?;
+
+                st.push((Style::new(), s2.to_string()));
+                return Ok(());
+            }
+        }
+    }
+    let tokens = tokens.unwrap();
+
+    for token in tokens {
+        match token {
+            Token::Mul => st.push((Style::new().fg(Color::Purple), "*".to_string())),
+            Token::LParen => st.push((Style::new().fg(Color::Purple), "(".to_string())),
+            Token::RParen => st.push((Style::new().fg(Color::Purple), ")".to_string())),
+            Token::Comma => st.push((Style::new().fg(Color::Purple), ",".to_string())),
+            Token::SemiColon => st.push((Style::new().fg(Color::White).bold(), ";".to_string())),
+            Token::SingleQuotedString(s) => {
+                st.push((Style::new().fg(Color::Yellow).italic(), format!("'{}'", s)))
+            }
+            Token::DoubleQuotedString(s) => st.push((
+                Style::new().fg(Color::Yellow).italic(),
+                format!("\"{}\"", s),
+            )),
+            Token::Word(w) => match w.keyword {
+                Keyword::SELECT
+                | Keyword::FROM
+                | Keyword::WHERE
+                | Keyword::GROUP
+                | Keyword::BY
+                | Keyword::ORDER
+                | Keyword::LIMIT
+                | Keyword::OFFSET
+                | Keyword::AND
+                | Keyword::OR
+                | Keyword::AS
+                | Keyword::ON
+                | Keyword::INNER
+                | Keyword::LEFT
+                | Keyword::RIGHT
+                | Keyword::FULL
+                | Keyword::OUTER
+                | Keyword::JOIN
+                | Keyword::CREATE
+                | Keyword::EXTERNAL
+                | Keyword::TABLE
+                | Keyword::SHOW
+                | Keyword::TABLES
+                | Keyword::VARCHAR
+                | Keyword::INT
+                | Keyword::FLOAT
+                | Keyword::DOUBLE
+                | Keyword::BOOLEAN
+                | Keyword::DATE
+                | Keyword::TIME
+                | Keyword::DATETIME
+                | Keyword::ARRAY
+                | Keyword::ASC
+                | Keyword::DESC
+                | Keyword::NULL
+                | Keyword::NOT
+                | Keyword::IN
+                | Keyword::WITH => {
+                    st.push((Style::new().fg(Color::LightGreen), format!("{w}")));
+                }
+                // TODO: add more keywords
+                _ => st.push((Style::new(), format!("{w}"))),
+            },
+            other => {
+                st.push((Style::new(), format!("{other}")));
+            }
+        }
+    }
+    Ok(())
+}
+
+impl Highlighter for SQLHighlighter {
+    fn highlight(&self, line: &str, _cursor: usize) -> reedline::StyledText {
+        let mut styled_text = StyledText::new();
+        colorize_sql(line, &mut styled_text).unwrap();
+        styled_text
+    }
+}

--- a/crates/glaredb/src/lib.rs
+++ b/crates/glaredb/src/lib.rs
@@ -3,4 +3,6 @@ pub mod metastore;
 pub mod proxy;
 pub mod server;
 
+mod highlighter;
+mod prompt;
 mod util;

--- a/crates/glaredb/src/prompt.rs
+++ b/crates/glaredb/src/prompt.rs
@@ -1,0 +1,40 @@
+use std::borrow::Cow;
+
+use reedline::{Prompt, PromptHistorySearchStatus};
+
+pub(super) struct SQLPrompt {}
+
+impl Prompt for SQLPrompt {
+    fn render_prompt_left(&self) -> std::borrow::Cow<str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_right(&self) -> std::borrow::Cow<str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_indicator(
+        &self,
+        _prompt_mode: reedline::PromptEditMode,
+    ) -> std::borrow::Cow<str> {
+        "〉".into()
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> std::borrow::Cow<str> {
+        Cow::Borrowed("::: ")
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: reedline::PromptHistorySearch,
+    ) -> std::borrow::Cow<str> {
+        let prefix = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+        Cow::Owned(format!(
+            "({}reverse-search: {}) ",
+            prefix, history_search.term
+        ))
+    }
+}

--- a/crates/sqlexec/src/lib.rs
+++ b/crates/sqlexec/src/lib.rs
@@ -10,3 +10,7 @@ mod functions;
 mod metrics;
 mod planner;
 mod vars;
+
+pub mod export {
+    pub use sqlparser;
+}


### PR DESCRIPTION
adds support for the following to the cli: 
- syntax highlighting,  
- multiline support  _(as is common with other sql interfaces.)_ 
- history autofill

![image](https://github.com/GlareDB/glaredb/assets/21327470/12750712-3803-4758-bdfb-79ca45a6d73a)

partially closes https://github.com/GlareDB/glaredb/issues/1090