### PR TITLE
chore: Remove native table inner

### DIFF
--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -135,9 +135,6 @@ pub struct NativeTable {
     delta: DeltaTable,
 }
 
-#[derive(Debug)]
-struct NativeTableInner {}
-
 impl NativeTable {
     fn new(delta: DeltaTable) -> Self {
         NativeTable { delta }


### PR DESCRIPTION
Unused