### PR TITLE
fix: Fix explain queries

### DIFF
--- a/testdata/sqllogictests/explain.slt
+++ b/testdata/sqllogictests/explain.slt
@@ -1,0 +1,7 @@
+# Test `EXPLAIN ...` queries
+
+statement ok
+explain select 1;
+
+statement ok
+explain analyze select 1;


### PR DESCRIPTION
Datafusion's `from_plan` function will error/panic if provided a logical plan for EXPLAIN/EXPLAIN ANALYZE alongside an empty expression list. This gets called when replacing paramters for query. Since we go through the prepare/bind/execute phases even for queries that don't have paramters, we would reach this every time.

The conditional check just pulls out the inner logical plan and replaces parameters for that.

```
% cargo run --bin glaredb -- local --query "explain select 1;"
    Finished dev [unoptimized + debuginfo] target(s) in 0.46s
     Running `target/debug/glaredb local --query 'explain select 1;'`
+---------------+--------------------------------------+
| plan_type     | plan                                 |
+---------------+--------------------------------------+
| logical_plan  | Projection: Int64(1)                 |
|               |   EmptyRelation                      |
| physical_plan | ProjectionExec: expr=[1 as Int64(1)] |
|               |   EmptyExec: produce_one_row=true    |
|               |                                      |
+---------------+--------------------------------------+
```

Closes #1248 