### PR TITLE
remove python dep from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.69-bookworm AS builder
 WORKDIR /usr/src/glaredb
 COPY . .
 
-RUN apt-get update && apt-get install -y openssl ca-certificates python3-dev
+RUN apt-get update && apt-get install -y openssl ca-certificates
 
 # Build release binary.
 RUN cargo xtask build --release


### PR DESCRIPTION
#1198 made it so we no longer need this in our dockerfile. 