### PR TITLE
feat: add "parquet_scan" function

### DIFF
--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -24,7 +24,7 @@ metastoreproto = { path = "../metastoreproto" }
 mongodb = "2.5.0"
 mysql_async = { version = "0.32.2", default-features = false, features = ["default-rustls"] }
 mysql_common = { version = "0.30.5", features = ["chrono"] }
-object_store = { version = "0.5", features = ["gcp", "aws"] }
+object_store = { version = "0.5", features = ["gcp", "aws", "http"] }
 object_store_util = { path = "../object_store_util" }
 once_cell = "1.18.0"
 openssh = "0.9.9"

--- a/crates/datasources/src/object_store/errors.rs
+++ b/crates/datasources/src/object_store/errors.rs
@@ -25,6 +25,9 @@ pub enum ObjectStoreSourceError {
 
     #[error("{0}")]
     Static(&'static str),
+
+    #[error("Failed to read object over http: {0}")]
+    Reqwest(#[from] reqwest::Error),
 }
 
 pub type Result<T, E = ObjectStoreSourceError> = std::result::Result<T, E>;

--- a/crates/datasources/src/object_store/mod.rs
+++ b/crates/datasources/src/object_store/mod.rs
@@ -11,11 +11,12 @@ use errors::Result;
 
 pub mod errors;
 pub mod gcs;
+pub mod http;
 pub mod local;
+pub mod parquet;
 pub mod s3;
 
 mod csv;
-mod parquet;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FileType {

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -502,13 +502,14 @@ impl TableFunc for ParquetScan {
                 let accessor = HttpAccessor::try_new(url)
                     .await
                     .map_err(|e| BuiltinError::Access(Box::new(e)))?;
+
                 let prov = ParquetTableProvider::from_table_accessor(accessor, false)
                     .await
-                    .unwrap();
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?;
 
                 Ok(Arc::new(prov))
             }
-            _ => Err(BuiltinError::Unimplemented("invalid number of arguments")),
+            _ => Err(BuiltinError::InvalidNumArgs),
         }
     }
 }

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -15,6 +15,8 @@ use datasources::common::listing::VirtualLister;
 use datasources::debug::DebugVirtualLister;
 use datasources::mongodb::{MongoAccessor, MongoTableAccessInfo};
 use datasources::mysql::{MysqlAccessor, MysqlTableAccess};
+use datasources::object_store::http::HttpAccessor;
+use datasources::object_store::parquet::ParquetTableProvider;
 use datasources::postgres::{PostgresAccessor, PostgresTableAccess};
 use datasources::snowflake::{SnowflakeAccessor, SnowflakeDbConnection, SnowflakeTableAccess};
 use futures::Stream;
@@ -59,6 +61,7 @@ impl BuiltinTableFuncs {
             Arc::new(ReadMongoDb),
             Arc::new(ReadMysql),
             Arc::new(ReadSnowflake),
+            Arc::new(ParquetScan),
             // Listing
             Arc::new(ListSchemas),
             Arc::new(ListTables),
@@ -462,6 +465,50 @@ impl TableFunc for ReadSnowflake {
                 Ok(Arc::new(prov))
             }
             _ => Err(BuiltinError::InvalidNumArgs),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParquetScan;
+
+#[async_trait]
+impl TableFunc for ParquetScan {
+    fn name(&self) -> &str {
+        "parquet_scan"
+    }
+
+    fn parameters(&self) -> &[TableFuncParameters] {
+        const PARAMS: &[TableFuncParameters] = &[TableFuncParameters {
+            params: &[TableFuncParameter {
+                name: "url",
+                typ: DataType::Utf8,
+            }],
+        }];
+
+        PARAMS
+    }
+
+    async fn create_provider(
+        &self,
+        _: &dyn TableFuncContextProvider,
+        args: Vec<ScalarValue>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        match args.len() {
+            // parquet_scan(url)
+            1 => {
+                let mut args = args.into_iter();
+                let url = string_from_scalar(args.next().unwrap())?;
+                let accessor = HttpAccessor::try_new(url)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?;
+                let prov = ParquetTableProvider::from_table_accessor(accessor, false)
+                    .await
+                    .unwrap();
+
+                Ok(Arc::new(prov))
+            }
+            _ => Err(BuiltinError::Unimplemented("invalid number of arguments")),
         }
     }
 }


### PR DESCRIPTION
closes #1098 

note: this is currently limited to `parquet` for a single file. 

Todo: 
- add support for an array of files `parquet_scan([...])`