### PR TITLE
chore: Allow ignoring auth messages

### DIFF
--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -6,7 +6,9 @@ use glaredb::proxy::Proxy;
 use glaredb::server::{Server, ServerConfig};
 use object_store::local::LocalFileSystem;
 use object_store::{gcp::GoogleCloudStorageBuilder, memory::InMemory, ObjectStore};
-use pgsrv::auth::{LocalAuthenticator, PasswordlessAuthenticator, SingleUserAuthenticator};
+use pgsrv::auth::{
+    IgnoreAuthAuthenticator, LocalAuthenticator, PasswordlessAuthenticator, SingleUserAuthenticator,
+};
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -79,13 +81,24 @@ enum Commands {
         #[clap(short = 'f', long, value_parser)]
         local_file_path: Option<PathBuf>,
 
-        /// API key for segment.
-        #[clap(long, value_parser)]
-        segment_key: Option<String>,
-
         /// Path to spill temporary files to.
         #[clap(long, value_parser)]
         spill_path: Option<PathBuf>,
+
+        /// Ignore authentication messages.
+        ///
+        /// (Internal)
+        ///
+        /// This is only relevant for internal development. The postgres
+        /// protocol proxy will drop all authentication related messages.
+        #[clap(long, value_parser)]
+        ignore_auth: bool,
+
+        /// API key for segment.
+        ///
+        /// (Internal)
+        #[clap(long, value_parser)]
+        segment_key: Option<String>,
     },
 
     /// Starts an instance of the pgsrv proxy.
@@ -163,13 +176,15 @@ fn main() -> Result<()> {
             local_file_path,
             mut segment_key,
             spill_path,
+            ignore_auth,
         } => {
             // Map an empty string to None. Makes writing the terraform easier.
             segment_key = segment_key.and_then(|s| if s.is_empty() { None } else { Some(s) });
 
-            let auth: Box<dyn LocalAuthenticator> = match password {
-                Some(password) => Box::new(SingleUserAuthenticator { user, password }),
-                None => Box::new(PasswordlessAuthenticator),
+            let auth: Box<dyn LocalAuthenticator> = match (password, ignore_auth) {
+                (Some(password), _) => Box::new(SingleUserAuthenticator { user, password }),
+                (None, false) => Box::new(PasswordlessAuthenticator),
+                (None, true) => Box::new(IgnoreAuthAuthenticator),
             };
 
             begin_server(

--- a/crates/pgsrv/src/auth.rs
+++ b/crates/pgsrv/src/auth.rs
@@ -5,10 +5,16 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy)]
 pub enum PasswordMode {
-    /// Frontend should send over password in clear text.
-    Cleartext,
-    /// No password required.
-    NoPassword,
+    /// A cleartext password is required.
+    ///
+    /// Should error if no password is provided.
+    RequiredCleartext,
+
+    /// Requires that no password is provided.
+    RequireNoPassword,
+
+    /// Ignore all authentication messages.
+    IgnoreAuth,
 }
 
 /// Authenticate connection on the glaredb node itself.
@@ -26,7 +32,7 @@ pub struct SingleUserAuthenticator {
 
 impl LocalAuthenticator for SingleUserAuthenticator {
     fn password_mode(&self) -> PasswordMode {
-        PasswordMode::Cleartext
+        PasswordMode::RequiredCleartext
     }
 
     fn authenticate(&self, user: &str, password: &str, _db_name: &str) -> Result<()> {
@@ -41,13 +47,27 @@ impl LocalAuthenticator for SingleUserAuthenticator {
     }
 }
 
-/// Allows any user and password.
+/// Require no password provided.
 #[derive(Debug, Clone, Copy)]
 pub struct PasswordlessAuthenticator;
 
 impl LocalAuthenticator for PasswordlessAuthenticator {
     fn password_mode(&self) -> PasswordMode {
-        PasswordMode::NoPassword
+        PasswordMode::RequireNoPassword
+    }
+
+    fn authenticate(&self, _user: &str, _password: &str, _db_name: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Allow any password.
+#[derive(Debug, Clone, Copy)]
+pub struct IgnoreAuthAuthenticator;
+
+impl LocalAuthenticator for IgnoreAuthAuthenticator {
+    fn password_mode(&self) -> PasswordMode {
+        PasswordMode::IgnoreAuth
     }
 
     fn authenticate(&self, _user: &str, _password: &str, _db_name: &str) -> Result<()> {

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -31,32 +31,26 @@ use tokio_postgres::types::Type as PgType;
 use tracing::{debug, debug_span, warn, Instrument};
 use uuid::Uuid;
 
+pub struct ProtocolHandlerConfig {
+    /// Authenticor to use on the server side.
+    pub authenticator: Box<dyn LocalAuthenticator>,
+    /// SSL configuration to use on the server side.
+    pub ssl_conf: Option<SslConfig>,
+    /// If the server should be configured for integration tests. This is only
+    /// applicable for local databases.
+    pub integration_testing: bool,
+}
+
 /// A wrapper around a SQL engine that implements the Postgres frontend/backend
 /// protocol.
 pub struct ProtocolHandler {
     pub engine: Engine,
-    authenticator: Box<dyn LocalAuthenticator>,
-    ssl_conf: Option<SslConfig>,
-    /// If the server should be configured for integration tests. This is only
-    /// applicable for local databases.
-    integration_testing: bool,
+    conf: ProtocolHandlerConfig,
 }
 
 impl ProtocolHandler {
-    pub fn new(
-        engine: Engine,
-        authenticator: Box<dyn LocalAuthenticator>,
-        integration_testing: bool,
-    ) -> Self {
-        ProtocolHandler {
-            engine,
-            authenticator,
-            // TODO: Allow specifying SSL/TLS on the GlareDB side as well. I
-            // want to hold off on doing that until we have a shared config
-            // between the proxy and GlareDB.
-            ssl_conf: None,
-            integration_testing,
-        }
+    pub fn new(engine: Engine, conf: ProtocolHandlerConfig) -> Self {
+        ProtocolHandler { engine, conf }
     }
 
     pub async fn handle_connection<C>(&self, id: Uuid, conn: C) -> Result<()>
@@ -74,7 +68,7 @@ impl ProtocolHandler {
                     return Ok(());
                 }
                 StartupMessage::SSLRequest { .. } => {
-                    conn = match (conn, &self.ssl_conf) {
+                    conn = match (conn, &self.conf.ssl_conf) {
                         (Connection::Unencrypted(mut conn), Some(conf)) => {
                             debug!("accepting ssl request");
                             // SSL supported, send back that we support it and
@@ -127,7 +121,7 @@ impl ProtocolHandler {
 
     /// Whether the server should be configured for integration testing.
     fn is_integration_testing_enabled(&self) -> bool {
-        self.integration_testing
+        self.conf.integration_testing
     }
 
     /// Runs the postgres protocol for a connection to completion.
@@ -173,18 +167,19 @@ impl ProtocolHandler {
         };
 
         // Handle password.
-        match self.authenticator.password_mode() {
-            PasswordMode::Cleartext => {
+        match self.conf.authenticator.password_mode() {
+            PasswordMode::RequiredCleartext => {
                 framed
                     .send(BackendMessage::AuthenticationCleartextPassword)
                     .await?;
                 let msg = framed.read().await?;
                 match msg {
                     Some(FrontendMessage::PasswordMessage { password }) => {
-                        match self
-                            .authenticator
-                            .authenticate(&user_name, &password, &database_name)
-                        {
+                        match self.conf.authenticator.authenticate(
+                            &user_name,
+                            &password,
+                            &database_name,
+                        ) {
                             Ok(sess) => sess,
                             Err(e) => {
                                 framed
@@ -208,8 +203,27 @@ impl ProtocolHandler {
                     None => return Ok(()),
                 }
             }
-            PasswordMode::NoPassword => {
+            PasswordMode::RequireNoPassword => {
                 // Nothin to do.
+                framed.send(BackendMessage::AuthenticationOk).await?;
+            }
+            PasswordMode::IgnoreAuth => {
+                // Continually read all auth messages from the frontend. These
+                // are ignored.
+                loop {
+                    let msg = framed.peek().await?;
+                    match msg {
+                        Some(msg) if msg.is_auth_message() => {
+                            let dropped = framed.read().await?; // Drop auth message.
+                            warn!(?dropped, "dropping authentication message");
+                        }
+                        Some(_msg) => break, // We peeked a message not related to auth.
+                        None => return Ok(()), // Connection closed.
+                    }
+                }
+
+                // And finally send back auth ok after dropping all auth
+                // messages.
                 framed.send(BackendMessage::AuthenticationOk).await?;
             }
         }

--- a/crates/pgsrv/src/messages.rs
+++ b/crates/pgsrv/src/messages.rs
@@ -122,10 +122,7 @@ impl FrontendMessage {
     }
 
     pub(crate) fn is_auth_message(&self) -> bool {
-        match self {
-            FrontendMessage::PasswordMessage { .. } => true,
-            _ => false,
-        }
+        matches!(self, FrontendMessage::PasswordMessage { .. })
     }
 }
 

--- a/crates/pgsrv/src/messages.rs
+++ b/crates/pgsrv/src/messages.rs
@@ -31,7 +31,7 @@ pub enum StartupMessage {
 }
 
 /// Messages sent by the frontend.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FrontendMessage {
     /// A query (or queries) to execute.
     Query { sql: String },
@@ -118,6 +118,13 @@ impl FrontendMessage {
             FrontendMessage::Flush => "flush",
             FrontendMessage::Sync => "sync",
             FrontendMessage::Terminate => "terminate",
+        }
+    }
+
+    pub(crate) fn is_auth_message(&self) -> bool {
+        match self {
+            FrontendMessage::PasswordMessage { .. } => true,
+            _ => false,
         }
     }
 }
@@ -362,7 +369,7 @@ pub struct FieldDescription {
     pub format: i16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum DescribeObjectType {
     Statement = b'S',


### PR DESCRIPTION
A bit of hack (since compliant frontends shouldn't send auth messages after AuthenticationOk), but should help with internal development.

```
glaredb server --ignore-auth
```