### PR TITLE
feat: Windows builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,16 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # See https://github.com/GlareDB/glaredb/issues/1030
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          # - os: ubuntu-2004-8-cores
-          #   target: x86_64-unknown-linux-gnu
-          # - os: macos-12-xl
-          #   target: x86_64-apple-darwin
-          # - os: macos-12-xl
-          #   target: aarch64-apple-darwin
-
+          - os: ubuntu-2004-8-cores
+            target: x86_64-unknown-linux-gnu
+          - os: macos-12-xl
+            target: x86_64-apple-darwin
+          - os: macos-12-xl
+            target: aarch64-apple-darwin
 
     name: Build release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -53,28 +51,32 @@ jobs:
           name: dist-${{ matrix.target }}
           path: ./target/dist/
 
-  # publish:
-  #   name: Publish
-  #   runs-on: ubuntu-latest
-  #   needs: ["dist"]
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: dist-aarch64-apple-darwin
-  #         path: dist
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: dist-x86_64-apple-darwin
-  #         path: dist
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: dist-x86_64-unknown-linux-gnu
-  #         path: dist
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: ["dist"]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-pc-windows-msvc 
+          path: dist
 
-  #     - run: ls -al ./dist
+      - run: ls -al ./dist
 
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: releases
-  #         path: ./dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: releases
+          path: ./dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
     - cron: 0 12 * * *
   workflow_dispatch:
   push:
+    branches:
+      - "sean/windows-builds"
     tags:
       - "*"
 
@@ -16,14 +18,14 @@ jobs:
       matrix:
         include:
           # See https://github.com/GlareDB/glaredb/issues/1030
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          - os: ubuntu-2004-8-cores
-            target: x86_64-unknown-linux-gnu
-          - os: macos-12-xl
-            target: x86_64-apple-darwin
-          - os: macos-12-xl
-            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          # - os: ubuntu-2004-8-cores
+          #   target: x86_64-unknown-linux-gnu
+          # - os: macos-12-xl
+          #   target: x86_64-apple-darwin
+          # - os: macos-12-xl
+          #   target: aarch64-apple-darwin
 
 
     name: Build release (${{ matrix.target }})
@@ -51,28 +53,28 @@ jobs:
           name: dist-${{ matrix.target }}
           path: ./target/dist/
 
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: ["dist"]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-aarch64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-unknown-linux-gnu
-          path: dist
+  # publish:
+  #   name: Publish
+  #   runs-on: ubuntu-latest
+  #   needs: ["dist"]
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist-aarch64-apple-darwin
+  #         path: dist
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist-x86_64-apple-darwin
+  #         path: dist
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist-x86_64-unknown-linux-gnu
+  #         path: dist
 
-      - run: ls -al ./dist
+  #     - run: ls -al ./dist
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: releases
-          path: ./dist
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: releases
+  #         path: ./dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-latest-8-cores
             target: x86_64-pc-windows-msvc
           - os: ubuntu-2004-8-cores
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,6 @@ on:
     - cron: 0 12 * * *
   workflow_dispatch:
   push:
-    branches:
-      - "sean/windows-builds"
     tags:
       - "*"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ All commits to `main` should first go through a PR. All CI checks should pass
 before merging in a PR. Since we squash merge, PR titles should follow
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
-## Development environemnt
+## Development environment
 
 Developing GlareDB requires that you have Rust and Cargo installed, along with
 some additional system dependencies:
@@ -24,6 +24,19 @@ docker run --rm --name my_scratch_postgres -p 5432:5432 -e POSTGRES_HOST_AUTH_ME
 ```
 
 See [Get Docker](https://docs.docker.com/get-docker/) for info on installing Docker (Desktop).
+
+## Platform support
+
+GlareDB aims to support the following platforms:
+
+- Windows (x86_64)
+- MacOS (x86_64 and Arm)
+- Linux (x86_64)
+
+Platform specific code should be kept to minimum. At the time of this writing,
+the only divergence is with SSH tunnels. The Linux and Mac code paths both use
+openssl, while the Windows code path is a stub that returns an "unsupported"
+error.
 
 ## Testing
 

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -27,7 +27,6 @@ mysql_common = { version = "0.30.6", features = ["chrono"] }
 object_store = { version = "0.5", features = ["gcp", "aws", "http"] }
 object_store_util = { path = "../object_store_util" }
 once_cell = "1.18.0"
-openssh = "0.9.9"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 repr = { path = "../repr" }
@@ -48,3 +47,7 @@ tracing = "0.1"
 uuid = "1.3.4"
 url.workspace = true
 webpki-roots = "0.23.1"
+
+# SSH tunnels
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+openssh = "0.9.9"

--- a/crates/datasources/src/common/errors.rs
+++ b/crates/datasources/src/common/errors.rs
@@ -1,28 +1,5 @@
 #[derive(Debug, thiserror::Error)]
 pub enum DatasourceCommonError {
-    /// Generic openssh errors.
-    ///
-    /// Using debug to get the underlying errors (the openssh crate doesn't keep
-    /// those in the message).
-    #[error("{0:?}")]
-    OpenSsh(#[from] openssh::Error),
-
-    #[error(transparent)]
-    SshKeyGen(#[from] ssh_key::Error),
-
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-
-    /// Port forward error with openssh.
-    ///
-    /// Using debug to get the underlying errors (the openssh crate doesn't keep
-    /// those in the message).
-    #[error("Cannot establish SSH tunnel: {0:?}")]
-    SshPortForward(openssh::Error),
-
-    #[error("Failed to find an open port to open the SSH tunnel")]
-    NoOpenPorts,
-
     #[error("Invalid SSH connection string: {0}")]
     SshConnectionParseError(String),
 

--- a/crates/datasources/src/common/errors.rs
+++ b/crates/datasources/src/common/errors.rs
@@ -26,6 +26,9 @@ pub enum DatasourceCommonError {
     #[error("Invalid SSH connection string: {0}")]
     SshConnectionParseError(String),
 
+    #[error("Feature currently unsupported: {0}")]
+    Unsupported(&'static str),
+
     #[error(transparent)]
     ListingErrBoxed(#[from] Box<dyn std::error::Error + Sync + Send>),
 

--- a/crates/datasources/src/common/ssh/key.rs
+++ b/crates/datasources/src/common/ssh/key.rs
@@ -1,0 +1,41 @@
+use ssh_key::{LineEnding, PrivateKey};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SshKeyError {
+    #[error(transparent)]
+    SshKeyGen(#[from] ssh_key::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct SshKey {
+    keypair: PrivateKey,
+}
+
+impl SshKey {
+    /// Generate a random Ed25519 ssh key pair.
+    pub fn generate_random() -> Result<Self, SshKeyError> {
+        let keypair = PrivateKey::random(rand::thread_rng(), ssh_key::Algorithm::Ed25519)?;
+        Ok(Self { keypair })
+    }
+
+    /// Recreate ssh key from bytes store in catalog.
+    pub fn from_bytes(keypair: &[u8]) -> Result<Self, SshKeyError> {
+        let keypair = PrivateKey::from_bytes(keypair)?;
+        Ok(Self { keypair })
+    }
+
+    /// Serialize sshk key as raw bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, SshKeyError> {
+        Ok(self.keypair.to_bytes()?.to_vec())
+    }
+
+    /// Create an OpenSSH-formatted public key as a String.
+    pub fn public_key(&self) -> Result<String, SshKeyError> {
+        Ok(self.keypair.public_key().to_openssh()?)
+    }
+
+    /// Create an OpenSSH-formatted private key as a String.
+    pub(crate) fn to_openssh(&self) -> Result<String, SshKeyError> {
+        Ok(self.keypair.to_openssh(LineEnding::default())?.to_string())
+    }
+}

--- a/crates/datasources/src/common/ssh/session.rs
+++ b/crates/datasources/src/common/ssh/session.rs
@@ -1,7 +1,6 @@
 use std::fs::Permissions;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::os::unix::prelude::PermissionsExt;
 use std::time::Duration;
 
 use tempfile::NamedTempFile;
@@ -35,6 +34,9 @@ pub enum SshTunnelError {
 
     #[error("Failed to find an open port to open the SSH tunnel")]
     NoOpenPorts,
+
+    #[error("SSH tunnels unsupported on this platform")]
+    Unsupported,
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -99,6 +101,7 @@ impl SshTunnelAccess {
 mod unix_impl {
     use super::*;
     use openssh::{ForwardType, KnownHosts, Session, SessionBuilder};
+    use std::os::unix::prelude::PermissionsExt;
 
     #[derive(Debug)]
     pub struct SshTunnelSessionImpl(pub(super) Session);
@@ -239,6 +242,6 @@ mod not_unix_impl {
     where
         T: ToSocketAddrs,
     {
-        Err(DatasourceCommonError::Unsupported("SSH tunnels on windows"))
+        Err(SshTunnelError::Unsupported)
     }
 }

--- a/crates/datasources/src/common/ssh/session.rs
+++ b/crates/datasources/src/common/ssh/session.rs
@@ -18,6 +18,7 @@ pub enum SshTunnelError {
     ///
     /// Using debug to get the underlying errors (the openssh crate doesn't keep
     /// those in the message).
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[error("{0:?}")]
     OpenSsh(#[from] openssh::Error),
 
@@ -25,6 +26,7 @@ pub enum SshTunnelError {
     ///
     /// Using debug to get the underlying errors (the openssh crate doesn't keep
     /// those in the message).
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[error("Cannot establish SSH tunnel: {0:?}")]
     SshPortForward(openssh::Error),
 

--- a/crates/datasources/src/common/ssh/session.rs
+++ b/crates/datasources/src/common/ssh/session.rs
@@ -1,0 +1,172 @@
+use std::fmt::Display;
+use std::fs::Permissions;
+use std::io;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::os::unix::prelude::PermissionsExt;
+use std::str::FromStr;
+use std::time::Duration;
+
+use ssh_key::{LineEnding, PrivateKey};
+use tempfile::NamedTempFile;
+use tokio::fs;
+use tokio::fs::File;
+use tokio::net::TcpListener;
+use tracing::{debug, trace};
+
+use crate::common::errors::{DatasourceCommonError, Result};
+use crate::common::ssh::SshKey;
+
+#[derive(Debug)]
+pub struct SshTunnelSession {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    inner: unix_impl::SshTunnelSessionImpl,
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    inner: not_unix_impl::SshTunnelSessionImpl,
+}
+
+#[derive(Debug, Clone)]
+pub struct SshTunnelAccess {
+    pub connection_string: String,
+    pub keypair: SshKey,
+}
+
+impl SshTunnelAccess {
+    /// Create an ssh tunnel using port fowarding from a random local port to
+    /// the host specified in `connection_string`.
+    pub async fn create_tunnel<T>(&self, remote_addr: &T) -> Result<(SshTunnelSession, SocketAddr)>
+    where
+        T: ToSocketAddrs,
+    {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let (inner, addr) =
+            unix_impl::create_tunnel(remote_addr, &self.connection_string, &self.keypair).await?;
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let (inner, addr) =
+            not_unix_impl::create_tunnel(remote_addr, &self.connection_string, &self.keypair)
+                .await?;
+        Ok((SshTunnelSession { inner }, addr))
+    }
+}
+
+/// Unix implementation for the ssh tunnel. This implementation is tested and
+/// what's exposed in Cloud.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod unix_impl {
+    use super::*;
+    use openssh::{ForwardType, KnownHosts, Session, SessionBuilder};
+
+    #[derive(Debug)]
+    pub struct SshTunnelSessionImpl(pub(super) Session);
+
+    pub(super) async fn create_tunnel<T>(
+        remote_addr: &T,
+        connection_str: &str,
+        keypair: &SshKey,
+    ) -> Result<(SshTunnelSessionImpl, SocketAddr)>
+    where
+        T: ToSocketAddrs,
+    {
+        let temp_keyfile = generate_temp_keyfile(keypair.to_openssh()?.as_ref()).await?;
+
+        let tunnel = SessionBuilder::default()
+            .known_hosts_check(KnownHosts::Accept)
+            .keyfile(temp_keyfile.path())
+            // Set control directory explicitly. Otherwise we run the the
+            // chance of an error like the following:
+            //
+            // 'path ... too long for Unix domain socket'
+            .control_directory(std::env::temp_dir())
+            // Wait 15 seconds before timing out ssh connection attempt
+            .connect_timeout(Duration::from_secs(15))
+            .connect(connection_str)
+            .await?;
+
+        // Check the status of the connection before proceeding.
+        tunnel.check().await?;
+
+        // Find open local port and attempt to create tunnel
+        // Retry generating a port up to 10 times
+        for _ in 0..10 {
+            let local_addr = generate_random_port().await?;
+
+            let local = openssh::Socket::new(&local_addr)?;
+            let remote = openssh::Socket::new(remote_addr)?;
+
+            match tunnel
+                .request_port_forward(ForwardType::Local, local, remote)
+                .await
+            {
+                // Tunnel successfully created
+                Ok(()) => return Ok((SshTunnelSessionImpl(tunnel), local_addr)),
+                Err(err) => match err {
+                    openssh::Error::Ssh(err)
+                        if err.to_string().contains("forwarding request failed") =>
+                    {
+                        debug!("port already in use, testing another port");
+                    }
+                    e => {
+                        return Err(DatasourceCommonError::SshPortForward(e));
+                    }
+                },
+            };
+        }
+        // If unable to find a port after 10 attempts
+        Err(DatasourceCommonError::NoOpenPorts)
+    }
+
+    /// Generate temproary keyfile using the given private_key
+    async fn generate_temp_keyfile(private_key: &str) -> Result<NamedTempFile> {
+        let temp_keyfile = tempfile::Builder::new()
+            .prefix("ssh_tunnel_key-")
+            .tempfile()?;
+        trace!(temp_keyfile = ?temp_keyfile.path(), "Temporary keyfile location");
+
+        let keyfile = File::open(&temp_keyfile.path()).await?;
+        // Set keyfile to only owner read and write permissions
+        keyfile
+            .set_permissions(Permissions::from_mode(0o600))
+            .await?;
+
+        fs::write(temp_keyfile.path(), private_key.as_bytes()).await?;
+
+        // Remove write permission from file to prevent clobbering
+        keyfile
+            .set_permissions(Permissions::from_mode(0o400))
+            .await?;
+
+        Ok(temp_keyfile)
+    }
+
+    /// Generate random port using operating system by using port 0.
+    async fn generate_random_port() -> Result<SocketAddr, io::Error> {
+        // The 0 port indicates to the OS to assign a random port
+        let listener = TcpListener::bind("localhost:0").await.map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to bind to a random port due to {e}"),
+            )
+        })?;
+        listener.local_addr()
+    }
+}
+
+/// A stub implementation that returns always returns unsupported errors when
+/// trying to create a tunnel.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod not_unix_impl {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct SshTunnelSessionImpl;
+
+    pub(super) async fn create_tunnel<T>(
+        remote_addr: &T,
+        connection_str: &str,
+        keypair: &SshKey,
+    ) -> Result<(SshTunnelSessionImpl, SocketAddr)>
+    where
+        T: ToSocketAddrs,
+    {
+        Err(DatasourceCommonError::Unsupported("SSH tunnels on windows"))
+    }
+}

--- a/crates/datasources/src/mysql/errors.rs
+++ b/crates/datasources/src/mysql/errors.rs
@@ -13,9 +13,6 @@ pub enum MysqlError {
     Arrow(#[from] datafusion::arrow::error::ArrowError),
 
     #[error(transparent)]
-    Ssh(#[from] crate::common::errors::DatasourceCommonError),
-
-    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
@@ -32,6 +29,14 @@ pub enum MysqlError {
 
     #[error(transparent)]
     ConnectionUrl(#[from] mysql_async::UrlError),
+
+    #[error(transparent)]
+    Common(#[from] crate::common::errors::DatasourceCommonError),
+
+    #[error(transparent)]
+    SshKey(#[from] crate::common::ssh::key::SshKeyError),
+    #[error(transparent)]
+    SshTunnel(#[from] crate::common::ssh::session::SshTunnelError),
 }
 
 pub type Result<T, E = MysqlError> = std::result::Result<T, E>;

--- a/crates/datasources/src/mysql/mod.rs
+++ b/crates/datasources/src/mysql/mod.rs
@@ -136,7 +136,6 @@ impl MysqlAccessor {
         Ok((conn, None))
     }
 
-    // TODO: Add ssh tunnel support for MySQL
     async fn connect_with_ssh_tunnel(
         connection_string: &str,
         ssh_tunnel: SshTunnelAccess,

--- a/crates/datasources/src/postgres/errors.rs
+++ b/crates/datasources/src/postgres/errors.rs
@@ -27,9 +27,6 @@ pub enum PostgresError {
     #[error(transparent)]
     Arrow(#[from] datafusion::arrow::error::ArrowError),
 
-    #[error("Failed to create SSH Tunnel: {0}")]
-    Ssh(#[from] crate::common::errors::DatasourceCommonError),
-
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
@@ -41,6 +38,14 @@ pub enum PostgresError {
 
     #[error(transparent)]
     DecimalError(#[from] decimal::DecimalError),
+
+    #[error(transparent)]
+    Common(#[from] crate::common::errors::DatasourceCommonError),
+
+    #[error(transparent)]
+    SshKey(#[from] crate::common::ssh::key::SshKeyError),
+    #[error(transparent)]
+    SshTunnel(#[from] crate::common::ssh::session::SshTunnelError),
 }
 
 pub type Result<T, E = PostgresError> = std::result::Result<T, E>;

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -4,7 +4,8 @@ mod tls;
 
 use crate::common::errors::DatasourceCommonError;
 use crate::common::listing::VirtualLister;
-use crate::common::ssh::{SshKey, SshTunnelAccess};
+use crate::common::ssh::session::SshTunnelSession;
+use crate::common::ssh::{key::SshKey, session::SshTunnelAccess};
 use crate::common::util;
 use async_trait::async_trait;
 use chrono::naive::{NaiveDateTime, NaiveTime};
@@ -218,7 +219,7 @@ impl PostgresAccessor {
 
         fn spawn_conn<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
             conn: Connection<TcpStream, T>,
-            session: openssh::Session,
+            session: SshTunnelSession,
         ) -> JoinHandle<()> {
             tokio::spawn(async move {
                 if let Err(e) = conn.await {

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -8,7 +8,7 @@ use datafusion::datasource::MemTable;
 use datafusion::datasource::TableProvider;
 use datafusion::datasource::ViewTable;
 use datasources::bigquery::{BigQueryAccessor, BigQueryTableAccess};
-use datasources::common::ssh::{SshConnectionParameters, SshKey};
+use datasources::common::ssh::{key::SshKey, SshConnectionParameters};
 use datasources::debug::DebugTableType;
 use datasources::delta::access::DeltaLakeAccessor;
 use datasources::mongodb::{MongoAccessor, MongoTableAccessInfo};
@@ -87,6 +87,8 @@ pub enum DispatchError {
     NativeDatasource(#[from] datasources::native::errors::NativeError),
     #[error(transparent)]
     CommonDatasource(#[from] datasources::common::errors::DatasourceCommonError),
+    #[error(transparent)]
+    SshKey(#[from] datasources::common::ssh::key::SshKeyError),
 }
 
 impl DispatchError {

--- a/crates/sqlexec/src/planner/errors.rs
+++ b/crates/sqlexec/src/planner/errors.rs
@@ -65,6 +65,9 @@ pub enum PlanError {
     DatasourceCommon(#[from] datasources::common::errors::DatasourceCommonError),
 
     #[error(transparent)]
+    SshKey(#[from] datasources::common::ssh::key::SshKeyError),
+
+    #[error(transparent)]
     ParseError(#[from] datafusion::sql::sqlparser::parser::ParserError),
 
     #[error(transparent)]

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -18,7 +18,7 @@ use datafusion::sql::sqlparser::ast::{self, Ident, ObjectName, ObjectType};
 use datafusion::sql::TableReference;
 use datafusion_planner::planner::SqlQueryPlanner;
 use datasources::bigquery::{BigQueryAccessor, BigQueryTableAccess};
-use datasources::common::ssh::{SshConnection, SshConnectionParameters, SshKey};
+use datasources::common::ssh::{key::SshKey, SshConnection, SshConnectionParameters};
 use datasources::debug::DebugTableType;
 use datasources::delta::access::DeltaLakeAccessor;
 use datasources::mongodb::{MongoAccessor, MongoDbConnection, MongoProtocol};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,7 +113,7 @@ fn run_fmt_check(sh: &Shell) -> Result<()> {
 
 fn run_dist(sh: &Shell, target: &Target) -> Result<()> {
     let triple = target.dist_target_triple()?;
-    cmd!(sh, "cargo build --bin glaredb --target {triple}").run()?;
+    cmd!(sh, "cargo build --release --bin glaredb --target {triple}").run()?;
 
     // TODO: Code signing goes here.
 
@@ -123,7 +123,7 @@ fn run_dist(sh: &Shell, target: &Target) -> Result<()> {
     let src_path = util::project_root()
         .join("target")
         .join(target.dist_target_triple()?)
-        .join("debug")
+        .join("release")
         .join(target.executable_name());
     let dest_path = util::project_root()
         .join("target")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -124,7 +124,7 @@ fn run_dist(sh: &Shell, target: &Target) -> Result<()> {
         .join("target")
         .join(target.dist_target_triple()?)
         .join("debug")
-        .join("glaredb");
+        .join(target.executable_name());
     let dest_path = util::project_root()
         .join("target")
         .join("dist")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,7 +113,7 @@ fn run_fmt_check(sh: &Shell) -> Result<()> {
 
 fn run_dist(sh: &Shell, target: &Target) -> Result<()> {
     let triple = target.dist_target_triple()?;
-    cmd!(sh, "cargo build --release --bin glaredb --target {triple}").run()?;
+    cmd!(sh, "cargo build --bin glaredb --target {triple}").run()?;
 
     // TODO: Code signing goes here.
 
@@ -123,7 +123,7 @@ fn run_dist(sh: &Shell, target: &Target) -> Result<()> {
     let src_path = util::project_root()
         .join("target")
         .join(target.dist_target_triple()?)
-        .join("release")
+        .join("debug")
         .join("glaredb");
     let dest_path = util::project_root()
         .join("target")

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -51,6 +51,13 @@ impl Target {
         let target = self.dist_target_triple()?;
         Ok(format!("glaredb-{target}.zip"))
     }
+
+    pub fn executable_name(&self) -> &'static str {
+        match self.os {
+            Os::Windows => "glaredb.exe",
+            Os::Mac | Os::Linux => "glaredb",
+        }
+    }
 }
 
 enum Arch {


### PR DESCRIPTION
- Closes #1030
- Closes #1053

Add windows builds to the release yaml. 

To accomplish this, we need to conditionally compile in openssh, which impacts the ssh tunnels feature. On linux and mac, this continues to work as expected, while the windows code path will always return an error when attempting to create a tunnel.

This required a small amount of refactoring, and I tried to keep the conditional compilation to a single file. I also needed to tweak the cargo.toml to avoid pulling openssh if we're building on a platform that it doesn't support.

Conditional compilation is currently based on checking the target os, and not on adding a cargo feature. Longer term, we may want to put ssh tunnels behind its own flag, and enable/disable depending on the platform we're building for. I opted not to do that now because I'm unsure what we would want that to look like. Checking target os seemed like the quickest solution for now.

The executable successfully builds, but I have not actually tried running it on a windows machine...