### PR TITLE
fix: Don't return hidden data sets from bigquery

### DIFF
--- a/crates/datasources/src/bigquery/mod.rs
+++ b/crates/datasources/src/bigquery/mod.rs
@@ -174,10 +174,7 @@ impl VirtualLister for BigQueryAccessor {
         let datasets = self
             .metadata
             .dataset()
-            .list(
-                &self.gcp_project_id,
-                dataset::ListOptions::default().all(true),
-            )
+            .list(&self.gcp_project_id, dataset::ListOptions::default())
             .await
             .map_err(|e| ListingErrBoxed(Box::new(BigQueryError::from(e))))?;
 


### PR DESCRIPTION
The `all` option means return all data sets, including hidden ones. I believe it was put in originally with the intent to not paginate. However, `list` won't paginate any ways.

Closes https://github.com/GlareDB/glaredb/issues/1161