### PR TITLE
feat: add "csv_scan" function

### DIFF
--- a/crates/datasources/src/object_store/http.rs
+++ b/crates/datasources/src/object_store/http.rs
@@ -22,14 +22,14 @@ pub struct HttpAccessor {
 }
 
 impl HttpAccessor {
-    pub async fn try_new(url: String) -> Result<Self> {
+    pub async fn try_new(url: String, file_type: FileType) -> Result<Self> {
         let meta = object_meta_from_head(&url).await?;
         let builder = object_store::http::HttpBuilder::new();
         let store = builder.with_url(url).build()?;
         Ok(Self {
             store: Arc::new(store),
             meta: Arc::new(meta),
-            file_type: FileType::Parquet,
+            file_type,
         })
     }
 }
@@ -47,7 +47,7 @@ impl TableAccessor for HttpAccessor {
     async fn into_table_provider(self, _: bool) -> Result<Arc<dyn TableProvider>> {
         let table_provider: Arc<dyn TableProvider> = match self.file_type {
             FileType::Parquet => {
-                Arc::new(ParquetTableProvider::from_table_accessor(self, false).await?)
+                Arc::new(ParquetTableProvider::from_table_accessor(self, true).await?)
             }
             FileType::Csv => Arc::new(CsvTableProvider::from_table_accessor(self).await?),
         };

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -15,7 +15,6 @@ use datasources::common::listing::VirtualLister;
 use datasources::debug::DebugVirtualLister;
 use datasources::mongodb::{MongoAccessor, MongoTableAccessInfo};
 use datasources::mysql::{MysqlAccessor, MysqlTableAccess};
-use datasources::object_store::gcs::{GcsAccessor, GcsTableAccess};
 use datasources::object_store::http::HttpAccessor;
 use datasources::object_store::local::{LocalAccessor, LocalTableAccess};
 use datasources::object_store::{FileType, TableAccessor};

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -15,6 +15,7 @@ use datasources::common::listing::VirtualLister;
 use datasources::debug::DebugVirtualLister;
 use datasources::mongodb::{MongoAccessor, MongoTableAccessInfo};
 use datasources::mysql::{MysqlAccessor, MysqlTableAccess};
+use datasources::object_store::gcs::{GcsAccessor, GcsTableAccess};
 use datasources::object_store::http::HttpAccessor;
 use datasources::object_store::local::{LocalAccessor, LocalTableAccess};
 use datasources::object_store::{FileType, TableAccessor};
@@ -64,6 +65,7 @@ impl BuiltinTableFuncs {
             Arc::new(ReadMysql),
             Arc::new(ReadSnowflake),
             Arc::new(ParquetScan),
+            Arc::new(CsvScan),
             // Listing
             Arc::new(ListSchemas),
             Arc::new(ListTables),
@@ -496,42 +498,76 @@ impl TableFunc for ParquetScan {
         _: &dyn TableFuncContextProvider,
         args: Vec<ScalarValue>,
     ) -> Result<Arc<dyn TableProvider>> {
-        match args.len() {
-            // parquet_scan(url)
-            1 => {
-                let mut args = args.into_iter();
-                let url_string = string_from_scalar(args.next().unwrap())?;
-                let url = Url::parse(&url_string).map_err(|e| BuiltinError::Access(Box::new(e)))?;
-                Ok(match url.scheme() {
-                    "file" => {
-                        let table_access = LocalTableAccess {
-                            location: url.to_file_path().unwrap().to_str().unwrap().to_string(),
-                            file_type: Some(FileType::Parquet),
-                        };
-                        LocalAccessor::new(table_access)
-                            .await
-                            .map_err(|e| BuiltinError::Access(Box::new(e)))?
-                            .into_table_provider(false)
-                            .await
-                            .map_err(|e| BuiltinError::Access(Box::new(e)))?
-                    }
-                    "http" | "https" => HttpAccessor::try_new(url_string)
-                        .await
-                        .map_err(|e| BuiltinError::Access(Box::new(e)))?
-                        .into_table_provider(false)
-                        .await
-                        .map_err(|e| BuiltinError::Access(Box::new(e)))?,
-                    _ => return Err(BuiltinError::Static("Unsupported scheme")),
-                })
-            }
-            _ => Err(BuiltinError::InvalidNumArgs),
-        }
+        create_provider_for_filetype(FileType::Parquet, args).await
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CsvScan;
+
+#[async_trait]
+impl TableFunc for CsvScan {
+    fn name(&self) -> &str {
+        "csv_scan"
+    }
+
+    fn parameters(&self) -> &[TableFuncParameters] {
+        const PARAMS: &[TableFuncParameters] = &[TableFuncParameters {
+            params: &[TableFuncParameter {
+                name: "url",
+                typ: DataType::Utf8,
+            }],
+        }];
+
+        PARAMS
+    }
+
+    async fn create_provider(
+        &self,
+        _: &dyn TableFuncContextProvider,
+        args: Vec<ScalarValue>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        create_provider_for_filetype(FileType::Csv, args).await
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ListSchemas;
 
+async fn create_provider_for_filetype(
+    file_type: FileType,
+    args: Vec<ScalarValue>,
+) -> Result<Arc<dyn TableProvider>> {
+    match args.len() {
+        1 => {
+            let mut args = args.into_iter();
+            let url_string = string_from_scalar(args.next().unwrap())?;
+            let url = Url::parse(&url_string).map_err(|e| BuiltinError::Access(Box::new(e)))?;
+            Ok(match url.scheme() {
+                "file" => {
+                    let table_access = LocalTableAccess {
+                        location: url.to_file_path().unwrap().to_str().unwrap().to_string(),
+                        file_type: Some(file_type),
+                    };
+                    LocalAccessor::new(table_access)
+                        .await
+                        .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                        .into_table_provider(true)
+                        .await
+                        .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                }
+                "http" | "https" => HttpAccessor::try_new(url_string, file_type)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                    .into_table_provider(false)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?,
+                _ => return Err(BuiltinError::Static("Unsupported scheme")),
+            })
+        }
+        _ => Err(BuiltinError::InvalidNumArgs),
+    }
+}
 #[async_trait]
 impl TableFunc for ListSchemas {
     fn name(&self) -> &str {


### PR DESCRIPTION
can now read from csv''s both locally & remotely

```
〉select * from csv_scan('https://path/to/file.csv');
〉select * from csv_scan('file://path/to/file.csv');
```