### PR TITLE
chore: Add demo data source to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,42 @@ Postgres client. For example, connected to a local instance of GlareDB using
 psql "host=localhost user=glaredb dbname=glaredb port=6543"
 ```
 
+## Your first data source
+
+A demo Postgres instance is deployed at `pg.demo.glaredb.com`. Adding this
+Postgres instance as data source is as easy as running the following command:
+
+```sql
+CREATE EXTERNAL DATABASE my_pg
+    FROM postgres
+    OPTIONS (
+        host = 'pg.demo.glaredb.com',
+        port = '5432',
+        user = 'demo',
+        password = 'demo',
+        database = 'postgres',
+    );
+```
+
+Once the data source has been added, it can be queried using fully qualified
+table names:
+
+```sql
+SELECT *
+FROM my_pg.public.lineitem
+WHERE l_shipdate <= date '1998-12-01' - INTERVAL '90'
+LIMIT 5
+```
+
+Check out the docs to learn about all [supported data sources](https://docs.glaredb.com/docs/data-sources/supported/). Many
+data sources can be connected to the same GlareDB instance.
+
+Done with this data source? Remove it with the following command:
+
+```sql
+DROP DATABASE my_pg;
+```
+
 ## Building from source
 
 Building GlareDB requires Rust/Cargo to be installed. Check out [rustup](https://rustup.rs/) for

--- a/crates/datasources/src/postgres/errors.rs
+++ b/crates/datasources/src/postgres/errors.rs
@@ -18,6 +18,9 @@ pub enum PostgresError {
     #[error("Failed to connect to Postgres instance: {0}")]
     TokioPostgres(#[from] tokio_postgres::Error),
 
+    #[error("Unuspported ssl mode: {0:?}")]
+    UnsupportSslMode(tokio_postgres::config::SslMode),
+
     #[error("Unsupported tunnel '{0}' for Postgres")]
     UnsupportedTunnel(String),
 

--- a/testdata/sqllogictests/demo_pg.slt
+++ b/testdata/sqllogictests/demo_pg.slt
@@ -19,3 +19,6 @@ SELECT *
 FROM my_pg.public.lineitem
 WHERE l_shipdate <= date '1998-12-01' - INTERVAL '90'
 LIMIT 5
+
+statement ok
+DROP DATABASE my_pg;

--- a/testdata/sqllogictests/demo_pg.slt
+++ b/testdata/sqllogictests/demo_pg.slt
@@ -1,0 +1,21 @@
+# Queries that are included in the readme.
+#
+# Since this is also hitting a Cloud SQL instance, this also serves as a test
+# for #1120.
+
+statement ok
+CREATE EXTERNAL DATABASE my_pg
+    FROM postgres
+    OPTIONS (
+        host = 'pg.demo.glaredb.com',
+        port = '5432',
+        user = 'demo',
+        password = 'demo',
+        database = 'postgres',
+    );
+
+statement ok
+SELECT *
+FROM my_pg.public.lineitem
+WHERE l_shipdate <= date '1998-12-01' - INTERVAL '90'
+LIMIT 5


### PR DESCRIPTION
Show the sql commands to add, query, and remove the postgres demo data source.

Also fixes #1120 