### PR TITLE
chore: Add slt tests for parquet_scan and csv_scan

### DIFF
--- a/testdata/sqllogictests/functions/csv_scan.slt
+++ b/testdata/sqllogictests/functions/csv_scan.slt
@@ -1,0 +1,19 @@
+# Tests `csv_scan`
+
+# Absolute path
+query I
+select count(*) from csv_scan('file://${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv')
+----
+102
+
+# # Relative path
+# query I
+# select count(*) from csv_scan('./testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv')
+# ----
+# 102
+
+# # Remote path
+# query I
+# select count(*) from csv_scan('https://github.com/GlareDB/glaredb/blob/main/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv');
+# ----
+# 102

--- a/testdata/sqllogictests/functions/parquet_scan.slt
+++ b/testdata/sqllogictests/functions/parquet_scan.slt
@@ -1,0 +1,19 @@
+# Tests `parquet_scan`
+
+# Absolute path
+query I
+select count(*) from parquet_scan('file://${PWD}/testdata/parquet/userdata1.parquet')
+----
+1000
+
+# # Relative path
+# query I
+# select count(*) from parquet_scan('./testdata/parquet/userdata1.parquet')
+# ----
+# 1000
+
+# Remote path
+query I
+select count(*) from parquet_scan('https://github.com/GlareDB/glaredb/raw/main/testdata/parquet/userdata1.parquet');
+----
+1000


### PR DESCRIPTION
Commented out ones that don't work as they're written.

Relative paths (both csv and parquet):

```
2023-06-28T00:23:15.631409Z ERROR                 main ThreadId(01) testing::slt::cli: crates/testing/src/slt/cli.rs:249: Error while running test `sqllogictests/functions/parquet_scan` error=test fail: query failed: db error: ERROR: Error during planning: Failed to canonicalize path "./testdata/parquet/userdata1.parquet": No such file or directory (os error 2)
[SQL] select count(*) from parquet_scan('./testdata/parquet/userdata1.parquet')
at /Users/sean/Code/github.com/glaredb/glaredb/testdata/sqllogictests/functions/parquet_scan.slt:10

Error: Test failures
error: test failed, to rerun pass `-p testing --test sqllogictests`
```

Remote csv:

```
2023-06-28T00:24:19.913234Z ERROR                 main ThreadId(01) testing::slt::cli: crates/testing/src/slt/cli.rs:249: Error while running test `sqllogictests/functions/csv_scan` error=test fail: query failed: db error: ERROR: Error during planning: Execution error: Encountered unequal lengths between records on CSV file whilst inferring schema. Expected 1 records, found 367 records
[SQL] select count(*) from csv_scan('https://github.com/GlareDB/glaredb/blob/main/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv');
at /Users/sean/Code/github.com/glaredb/glaredb/testdata/sqllogictests/functions/csv_scan.slt:16

Error: Test failures
error: test failed, to rerun pass `-p testing --test sqllogictests`
```