### PR TITLE
add support for reading from "file://" for `parquet_scan`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "tokio-postgres",
  "tonic",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ lto = "thin"
 [workspace.dependencies]
 datafusion = { version = "26.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs.git", branch = "main",features = ["s3", "gcs", "azure", "datafusion","arrow","parquet"] }
+url = "2.4.0"

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -46,5 +46,5 @@ tokio-postgres = { version = "0.7.8", features = ["with-uuid-1", "with-serde_jso
 tokio-rustls = "0.24.1"
 tracing = "0.1"
 uuid = "1.3.4"
-url = "2.4.0"
+url.workspace = true
 webpki-roots = "0.23.1"

--- a/crates/datasources/src/object_store/mod.rs
+++ b/crates/datasources/src/object_store/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use datafusion::datasource::TableProvider;
 use errors::ObjectStoreSourceError;
 use object_store::path::Path as ObjectStorePath;
 use object_store::{ObjectMeta, ObjectStore};
@@ -37,10 +38,12 @@ impl FromStr for FileType {
     }
 }
 
+#[async_trait::async_trait]
 pub trait TableAccessor: Send + Sync {
     fn store(&self) -> &Arc<dyn ObjectStore>;
 
     fn object_meta(&self) -> &Arc<ObjectMeta>;
+    async fn into_table_provider(self, predicate_pushdown: bool) -> Result<Arc<dyn TableProvider>>;
 }
 
 pub fn file_type_from_path(path: &ObjectStorePath) -> Result<FileType> {

--- a/crates/sqlbuiltins/Cargo.toml
+++ b/crates/sqlbuiltins/Cargo.toml
@@ -25,4 +25,4 @@ regex = "1.8"
 tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
 tokio-postgres = "0.7.8"
 once_cell = "1.18.0"
-
+url.workspace = true

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -16,6 +16,7 @@ use datasources::mysql::{MysqlAccessor, MysqlTableAccess};
 use datasources::object_store::gcs::{GcsAccessor, GcsTableAccess};
 use datasources::object_store::local::{LocalAccessor, LocalTableAccess};
 use datasources::object_store::s3::{S3Accessor, S3TableAccess};
+use datasources::object_store::TableAccessor;
 use datasources::postgres::{PostgresAccessor, PostgresTableAccess};
 use datasources::snowflake::{SnowflakeAccessor, SnowflakeDbConnection, SnowflakeTableAccess};
 use metastore::builtins::{


### PR DESCRIPTION
follow up from #1160. 

in addition to the `http`/`https` schemes, we also support `file://`

```sql
select * from parquet_scan('file://path/to/file.parquet');
```