### PR TITLE
chore: Log error if failed to find catalog

### DIFF
--- a/crates/metastore/src/srv.rs
+++ b/crates/metastore/src/srv.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
-use tracing::info;
+use tracing::{error, info};
 use uuid::Uuid;
 
 /// Metastore GRPC service.
@@ -89,9 +89,13 @@ impl MetastoreService for Service {
             .map_err(|_| MetastoreError::InvalidDatabaseId(req.db_id))?;
         let catalogs = self.catalogs.read().await;
 
-        let catalog = catalogs
-            .get(&id)
-            .ok_or(MetastoreError::MissingCatalog(id))?;
+        let catalog = match catalogs.get(&id) {
+            Some(catalog) => catalog,
+            None => {
+                error!(%id, "missing catalog during fetch");
+                return Err(MetastoreError::MissingCatalog(id).into());
+            }
+        };
 
         let state = catalog.get_state().await?;
 
@@ -109,9 +113,13 @@ impl MetastoreService for Service {
             .map_err(|_| MetastoreError::InvalidDatabaseId(req.db_id))?;
 
         let catalogs = self.catalogs.read().await;
-        let catalog = catalogs
-            .get(&id)
-            .ok_or(MetastoreError::MissingCatalog(id))?;
+        let catalog = match catalogs.get(&id) {
+            Some(catalog) => catalog,
+            None => {
+                error!(%id, "missing catalog during mutate");
+                return Err(MetastoreError::MissingCatalog(id).into());
+            }
+        };
 
         let mutations = req
             .mutations


### PR DESCRIPTION
This happens rarely, and corresponds to redeploys of metastore. After some time, it does fix itself.

The fix is to fallback to loading the catalog from storage if it's not in the map. But before doing that, I think we should look at how we want to evict catalogs, because implementing that would solve this issue too.

The logging is really there to tell us how often this happens.