### PR TITLE
feat: Add support for credentials objects

### DIFF
--- a/crates/metastore/src/builtins.rs
+++ b/crates/metastore/src/builtins.rs
@@ -88,6 +88,18 @@ pub static GLARE_TUNNELS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     ]),
 });
 
+pub static GLARE_CREDENTIALS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    schema: INTERNAL_SCHEMA,
+    name: "credentials",
+    columns: InternalColumnDefinition::from_tuples([
+        ("oid", DataType::UInt32, false),
+        ("credentials_name", DataType::Utf8, false),
+        ("builtin", DataType::Boolean, false),
+        ("provider", DataType::Utf8, false),
+        ("comment", DataType::Utf8, false),
+    ]),
+});
+
 pub static GLARE_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: INTERNAL_SCHEMA,
     name: "schemas",
@@ -209,6 +221,7 @@ impl BuiltinTable {
         vec![
             &GLARE_DATABASES,
             &GLARE_TUNNELS,
+            &GLARE_CREDENTIALS,
             &GLARE_SCHEMAS,
             &GLARE_VIEWS,
             &GLARE_TABLES,

--- a/crates/metastore/src/errors.rs
+++ b/crates/metastore/src/errors.rs
@@ -30,6 +30,9 @@ pub enum MetastoreError {
     #[error("Missing tunnel: {0}")]
     MissingTunnel(String),
 
+    #[error("Missing credentials: {0}")]
+    MissingCredentials(String),
+
     #[error("Missing schema: {0}")]
     MissingNamedSchema(String),
 
@@ -41,6 +44,12 @@ pub enum MetastoreError {
 
     #[error("Tunnel '{tunnel}' not supported by datasource '{datasource}'")]
     TunnelNotSupportedByDatasource { tunnel: String, datasource: String },
+
+    #[error("Credentials '{credentials}' not supported by datasource '{datasource}'")]
+    CredentialsNotSupportedByDatasource {
+        credentials: String,
+        datasource: String,
+    },
 
     #[error("Tunnel '{tunnel} not supported for {action}'")]
     TunnelNotSupportedForAction {

--- a/crates/metastoreproto/proto/catalog.proto
+++ b/crates/metastoreproto/proto/catalog.proto
@@ -55,6 +55,7 @@ message CatalogEntry {
     ViewEntry view = 4;
     TunnelEntry tunnel = 5;
     FunctionEntry function = 6;
+    CredentialsEntry credentials = 7;
   }
 }
 
@@ -78,6 +79,8 @@ message EntryMeta {
     TUNNEL = 5;
     // Function entry.
     FUNCTION = 6;
+    // Credentials entry.
+    CREDENTIALS = 7;
   }
 
   // Type of the entry.
@@ -165,4 +168,11 @@ message FunctionEntry {
 
   EntryMeta meta = 1;
   FunctionType func_type = 2;
+}
+
+message CredentialsEntry {
+  EntryMeta meta = 1;
+  options.CredentialsOptions options = 2;
+  string comment = 3;
+  // next: 4
 }

--- a/crates/metastoreproto/proto/options.proto
+++ b/crates/metastoreproto/proto/options.proto
@@ -183,3 +183,26 @@ message TunnelOptionsSsh {
   string connection_string = 1;
   bytes ssh_key = 2;
 }
+
+// Credentials options
+
+message CredentialsOptions {
+  oneof options {
+    CredentialsOptionsDebug debug = 1;
+    CredentialsOptionsGcp gcp = 2;
+    CredentialsOptionsAws aws = 3;
+  }
+}
+
+message CredentialsOptionsDebug {
+  string table_type = 1;
+}
+
+message CredentialsOptionsGcp {
+  string service_account_key = 1;
+}
+
+message CredentialsOptionsAws {
+  string access_key_id = 1;
+  string secret_access_key = 2;
+}

--- a/crates/metastoreproto/proto/service.proto
+++ b/crates/metastoreproto/proto/service.proto
@@ -34,21 +34,24 @@ message FetchCatalogResponse { catalog.CatalogState catalog = 1; }
 // Possible mutations to make.
 message Mutation {
   oneof mutation {
-    DropDatabase drop_database = 8;
     DropSchema drop_schema = 1;
     DropObject drop_object = 2;
     CreateSchema create_schema = 3;
     CreateView create_view = 4;
-    CreateTable create_table = 14;
+    // 5
     CreateExternalTable create_external_table = 6;
     CreateExternalDatabase create_external_database = 7;
+    DropDatabase drop_database = 8;
     AlterTableRename alter_table_rename = 9;
     AlterDatabaseRename alter_database_rename = 10;
     CreateTunnel create_tunnel = 11;
     DropTunnel drop_tunnel = 12;
     AlterTunnelRotateKeys alter_tunnel_rotate_keys = 13;
+    CreateTable create_table = 14;
+    CreateCredentials create_credentials = 15;
+    DropCredentials drop_credentials = 16;
   }
-  // next: 15
+  // next: 17
 }
 
 message DropDatabase {
@@ -130,6 +133,17 @@ message AlterTunnelRotateKeys {
   bool if_exists = 2;
   bytes new_ssh_key = 3;
   // next: 4
+}
+
+message CreateCredentials {
+  string name = 1;
+  options.CredentialsOptions options = 2;
+  string comment = 3;
+}
+
+message DropCredentials {
+  string name = 1;
+  bool if_exists = 2;
 }
 
 message MutateRequest {

--- a/crates/metastoreproto/src/types/options.rs
+++ b/crates/metastoreproto/src/types/options.rs
@@ -965,3 +965,135 @@ mod tests {
         }
     }
 }
+
+#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+pub enum CredentialsOptions {
+    Debug(CredentialsOptionsDebug),
+    Gcp(CredentialsOptionsGcp),
+    Aws(CredentialsOptionsAws),
+}
+
+impl CredentialsOptions {
+    pub const DEBUG: &str = "debug";
+    pub const GCP: &str = "gcp";
+    pub const AWS: &str = "aws";
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Debug(_) => Self::DEBUG,
+            Self::Gcp(_) => Self::GCP,
+            Self::Aws(_) => Self::AWS,
+        }
+    }
+}
+
+impl fmt::Display for CredentialsOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<options::credentials_options::Options> for CredentialsOptions {
+    type Error = ProtoConvError;
+    fn try_from(value: options::credentials_options::Options) -> Result<Self, Self::Error> {
+        Ok(match value {
+            options::credentials_options::Options::Debug(v) => Self::Debug(v.try_into()?),
+            options::credentials_options::Options::Gcp(v) => Self::Gcp(v.try_into()?),
+            options::credentials_options::Options::Aws(v) => Self::Aws(v.try_into()?),
+        })
+    }
+}
+
+impl TryFrom<options::CredentialsOptions> for CredentialsOptions {
+    type Error = ProtoConvError;
+    fn try_from(value: options::CredentialsOptions) -> Result<Self, Self::Error> {
+        value.options.required("options")
+    }
+}
+
+impl From<CredentialsOptions> for options::credentials_options::Options {
+    fn from(value: CredentialsOptions) -> Self {
+        match value {
+            CredentialsOptions::Debug(v) => options::credentials_options::Options::Debug(v.into()),
+            CredentialsOptions::Gcp(v) => options::credentials_options::Options::Gcp(v.into()),
+            CredentialsOptions::Aws(v) => options::credentials_options::Options::Aws(v.into()),
+        }
+    }
+}
+
+impl From<CredentialsOptions> for options::CredentialsOptions {
+    fn from(value: CredentialsOptions) -> Self {
+        options::CredentialsOptions {
+            options: Some(value.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+pub struct CredentialsOptionsDebug {
+    pub table_type: String,
+}
+
+impl TryFrom<options::CredentialsOptionsDebug> for CredentialsOptionsDebug {
+    type Error = ProtoConvError;
+    fn try_from(value: options::CredentialsOptionsDebug) -> Result<Self, Self::Error> {
+        Ok(CredentialsOptionsDebug {
+            table_type: value.table_type,
+        })
+    }
+}
+
+impl From<CredentialsOptionsDebug> for options::CredentialsOptionsDebug {
+    fn from(value: CredentialsOptionsDebug) -> Self {
+        options::CredentialsOptionsDebug {
+            table_type: value.table_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+pub struct CredentialsOptionsGcp {
+    pub service_account_key: String,
+}
+
+impl TryFrom<options::CredentialsOptionsGcp> for CredentialsOptionsGcp {
+    type Error = ProtoConvError;
+    fn try_from(value: options::CredentialsOptionsGcp) -> Result<Self, Self::Error> {
+        Ok(CredentialsOptionsGcp {
+            service_account_key: value.service_account_key,
+        })
+    }
+}
+
+impl From<CredentialsOptionsGcp> for options::CredentialsOptionsGcp {
+    fn from(value: CredentialsOptionsGcp) -> Self {
+        options::CredentialsOptionsGcp {
+            service_account_key: value.service_account_key,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+pub struct CredentialsOptionsAws {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+}
+
+impl TryFrom<options::CredentialsOptionsAws> for CredentialsOptionsAws {
+    type Error = ProtoConvError;
+    fn try_from(value: options::CredentialsOptionsAws) -> Result<Self, Self::Error> {
+        Ok(CredentialsOptionsAws {
+            access_key_id: value.access_key_id,
+            secret_access_key: value.secret_access_key,
+        })
+    }
+}
+
+impl From<CredentialsOptionsAws> for options::CredentialsOptionsAws {
+    fn from(value: CredentialsOptionsAws) -> Self {
+        options::CredentialsOptionsAws {
+            access_key_id: value.access_key_id,
+            secret_access_key: value.secret_access_key,
+        }
+    }
+}

--- a/crates/pgsrv/src/proxy.rs
+++ b/crates/pgsrv/src/proxy.rs
@@ -115,7 +115,7 @@ pub const GLAREDB_USER_ID_KEY: UuidProxyKey = UuidProxyKey {
     default: Uuid::nil(),
 };
 
-/// Param key for the max number ofdatasources allowed. Added by pgsrv during proxying.
+/// Param key for the max number of datasources allowed. Added by pgsrv during proxying.
 pub const GLAREDB_MAX_DATASOURCE_COUNT_KEY: UsizeProxyKey = UsizeProxyKey {
     key: "max_datasource_count",
     default: 100,
@@ -127,9 +127,15 @@ pub const GLAREDB_MEMORY_LIMIT_BYTES_KEY: UsizeProxyKey = UsizeProxyKey {
     default: 0,
 };
 
-/// Param key for the memory limit in bytes. Added by pgsrv during proxying.
+/// Param key for the max number of tunnels allowed. Added by pgsrv during proxying.
 pub const GLAREDB_MAX_TUNNEL_COUNT_KEY: UsizeProxyKey = UsizeProxyKey {
     key: "max_tunnel_count",
+    default: 100,
+};
+
+/// Param key for the max number of credentials allowed. Added by pgsrv during proxying.
+pub const GLAREDB_MAX_CREDENTIALS_COUNT_KEY: UsizeProxyKey = UsizeProxyKey {
+    key: "max_credentials_count",
     default: 100,
 };
 

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -47,12 +47,14 @@ pub struct SessionStorageConfig {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SessionLimits {
-    // Max datasource count allowed.
+    /// Max datasource count allowed.
     pub max_datasource_count: Option<usize>,
-    // Memory limit applied to the session.
+    /// Memory limit applied to the session.
     pub memory_limit_bytes: Option<usize>,
-    // Max tunnel count allowed.
+    /// Max tunnel count allowed.
     pub max_tunnel_count: Option<usize>,
+    /// Max credentials count.
+    pub max_credentials_count: Option<usize>,
 }
 
 /// Storage configuration for the compute engine.

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -116,11 +116,12 @@ pub enum ExecError {
     #[error("All connection methods as part of ssh_tunnel should be ssh connections")]
     NonSshConnection,
 
-    #[error("Cannot create additional data sources. Max: {max}, Current: {current}")]
-    MaxDatasourceCount { max: usize, current: usize },
-
-    #[error("Cannot create additional tunnels. Max: {max}, Current: {current}")]
-    MaxTunnelCount { max: usize, current: usize },
+    #[error("Cannot create additional {typ}. Max: {max}, Current: {current}")]
+    MaxObjectCount {
+        typ: &'static str,
+        max: usize,
+        current: usize,
+    },
 
     #[error("Invalid storage configuration: {0}")]
     InvalidStorageConfig(&'static str),

--- a/crates/sqlexec/src/planner/errors.rs
+++ b/crates/sqlexec/src/planner/errors.rs
@@ -27,6 +27,9 @@ pub enum PlanError {
     #[error("Invalid tunnel '{tunnel}': {reason}")]
     InvalidTunnel { tunnel: String, reason: String },
 
+    #[error("Invalid credentials '{credentials}': {reason}")]
+    InvalidCredentials { credentials: String, reason: String },
+
     #[error("External database validation failed: {source}")]
     InvalidExternalDatabase {
         source: Box<dyn std::error::Error + Send + Sync>,

--- a/crates/sqlexec/src/planner/logical_plan.rs
+++ b/crates/sqlexec/src/planner/logical_plan.rs
@@ -6,7 +6,7 @@ use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::sqlparser::ast;
 use metastoreproto::types::options::{
-    DatabaseOptions, TableOptions, TableOptionsInternal, TunnelOptions,
+    CredentialsOptions, DatabaseOptions, TableOptions, TableOptionsInternal, TunnelOptions,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -114,6 +114,7 @@ impl std::fmt::Debug for Insert {
 pub enum DdlPlan {
     CreateExternalDatabase(CreateExternalDatabase),
     CreateTunnel(CreateTunnel),
+    CreateCredentials(CreateCredentials),
     CreateSchema(CreateSchema),
     CreateTempTable(CreateTempTable),
     CreateExternalTable(CreateExternalTable),
@@ -128,6 +129,7 @@ pub enum DdlPlan {
     DropSchemas(DropSchemas),
     DropDatabase(DropDatabase),
     DropTunnel(DropTunnel),
+    DropCredentials(DropCredentials),
 }
 
 impl From<DdlPlan> for LogicalPlan {
@@ -149,6 +151,13 @@ pub struct CreateTunnel {
     pub name: String,
     pub if_not_exists: bool,
     pub options: TunnelOptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateCredentials {
+    pub name: String,
+    pub options: CredentialsOptions,
+    pub comment: String,
 }
 
 #[derive(Clone, Debug)]
@@ -226,6 +235,12 @@ pub struct DropDatabase {
 
 #[derive(Clone, Debug)]
 pub struct DropTunnel {
+    pub names: Vec<String>,
+    pub if_exists: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct DropCredentials {
     pub names: Vec<String>,
     pub if_exists: bool,
 }

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -55,6 +55,8 @@ pub enum ExecutionResult {
     CreateDatabase,
     /// Tunnel created.
     CreateTunnel,
+    /// Credentials created.
+    CreateCredentials,
     /// Schema created.
     CreateSchema,
     /// A view was created.
@@ -79,6 +81,8 @@ pub enum ExecutionResult {
     DropDatabase,
     /// Tunnel is dropped.
     DropTunnel,
+    /// Credentials are dropped.
+    DropCredentials,
 }
 
 impl ExecutionResult {
@@ -94,6 +98,7 @@ impl ExecutionResult {
             ExecutionResult::CreateTable => "create_table",
             ExecutionResult::CreateDatabase => "create_database",
             ExecutionResult::CreateTunnel => "create_tunnel",
+            ExecutionResult::CreateCredentials => "create_credentials",
             ExecutionResult::CreateSchema => "create_schema",
             ExecutionResult::CreateView => "create_view",
             ExecutionResult::CreateConnection => "create_connection",
@@ -106,6 +111,7 @@ impl ExecutionResult {
             ExecutionResult::DropSchemas => "drop_schemas",
             ExecutionResult::DropDatabase => "drop_database",
             ExecutionResult::DropTunnel => "drop_tunnel",
+            ExecutionResult::DropCredentials => "drop_credentials",
         }
     }
 }
@@ -127,6 +133,7 @@ impl fmt::Debug for ExecutionResult {
             ExecutionResult::CreateTable => write!(f, "create table"),
             ExecutionResult::CreateDatabase => write!(f, "create database"),
             ExecutionResult::CreateTunnel => write!(f, "create tunnel"),
+            ExecutionResult::CreateCredentials => write!(f, "create credentials"),
             ExecutionResult::CreateSchema => write!(f, "create schema"),
             ExecutionResult::CreateView => write!(f, "create view"),
             ExecutionResult::CreateConnection => write!(f, "create connection"),
@@ -139,6 +146,7 @@ impl fmt::Debug for ExecutionResult {
             ExecutionResult::DropSchemas => write!(f, "drop schemas"),
             ExecutionResult::DropDatabase => write!(f, "drop database"),
             ExecutionResult::DropTunnel => write!(f, "drop tunnel"),
+            ExecutionResult::DropCredentials => write!(f, "drop credentials"),
         }
     }
 }
@@ -223,6 +231,11 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) async fn create_credentials(&mut self, plan: CreateCredentials) -> Result<()> {
+        self.ctx.create_credentials(plan).await?;
+        Ok(())
+    }
+
     pub(crate) async fn create_view(&mut self, plan: CreateView) -> Result<()> {
         self.ctx.create_view(plan).await?;
         Ok(())
@@ -268,6 +281,11 @@ impl Session {
 
     pub(crate) async fn drop_tunnel(&mut self, plan: DropTunnel) -> Result<()> {
         self.ctx.drop_tunnel(plan).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn drop_credentials(&mut self, plan: DropCredentials) -> Result<()> {
+        self.ctx.drop_credentials(plan).await?;
         Ok(())
     }
 
@@ -401,6 +419,10 @@ impl Session {
                 self.create_tunnel(plan).await?;
                 ExecutionResult::CreateTunnel
             }
+            LogicalPlan::Ddl(DdlPlan::CreateCredentials(plan)) => {
+                self.create_credentials(plan).await?;
+                ExecutionResult::CreateCredentials
+            }
             LogicalPlan::Ddl(DdlPlan::CreateTableAs(plan)) => {
                 self.create_table_as(plan).await?;
                 ExecutionResult::CreateTable
@@ -444,6 +466,10 @@ impl Session {
             LogicalPlan::Ddl(DdlPlan::DropTunnel(plan)) => {
                 self.drop_tunnel(plan).await?;
                 ExecutionResult::DropTunnel
+            }
+            LogicalPlan::Ddl(DdlPlan::DropCredentials(plan)) => {
+                self.drop_credentials(plan).await?;
+                ExecutionResult::DropCredentials
             }
             LogicalPlan::Write(WritePlan::Insert(plan)) => {
                 self.insert_into(plan).await?;

--- a/testdata/sqllogictests/credentials.slt
+++ b/testdata/sqllogictests/credentials.slt
@@ -1,0 +1,94 @@
+# Basic tests for credentials and datasources.
+
+statement ok
+CREATE CREDENTIALS debug_creds PROVIDER debug
+	OPTIONS (table_type = 'never_ending');
+
+statement error Duplicate name
+CREATE CREDENTIALS debug_creds PROVIDER debug
+	OPTIONS (table_type = 'never_ending');
+
+query TT
+SELECT credentials_name, provider
+	FROM glare_catalog.credentials
+	WHERE credentials_name = 'debug_creds';
+----
+debug_creds debug
+
+# Incorrect credentials name should error
+
+statement error does not exist
+CREATE EXTERNAL TABLE debug_creds_table
+  FROM debug
+  CREDENTIALS debug_creds_abc;
+
+# Try creating datasource using credentials
+
+statement ok
+CREATE EXTERNAL TABLE debug_creds_table
+  FROM debug
+  CREDENTIALS debug_creds;
+
+query III
+SELECT *
+  FROM debug_creds_table
+  LIMIT 1;
+----
+1 2 3
+
+# Options to over-ride credentials.
+
+statement ok
+CREATE EXTERNAL TABLE debug_creds_table_opts
+  FROM debug
+  CREDENTIALS debug_creds
+  OPTIONS (table_type = 'error_during_execution');
+
+statement error always error
+SELECT *
+  FROM debug_creds_table_opts
+  LIMIT 1;
+
+# Check compatibility: datasource <-> credentials.
+# Debug DBs don't support debug creds (since not required)
+
+statement error not supported by datasource
+CREATE EXTERNAL DATABASE debug_creds_db
+	FROM debug
+	CREDENTIALS debug_creds;
+
+# Credentials also work with tunnels.
+
+statement ok
+CREATE TUNNEL debug_tunnel FROM debug;
+
+statement ok
+CREATE EXTERNAL TABLE debug_creds_tunnel_table
+	FROM debug
+	TUNNEL debug_tunnel
+	CREDENTIALS debug_creds;
+
+query TTT
+SELECT * FROM debug_creds_tunnel_table
+	LIMIT 1;
+----
+10	20	30
+
+# Credentials can have comments (optionally)
+
+statement ok
+CREATE CREDENTIALS comment1 PROVIDER debug
+	OPTIONS (table_type = 'never_ending');
+
+statement ok
+CREATE CREDENTIALS comment2 PROVIDER debug
+	OPTIONS (table_type = 'never_ending')
+	COMMENT 'creds-for-debug';
+
+query TT rowsort
+SELECT credentials_name, comment
+	FROM glare_catalog.credentials
+	WHERE credentials_name LIKE 'comment%';
+----
+comment1	(empty)
+comment2	creds-for-debug

--- a/testdata/sqllogictests/drop.slt
+++ b/testdata/sqllogictests/drop.slt
@@ -94,6 +94,54 @@ query TT
 select tunnel_name, tunnel_type from glare_catalog.tunnels where tunnel_name like 'drop_tunnel%';
 ----
 
+# Test dropping credentials
+
+statement ok
+create credentials drop_credentials provider debug options (table_type = 'never_ending');
+
+query TT
+select credentials_name, provider
+    from glare_catalog.credentials where credentials_name='drop_credentials';
+----
+drop_credentials debug
+
+statement ok
+drop credentials drop_credentials;
+
+statement error
+drop credentials drop_credentials;
+
+statement ok
+drop credentials if exists drop_credentials;
+
+query TT
+select credentials_name, provider
+    from glare_catalog.credentials where credentials_name='drop_credentials';
+----
+
+# Test dropping multiple credentialss
+
+statement ok
+create credentials drop_credentials1 provider debug options (table_type = 'never_ending');
+
+statement ok
+create credentials drop_credentials2 provider debug options (table_type = 'never_ending');
+
+query TT rowsort
+select credentials_name, provider
+    from glare_catalog.credentials where credentials_name like 'drop_credentials%';
+----
+drop_credentials1  debug
+drop_credentials2  debug
+
+statement ok
+drop credentials drop_credentials1, drop_credentials2;
+
+query TT
+select credentials_name, provider
+    from glare_catalog.credentials where credentials_name like 'drop_credentials%';
+----
+
 # Test dropping empty schema
 
 statement ok

--- a/testdata/sqllogictests/object_names.slt
+++ b/testdata/sqllogictests/object_names.slt
@@ -122,6 +122,39 @@ Obj_Name_Tunnel
 statement ok
 DROP tunnel "Obj_Name_Tunnel";
 
+# Credentials names
+
+statement ok
+CREATE CREDENTIALS obj_name_credentials PROVIDER debug OPTIONS (table_type = 'never_ending');
+
+statement error
+CREATE CREDENTIALS Obj_Name_Credentials PROVIDER debug OPTIONS (table_type = 'never_ending');
+
+statement ok
+CREATE CREDENTIALS "Obj_Name_Credentials" PROVIDER debug OPTIONS (table_type = 'never_ending');
+
+query TT rowsort
+SELECT credentials_name FROM glare_catalog.credentials
+	WHERE credentials_name LIKE '%bj_%ame_%redentials' AND provider = 'debug';
+----
+Obj_Name_Credentials
+obj_name_credentials
+
+statement ok
+DROP credentials "obj_name_credentials";
+
+statement error
+DROP credentials Obj_Name_credentials;
+
+query TT rowsort
+SELECT credentials_name FROM glare_catalog.credentials
+	WHERE credentials_name LIKE '%bj_%ame_%redentials' AND provider = 'debug';
+----
+Obj_Name_Credentials
+
+statement ok
+DROP credentials "Obj_Name_Credentials";
+
 # View names
 
 statement ok

--- a/testdata/sqllogictests_bigquery/credentials.slt
+++ b/testdata/sqllogictests_bigquery/credentials.slt
@@ -1,0 +1,36 @@
+# Test if can create external tables/database using credentials.
+
+statement ok
+CREATE CREDENTIALS gcp_creds
+	PROVIDER gcp
+	OPTIONS (
+		service_account_key = '${GCP_SERVICE_ACCOUNT_KEY}',
+	);
+
+statement ok
+CREATE EXTERNAL TABLE bigquery_table
+	FROM bigquery
+	CREDENTIALS gcp_creds
+	OPTIONS (
+		project_id = '${GCP_PROJECT_ID}',
+		dataset_id = '${BIGQUERY_DATASET_ID}',
+		table_id = 'bikeshare_stations'
+	);
+
+query I
+SELECT COUNT(*) FROM bigquery_table;
+----
+102
+
+statement ok
+CREATE EXTERNAL DATABASE bigquery_db
+	FROM bigquery
+	CREDENTIALS gcp_creds
+	OPTIONS (
+		project_id = '${GCP_PROJECT_ID}',
+	);
+
+query I
+SELECT COUNT(*) FROM bigquery_db.${BIGQUERY_DATASET_ID}.bikeshare_stations;
+----
+102

--- a/testdata/sqllogictests_object_store/gcs/credentials.slt
+++ b/testdata/sqllogictests_object_store/gcs/credentials.slt
@@ -1,0 +1,22 @@
+# Test if can create external tables using credentials
+
+statement ok
+CREATE CREDENTIALS gcp_creds
+	PROVIDER gcp
+	OPTIONS (
+		service_account_key = '${GCP_SERVICE_ACCOUNT_KEY}',
+	);
+
+statement ok
+CREATE EXTERNAL TABLE gcs_table
+    FROM gcs
+	CREDENTIALS gcp_creds
+    OPTIONS (
+        bucket = '${GCS_BUCKET_NAME}',
+        location = 'bikeshare_stations.csv'
+    );
+
+query I
+SELECT COUNT(*) FROM gcs_table;
+----
+102

--- a/testdata/sqllogictests_object_store/s3/credentials.slt
+++ b/testdata/sqllogictests_object_store/s3/credentials.slt
@@ -1,0 +1,24 @@
+# Test if can create external tables using credentials.
+
+statement ok
+CREATE CREDENTIALS aws_creds
+	PROVIDER aws
+	OPTIONS (
+        access_key_id = '${AWS_ACCESS_KEY_ID}',
+        secret_access_key = '${AWS_SECRET_ACCESS_KEY}',
+	);
+
+statement ok
+CREATE EXTERNAL TABLE s3_table
+    FROM s3
+	CREDENTIALS aws_creds
+    OPTIONS (
+        region = '${AWS_S3_REGION}',
+        bucket = '${AWS_S3_BUCKET_NAME}',
+        location = 'bikeshare_stations.csv'
+    );
+
+query I
+SELECT COUNT(*) FROM s3_table;
+----
+102


### PR DESCRIPTION
```
CREATE CREDENTIALS debug_creds
  PROVIDER debug
  OPTIONS (table_type = 'never_ending');

CREATE EXTERNAL TABLE debug_table
  FROM debug
  CREDENTIALS debug_creds;

DROP CREDENTIALS debug_creds;
```

Internal catalog:

```
〉select * from glare_catalog.credentials;
+-------+------------------+---------+----------+----------------+
| oid   | credentials_name | builtin | provider | comment        |
+-------+------------------+---------+----------+----------------+
| 20000 | aws_creds        | false   | aws      | test aws creds |
+-------+------------------+---------+----------+----------------+
```

Fixes https://github.com/GlareDB/glaredb/issues/1126, https://github.com/GlareDB/glaredb/issues/1141, https://github.com/GlareDB/glaredb/issues/1142

### TODO

- [x] Add more providers (AWS, GCS ...)
- [ ] Add credentials support for `COPY TO ...`
- [ ] Reference credentials instead of copying and add `ALTER CREDENTIALS ...` support