### PR TITLE
feat: support compute_engine authentication parameter

### DIFF
--- a/crates/pgsrv/src/auth.rs
+++ b/crates/pgsrv/src/auth.rs
@@ -106,6 +106,7 @@ pub trait ProxyAuthenticator: Sync + Send {
         password: &str,
         db_name: &str,
         org: &str,
+        compute_engine: &str,
     ) -> Result<DatabaseDetails>;
 }
 
@@ -139,6 +140,7 @@ impl ProxyAuthenticator for CloudAuthenticator {
         password: &str,
         db_name: &str,
         org: &str,
+        compute_engine: &str,
     ) -> Result<DatabaseDetails> {
         let query = if Uuid::try_parse(org).is_ok() {
             [
@@ -146,6 +148,7 @@ impl ProxyAuthenticator for CloudAuthenticator {
                 ("password", password),
                 ("name", db_name),
                 ("org", org),
+                ("compute_engine", compute_engine),
             ]
         } else {
             [
@@ -153,6 +156,7 @@ impl ProxyAuthenticator for CloudAuthenticator {
                 ("password", password),
                 ("name", db_name),
                 ("orgname", org),
+                ("compute_engine", compute_engine),
             ]
         };
 

--- a/crates/pgsrv/src/proxy.rs
+++ b/crates/pgsrv/src/proxy.rs
@@ -339,6 +339,13 @@ impl<A: ProxyAuthenticator> ProxyHandler<A> {
                     None => user,
                 };
 
+                // Extract the compute engine name (optional) from startup params
+                // Defaults to empty string which will target the shared pool
+                let compute_engine = match params.get("compute_engine") {
+                    Some(compute_engine) => compute_engine,
+                    None => "",
+                };
+
                 let options = parse_options(params);
 
                 let (org_id, db_name) =
@@ -346,7 +353,7 @@ impl<A: ProxyAuthenticator> ProxyHandler<A> {
 
                 let details = self
                     .authenticator
-                    .authenticate(user, &password, db_name, org_id)
+                    .authenticate(user, &password, db_name, org_id, compute_engine)
                     .await?;
                 Ok(details)
             }

--- a/crates/pgsrv/src/proxy.rs
+++ b/crates/pgsrv/src/proxy.rs
@@ -416,10 +416,7 @@ fn parse_options(params: &HashMap<String, String>) -> Option<HashMap<String, Str
 }
 
 /// Get the compute engine from the database name.
-/// The compute engine is the first part of the database name
-/// separated by a '.'
-/// always returns 2 strings, the compute engine and the db_name and compute engine may be empty string
-/// if the database name does not contain a '.'
+/// Compute engine is optional and may be empty string.
 fn get_compute_engine(db_name: &str) -> Result<(&str, &str)> {
     let (compute_engine, db_name) = db_name.split_once('.').unwrap_or(("", db_name));
     Ok((compute_engine, db_name))


### PR DESCRIPTION
Cloud can now target compute engines based on this option and will return the compute engine IP that matches the name when specified or otherwise will target the shared pool. 