### PR TITLE
refactor: xtask --> justfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - cory/justfile
   pull_request:
   workflow_dispatch:
 
@@ -24,22 +25,21 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
-
+      - uses: extractions/setup-just@v1
       - name: Build
-        run: |
-          cargo xtask build
+        run: just build
 
       - name: Unit Tests
-        run: cargo xtask unit-tests
+        run: just unit-tests
 
       - name: Doc Tests
-        run: cargo xtask doc-tests
+        run: just doc-tests
 
       - name: Clippy
-        run: cargo xtask clippy
+        run: just clippy
 
       - name: Format
-        run: cargo xtask fmt-check
+        run: just fmt-check
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
@@ -112,8 +112,8 @@ jobs:
           # Prepare SLT (MongoDB)
           export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
 
-          cargo xtask sql-logic-tests -- -v --exclude '*/tunnels/ssh'
-          cargo xtask sql-logic-tests -- -v '*/tunnels/ssh'
+          just sql-logic-tests -- -v --exclude '*/tunnels/ssh'
+          just sql-logic-tests -- -v '*/tunnels/ssh'
 
       - name: Protocol Tests
         run: ./scripts/protocol-test.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - cory/justfile
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -24,8 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v1
       - name: install protoc
-        run: cargo xtask protoc
+        run: |
+          just protoc
+          export PROTOC="deps/protoc/bin/protoc"
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -52,7 +55,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: install protoc
-        run: cargo xtask protoc
+        run: |
+          just protoc
+          export PROTOC="deps/protoc/bin/protoc"
 
       - uses: actions/setup-python@v4
         with:
@@ -83,7 +88,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: install protoc
-        run: cargo xtask protoc
+        run: |
+          just protoc
+          export PROTOC="deps/protoc/bin/protoc"
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -26,9 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: extractions/setup-just@v1
       - name: install protoc
-        run: |
-          just protoc
-          export PROTOC="deps/protoc/bin/protoc"
+        run: just protoc
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -54,10 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v1
       - name: install protoc
-        run: |
-          just protoc
-          export PROTOC="deps/protoc/bin/protoc"
+        run: just protoc
 
       - uses: actions/setup-python@v4
         with:
@@ -87,10 +84,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v1
       - name: install protoc
-        run: |
-          just protoc
-          export PROTOC="deps/protoc/bin/protoc"
+        run: just protoc
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build
-        run: cargo xtask dist
+        run: just dist
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Unit tests attempt to test small parts of the system. These can be ran via
 cargo:
 
 ``` shell
-cargo xtask unit-tests
+just unit-tests
 ```
 
 When writing unit tests, aims to keep the scope small with a minimal amount of

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /usr/src/glaredb
 COPY . .
 
 RUN apt-get update && apt-get install -y openssl ca-certificates
-
+RUN cargo install just
 # Build release binary.
-RUN cargo xtask build --release
+RUN just build --release
 
 # Generate certs.
 RUN ./scripts/gen-certs.sh

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ an easy way to install Rust on your system.
 Running the following command will build a release binary:
 
 ```shell
-cargo xtask build --release
+just build --release
 ```
 
 The compiled release binary can be found in `target/release/glaredb`.

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # Shows help command
 default: help
 export CARGO_TERM_COLOR := "always"
-
+export PROTOC := justfile_directory() + "/deps/protoc/bin/protoc"
 alias py := python
 alias slt := sql-logic-tests
 
@@ -66,21 +66,18 @@ help:
 
 protoc:
   #!/bin/bash
-  if ! protoc --version > /dev/null; then 
+  if ! $PROTOC --version > /dev/null; then 
     echo "Installing protoc..." && \
     curl -L {{protoc_url}} -o protoc.zip && \
     rm -rf deps/protoc && \
     mkdir -p deps/ && \
     unzip -o protoc.zip -d deps/protoc && \
     rm protoc.zip
-    
   fi
 
 
 # private helpers below
 # ---------------------
-
-
 
 default_target_triple := if os_arch == "macos-x86_64" {
   "x86_64-apple-darwin"

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 # Build glaredb.
 default: build
+export CARGO_TERM_COLOR := "always"
 
 alias py := python
-
 os_arch := os() + '-' + arch()
 
   
@@ -67,7 +67,7 @@ help:
 # ---------------------
 
 [private]
-protoc: setenv
+protoc:
   #!/bin/bash
   if ! protoc --version > /dev/null; then 
     echo "Installing protoc..." && \
@@ -78,9 +78,6 @@ protoc: setenv
     rm protoc.zip
   fi
 
-[private]
-setenv:
-  @export CARGO_TERM_COLOR=always
 
 default_target_triple := if os_arch == "macos-x86_64" {
   "x86_64-apple-darwin"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,114 @@
+# Build glaredb.
+default: build
+
+alias py := python
+
+os_arch := os() + '-' + arch()
+
+  
+# Run py-glaredb subcommands. see `py-glaredb/justfile` for more details.
+python cmd *args: protoc
+  just py-glaredb/{{cmd}} {{args}}
+
+# Run glaredb server
+run *args: protoc
+  cargo run --bin glaredb {{args}}
+
+# Build glaredb.
+build *args: protoc
+  cargo build --bin glaredb {{args}}
+
+
+# A zip archive will be placed in `target/dist` containing the release binary.
+
+# Build the dist binary for release. The target can be overridden by passing in a target triple.
+dist triple=target_triple: protoc
+  #!/usr/bin/env bash
+  set -euo pipefail
+  just build --release --target {{triple}}
+  src_path="target/{{triple}}/release/{{executable_name}}"
+  dest_path="target/dist/glaredb-{{triple}}.zip"
+  zip -j $dest_path $src_path
+
+# Run tests with arbitrary arguments.
+test *args: protoc
+  cargo test {{args}}
+
+# Run unit tests.
+unittests: protoc
+  just test --lib --bins
+
+# Run doc tests.
+doctests: protoc
+  just test --doc
+
+# Run SQL Logic Tests.
+slt *args: protoc
+  just test --test sqllogictests {{args}}
+
+#  Check formatting.
+fmt-check: protoc
+  cargo fmt -- --check
+
+# Apply formatting.
+fmt *args: protoc
+  cargo fmt *args
+
+# Run clippy.
+clippy: protoc
+  cargo clippy --all-features -- --deny warnings
+
+# Displays help message.
+help: 
+  @just --list
+
+
+# private helpers below
+# ---------------------
+
+[private]
+protoc: setenv
+  #!/bin/bash
+  if ! protoc --version > /dev/null; then 
+    echo "Installing protoc..." && \
+    curl -L {{protoc_url}} -o protoc.zip && \
+    rm -rf deps/protoc && \
+    mkdir -p deps/ && \
+    unzip -o protoc.zip -d deps/protoc && \
+    rm protoc.zip
+  fi
+
+[private]
+setenv:
+  @export CARGO_TERM_COLOR=always
+
+default_target_triple := if os_arch == "macos-x86_64" {
+  "x86_64-apple-darwin"
+} else if os_arch == 'macos-aarch64' {
+  "aarch64-apple-darwin"
+} else if os_arch == "linux-x86_64" {
+  "x86_64-unknown-linux-gnu"
+} else if os_arch == "linux-aarch64" {
+  "aarch64-unknown-linux-gnu"
+} else if os_arch == "windows-x86_64" {
+  "x86_64-pc-windows-msvc"
+} else {
+  error("Unsupported platform: " + os_arch)
+}
+target_triple:= env_var_or_default("DIST_TARGET_TRIPLE", default_target_triple)
+
+protoc_url := if os_arch == "macos-x86_64" {
+  "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-osx-universal_binary.zip"
+} else if os_arch == 'macos-aarch64' {
+  "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-osx-universal_binary.zip"
+} else if os_arch == "linux-x86_64" {
+  "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-linux-x86_64.zip"
+} else if os_arch == "linux-aarch64" {
+  "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-linux-aarch_64.zip"
+} else if os_arch == "windows-x86_64" {
+  "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-win64.zip"
+} else {
+  error("Unsupported platform: " + os_arch)
+}
+
+executable_name:= if os() == "windows" {"glaredb.exe"} else {"glaredb"}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
-# Build glaredb.
-default: build
+# Shows help command
+default: help
 export CARGO_TERM_COLOR := "always"
 
 alias py := python

--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@ default: help
 export CARGO_TERM_COLOR := "always"
 
 alias py := python
+alias slt := sql-logic-tests
+
 os_arch := os() + '-' + arch()
 
   
@@ -35,15 +37,15 @@ test *args: protoc
   cargo test {{args}}
 
 # Run unit tests.
-unittests: protoc
+unit-tests: protoc
   just test --lib --bins
 
 # Run doc tests.
-doctests: protoc
+doc-tests: protoc
   just test --doc
 
 # Run SQL Logic Tests.
-slt *args: protoc
+sql-logic-tests *args: protoc
   just test --test sqllogictests {{args}}
 
 #  Check formatting.
@@ -62,11 +64,6 @@ clippy: protoc
 help: 
   @just --list
 
-
-# private helpers below
-# ---------------------
-
-[private]
 protoc:
   #!/bin/bash
   if ! protoc --version > /dev/null; then 
@@ -76,7 +73,13 @@ protoc:
     mkdir -p deps/ && \
     unzip -o protoc.zip -d deps/protoc && \
     rm protoc.zip
+    
   fi
+
+
+# private helpers below
+# ---------------------
+
 
 
 default_target_triple := if os_arch == "macos-x86_64" {

--- a/py-glaredb/justfile
+++ b/py-glaredb/justfile
@@ -16,4 +16,3 @@ VENV_BIN := ".venv/bin"
 build *args: requirements
 	@unset CONDA_PREFIX
 	{{VENV_BIN}}/maturin develop {{args}}
-

--- a/py-glaredb/justfile
+++ b/py-glaredb/justfile
@@ -1,19 +1,19 @@
-SHELL := '/bin/bash'
+set fallback
 VENV := ".venv"
 VENV_BIN := ".venv/bin"
 
 
-## Set up virtual environment and install requirements
-venv:  
-	python3 -m pip install virtualenv 
-	python3 -m virtualenv {{VENV}}
+@venv:  
+	@python3 -m pip install virtualenv > /dev/null
+	@python3 -m virtualenv {{VENV}} > /dev/null
 
-requirements: venv
-	{{VENV_BIN}}/python -m pip install --upgrade pip
-	{{VENV_BIN}}/pip install -r requirements.txt
+## Set up virtual environment and install requirements
+@requirements: venv
+	{{VENV_BIN}}/python -m pip install --upgrade pip > /dev/null
+	{{VENV_BIN}}/pip install -r requirements.txt > /dev/null
 
 ## Compile and install py-glaredb for development
-build: requirements
-	unset CONDA_PREFIX
-	{{VENV_BIN}}/maturin develop
+build *args: requirements
+	@unset CONDA_PREFIX
+	{{VENV_BIN}}/maturin develop {{args}}
 


### PR DESCRIPTION
closes #1238 
this replaces the xtask build tool with `just`

I havent replaced any of the commands in the ci or docs, wanted to confirm this looks good before doing so. 

what I think is nice about this approach is that just will auto inherit the parent justfile & you don't have to manage the working dir at all when running the scripts, unless otherwise specified, it'll always use the dir of the justfile. 

```sh
# /glaredb
just fmt # runs `cargo fmt` from the root dir
just build # runs the build cmd from pwd

# /glaredb/py-glaredb
 just fmt # runs the parent `fmt` from the parent's dir `/glaredb`
 just build # runs the build cmd from pwd
```

it's also pretty easy to add subcommands
for example, this delegates all `python` commands to the subdir's justfile. 
```make
# Run py-glaredb subcommands. see `py-glaredb/justfile` for more details.
python cmd *args: protoc
  just py-glaredb/{{cmd}} {{args}}
```

```sh
just python build
# or 
cd py-glaredb && just build
```

like xtask, you can also list out the commands. 

<img width="1404" alt="image" src="https://github.com/GlareDB/glaredb/assets/21327470/b758d677-9604-42e6-8667-1c19b4e93593">



closes https://github.com/GlareDB/glaredb/issues/1238