### PR TITLE
feat: Add pandas support

### DIFF
--- a/py-glaredb/examples/pandas_interop.py
+++ b/py-glaredb/examples/pandas_interop.py
@@ -1,0 +1,17 @@
+import glaredb
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "A": [1, 2, 3, 4, 5],
+        "fruits": ["banana", "banana", "apple", "apple", "banana"],
+        "B": [5, 4, 3, 2, 1],
+        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+    }
+)
+
+con = glaredb.connect("/tmp/testing")
+
+df = con.sql("select * from df where fruits = 'banana'").to_pandas();
+
+print(df)

--- a/py-glaredb/src/environment.rs
+++ b/py-glaredb/src/environment.rs
@@ -3,6 +3,7 @@ use datafusion::{
     arrow::{pyarrow::PyArrowType, record_batch::RecordBatch},
     datasource::TableProvider,
 };
+use pyo3::types::PyTuple;
 use pyo3::{prelude::*, types::PyType};
 use sqlexec::environment::EnvironmentReader;
 use std::sync::Arc;
@@ -24,11 +25,17 @@ impl EnvironmentReader for PyEnvironmentReader {
                 Err(_) => return Ok(None),
             };
 
+            // Polars
             if let Some(table) = resolve_polars(py, var).map_err(Box::new)? {
                 return Ok(Some(table));
             }
 
-            // TODO: Other data frame types.
+            // Pandas
+            if let Some(table) = resolve_pandas(py, var).map_err(Box::new)? {
+                return Ok(Some(table));
+            }
+
+            // Add other data frame types here.
 
             // Variable isn't one of the data frames that we support.
             Ok(None)
@@ -53,6 +60,38 @@ fn resolve_polars(py: Python, var: &PyAny) -> PyResult<Option<Arc<dyn TableProvi
     let arrow = var.call_method0("to_arrow").unwrap();
     let batches = arrow.call_method0("to_batches").unwrap();
     let batches = batches.extract::<PyArrowType<Vec<RecordBatch>>>().unwrap();
+    let batches = batches.0;
+
+    let schema = batches[0].schema();
+
+    let table = MemTable::try_new(schema, vec![batches]).unwrap();
+
+    Ok(Some(Arc::new(table) as Arc<dyn TableProvider>))
+}
+
+/// Try to resolve a variable as a pandas data frame.
+///
+/// Returns `Ok(None)` if the variable isn't a pandas data frame.
+fn resolve_pandas(py: Python, var: &PyAny) -> PyResult<Option<Arc<dyn TableProvider>>> {
+    let pandas_type: &PyType = py
+        .import("pandas")?
+        .getattr("DataFrame")?
+        .downcast()
+        .unwrap();
+
+    if !var.is_instance(pandas_type).unwrap() {
+        return Ok(None);
+    }
+
+    let args = PyTuple::new(py, [var]);
+    let table: PyObject = py
+        .import("pyarrow")?
+        .getattr("Table")?
+        .call_method1("from_pandas", args)?
+        .into();
+
+    let batches = table.call_method0(py, "to_batches")?;
+    let batches = batches.extract::<PyArrowType<Vec<RecordBatch>>>(py)?;
     let batches = batches.0;
 
     let schema = batches[0].schema();


### PR DESCRIPTION
Adds support for reading and writing to pandas data frames.

```python
import glaredb
import pandas as pd

df = pd.DataFrame(
    {
        "A": [1, 2, 3, 4, 5],
        "fruits": ["banana", "banana", "apple", "apple", "banana"],
        "B": [5, 4, 3, 2, 1],
        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
    }
)

con = glaredb.connect("/tmp/testing")

df = con.sql("select * from df where fruits = 'banana'").to_pandas();

print(df)
```

Output:

```
   A  fruits  B    cars
0  1  banana  5  beetle
1  2  banana  4    audi
2  5  banana  1  beetle
```