### PR TITLE
feat: Stream writes to tables

### DIFF
--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -1,25 +1,22 @@
 use crate::native::errors::{NativeError, Result};
+use crate::native::insert::NativeTableInsertExec;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown, TableType};
-use datafusion::physical_plan::insert::{DataSink, InsertExec};
-use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{ExecutionPlan, Statistics};
 use datafusion::prelude::Expr;
 use deltalake::action::SaveMode;
 use deltalake::operations::create::CreateBuilder;
-use deltalake::operations::write::WriteBuilder;
 use deltalake::storage::DeltaObjectStore;
 use deltalake::{DeltaTable, DeltaTableConfig};
-use futures::StreamExt;
 use metastoreproto::types::catalog::TableEntry;
 use metastoreproto::types::options::{TableOptions, TableOptionsInternal};
 use object_store::prefix::PrefixStore;
 use object_store_util::{conf::StorageConfig, shared::SharedObjectStore};
 use std::any::Any;
-use std::fmt;
 use std::sync::Arc;
 use tokio::fs;
 use url::Url;
@@ -135,23 +132,19 @@ impl NativeTableStorage {
 
 #[derive(Debug)]
 pub struct NativeTable {
-    inner: Arc<NativeTableInner>,
-}
-
-#[derive(Debug)]
-struct NativeTableInner {
     delta: DeltaTable,
 }
 
+#[derive(Debug)]
+struct NativeTableInner {}
+
 impl NativeTable {
     fn new(delta: DeltaTable) -> Self {
-        NativeTable {
-            inner: Arc::new(NativeTableInner { delta }),
-        }
+        NativeTable { delta }
     }
 
     pub fn storage_location(&self) -> String {
-        self.inner.delta.table_uri()
+        self.delta.table_uri()
     }
 
     pub fn into_table_provider(self) -> Arc<dyn TableProvider> {
@@ -166,19 +159,19 @@ impl TableProvider for NativeTable {
     }
 
     fn schema(&self) -> Arc<ArrowSchema> {
-        TableProvider::schema(&self.inner.delta)
+        TableProvider::schema(&self.delta)
     }
 
     fn table_type(&self) -> TableType {
-        self.inner.delta.table_type()
+        self.delta.table_type()
     }
 
     fn get_table_definition(&self) -> Option<&str> {
-        self.inner.delta.get_table_definition()
+        self.delta.get_table_definition()
     }
 
     fn get_logical_plan(&self) -> Option<&LogicalPlan> {
-        self.inner.delta.get_logical_plan()
+        self.delta.get_logical_plan()
     }
 
     async fn scan(
@@ -188,10 +181,7 @@ impl TableProvider for NativeTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.inner
-            .delta
-            .scan(session, projection, filters, limit)
-            .await
+        self.delta.scan(session, projection, filters, limit).await
     }
 
     fn supports_filter_pushdown(
@@ -199,11 +189,11 @@ impl TableProvider for NativeTable {
         filter: &Expr,
     ) -> DataFusionResult<TableProviderFilterPushDown> {
         #[allow(deprecated)]
-        self.inner.delta.supports_filter_pushdown(filter)
+        self.delta.supports_filter_pushdown(filter)
     }
 
     fn statistics(&self) -> Option<Statistics> {
-        self.inner.delta.statistics()
+        self.delta.statistics()
     }
 
     async fn insert_into(
@@ -211,39 +201,8 @@ impl TableProvider for NativeTable {
         _state: &SessionState,
         input: Arc<dyn ExecutionPlan>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(InsertExec::new(input, self.inner.clone())))
-    }
-}
-
-impl fmt::Display for NativeTableInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = self
-            .delta
-            .state
-            .current_metadata()
-            .and_then(|m| m.name.as_deref())
-            .unwrap_or("unknown");
-        write!(f, "NativeTable: {}", name)
-    }
-}
-
-#[async_trait]
-impl DataSink for NativeTableInner {
-    async fn write_all(&self, mut data: SendableRecordBatchStream) -> DataFusionResult<u64> {
-        // TODO: Don't buffer everything in memory...
-        let mut batches = Vec::new();
-        while let Some(result) = data.next().await {
-            let batch = result?;
-            batches.push(batch);
-        }
-
-        let count = batches.iter().fold(0, |acc, batch| acc + batch.num_rows());
-
-        let builder = WriteBuilder::new(self.delta.object_store(), self.delta.state.clone())
-            .with_input_batches(batches);
-
-        let _ = builder.await?;
-
-        Ok(count as u64)
+        let store = self.delta.object_store();
+        let snapshot = self.delta.state.clone();
+        Ok(Arc::new(NativeTableInsertExec::new(input, store, snapshot)))
     }
 }

--- a/crates/datasources/src/native/insert.rs
+++ b/crates/datasources/src/native/insert.rs
@@ -1,0 +1,143 @@
+use datafusion::arrow::array::UInt64Array;
+use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayFormatType, Distribution, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+    Statistics,
+};
+use deltalake::action::SaveMode;
+use deltalake::operations::write::WriteBuilder;
+use deltalake::storage::DeltaObjectStore;
+use deltalake::table_state::DeltaTableState;
+use futures::StreamExt;
+use std::any::Any;
+use std::sync::Arc;
+
+/// An execution plan for inserting data into a delta table.
+#[derive(Debug)]
+pub struct NativeTableInsertExec {
+    input: Arc<dyn ExecutionPlan>,
+    store: Arc<DeltaObjectStore>,
+    snapshot: DeltaTableState,
+}
+
+impl NativeTableInsertExec {
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        store: Arc<DeltaObjectStore>,
+        snapshot: DeltaTableState,
+    ) -> Self {
+        NativeTableInsertExec {
+            input,
+            store,
+            snapshot,
+        }
+    }
+}
+
+fn output_schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+impl ExecutionPlan for NativeTableInsertExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        output_schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::UnspecifiedDistribution]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self {
+            input: children[0].clone(),
+            store: self.store.clone(),
+            snapshot: self.snapshot.clone(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(
+                format!("Invalid requested partition {partition}. NativeTableInsertExec requires a single input partition.")));
+        }
+
+        // Allows writing multiple output partitions from the input execution
+        // plan.
+        //
+        // TODO: Possibly try avoiding cloning the snapshot.
+        let builder = WriteBuilder::new(self.store.clone(), self.snapshot.clone())
+            .with_save_mode(SaveMode::Append)
+            .with_input_execution_plan(self.input.clone());
+
+        let input = self.input.clone();
+        let output = futures::stream::once(async move {
+            let _ = builder
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            let count = input
+                .metrics()
+                .map(|metrics| metrics.output_rows().unwrap_or_default())
+                .unwrap_or_default();
+
+            let arr = UInt64Array::from_value(count as u64, 1);
+            let batch = RecordBatch::try_new(output_schema(), vec![Arc::new(arr)])?;
+
+            Ok(batch)
+        })
+        .boxed();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            output,
+        )))
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(f, "NativeTableInsertExec")
+            }
+        }
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}

--- a/crates/datasources/src/native/mod.rs
+++ b/crates/datasources/src/native/mod.rs
@@ -3,3 +3,4 @@
 //! "Just" another data source that we happen to manage.
 pub mod access;
 pub mod errors;
+pub mod insert;

--- a/testdata/sqllogictests/table.slt
+++ b/testdata/sqllogictests/table.slt
@@ -1,0 +1,13 @@
+# Tests for creating and inserting into table.
+
+statement ok
+create table basic (a int, b text);
+
+statement ok
+insert into basic values (1, 'a'), (2, 'b');
+
+query IT rowsort
+select * from basic;
+----
+1  a
+2  b

--- a/testdata/sqllogictests_native/basic.slt
+++ b/testdata/sqllogictests_native/basic.slt
@@ -1,0 +1,27 @@
+# TODO: Enable when creating tables with timestamps works correctly.
+
+halt
+
+statement ok
+CREATE TABLE basic (
+  station_id        INT,
+  name              TEXT,
+  status            TEXT,
+  address           TEXT,
+  alternate_name    TEXT,
+  city_asset_number TEXT,
+  property_type     TEXT,
+  number_of_docks   INT,
+  power_type        TEXT,
+  footprint_length  INT,
+  footprint_width   REAL,
+  notes             TEXT,
+  council_district  INT,
+  modified_date     TIMESTAMP,
+)
+
+# TODO: Needs `read_csv` (or whatever we're calling it)
+statement ok
+INSERT INTO basic SELECT * FROM read_csv('file://${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv')
+
+include ${PWD}/testdata/sqllogictests_datasources_common/include/basic.slti


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/1150

No longer buffering in memory.

When timestamps are properly supported in create tables (see https://github.com/GlareDB/glaredb/issues/1157), we can reuse a lot of our existing slt stuff to add tests for this.