### PR TITLE
fix: Downgrade datadriven crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,12 +1800,12 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "datadriven"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df18f0e7700f33562d92872dae54641b07bba9dc6a68faa40bf77c6a19ad6f97"
+checksum = "5c496e3277b660041bd6a2c0618593e99c3ba450b30d5f8d89035f78c87b4106"
 dependencies = [
+ "anyhow",
  "futures",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/pgprototest/Cargo.toml
+++ b/crates/pgprototest/Cargo.toml
@@ -7,7 +7,7 @@ edition = {workspace = true}
 
 [dependencies]
 anyhow = "1.0"
-datadriven = "0.7.0"
+datadriven = "0.6.0"
 postgres-protocol = "0.6.5"
 serde = { version = "1.0", features = ["derive"] }
 bytes = "1.4.0"


### PR DESCRIPTION
0.7.0 introduced bahvior around outputs ending with newlines. Specifically, if an output did not end with a newline, datadriven would add extra dashes around the output along with "no newline" text. Unfortunately, this behavior made the tests hard to read.

Adding just "\n" as the output didn't work as expected, since each test rewrite would add an additional newline to the output.

Downgrading seems like the best solution for the time being.