### PR TITLE
feat: Make data dir optional in python bindings

### DIFF
--- a/py-glaredb/examples/multiple.py
+++ b/py-glaredb/examples/multiple.py
@@ -1,0 +1,19 @@
+import glaredb
+import polars as pl
+
+con1 = glaredb.connect()
+con1.sql("create table hello (a int)").to_polars();
+
+t1 = con1.sql("select * from glare_catalog.tables where table_name = 'hello'").to_polars();
+print(t1)
+
+con2 = glaredb.connect()
+con2.sql("create table hello (a int)").to_polars();
+
+t2 = con2.sql("select * from glare_catalog.tables where table_name = 'hello'").to_polars();
+print(t2)
+
+try:
+    con2.sql("create table hello (a int)").to_polars();
+except Exception:
+    print("Duplicate table failed as expected")

--- a/py-glaredb/examples/pandas_interop.py
+++ b/py-glaredb/examples/pandas_interop.py
@@ -10,7 +10,7 @@ df = pd.DataFrame(
     }
 )
 
-con = glaredb.connect("/tmp/testing")
+con = glaredb.connect()
 
 df = con.sql("select * from df where fruits = 'banana'").to_pandas();
 

--- a/py-glaredb/examples/polars_interop.py
+++ b/py-glaredb/examples/polars_interop.py
@@ -10,7 +10,7 @@ df = pl.DataFrame(
     }
 )
 
-con = glaredb.connect("/tmp/testing")
+con = glaredb.connect()
 
 df = con.sql("select * from df where fruits = 'banana'").to_polars();
 


### PR DESCRIPTION
If provided, both table storage and metastore storage will write to this directory. Otherwise, everything will be in memory.

Also sets up spill path too.