### PR TITLE
chore: Bump rust version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69-bookworm AS builder
+FROM rust:1.70-bookworm AS builder
 
 # Copy in source.
 WORKDIR /usr/src/glaredb


### PR DESCRIPTION
Newer versions of `half` require 1.70 (which we're not using yet, but we'll likely need to bump it soon anyways).