### PR TITLE
chore: Set linker args for mac

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,15 @@
 dev = "run --bin glaredb --"
 xtask = "run --package xtask --"
 x = "run --quiet --package xtask --"
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Got it from here: https://pyo3.rs/v0.14.2/building_and_distribution.html#macos

Seems to fix the linker errors I was getting:

```
  = note: Undefined symbols for architecture arm64:
            "_PyBaseObject_Type", referenced from:
                _$LT$pyo3..types..any..PyAny$u20$as$u20$pyo3..type_object..PyTypeInfo$GT$::type_object_raw::ha89349ffaf7852ac in glaredb.2nxyhvrysb5kk1fk.rcgu.o
                _$LT$pyo3..pycell..PyCellBase$LT$U$GT$$u20$as$u20$pyo3..pycell..PyCellLayout$LT$T$GT$$GT$::tp_dealloc::hd02abd12265be509 in glaredb.309oreo1qy209inq.rcgu.o
                _$LT$pyo3..pyclass_init..PyNativeTypeInitializer$LT$T$GT$$u20$as$u20$pyo3..pyclass_init..PyObjectInit$LT$T$GT$$GT$::into_new_object::inner::h075e55961232443a in libpyo3-d33e106cb6629124.rlib(pyo3-d33e106cb6629124.pyo3.fc164f1e-cgu.11.rcgu.o)
```