### PR TITLE
feat: Support URLs for `COPY .. TO ..`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,8 +113,8 @@ jobs:
           # Prepare SLT (MongoDB)
           export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
 
-          just sql-logic-tests -- -v --exclude '*/tunnels/ssh'
-          just sql-logic-tests -- -v '*/tunnels/ssh'
+          just sql-logic-tests -v --exclude '*/tunnels/ssh'
+          just sql-logic-tests -v '*/tunnels/ssh'
 
       - name: Protocol Tests
         run: ./scripts/protocol-test.sh

--- a/crates/datasources/src/common/errors.rs
+++ b/crates/datasources/src/common/errors.rs
@@ -12,6 +12,9 @@ pub enum DatasourceCommonError {
     #[error("Scalar of type '{0}' not supported")]
     UnsupportedDatafusionScalar(datafusion::arrow::datatypes::DataType),
 
+    #[error("Invalid url: {0}")]
+    InvalidUrl(String),
+
     #[error(transparent)]
     ReprError(#[from] repr::error::ReprError),
 
@@ -29,6 +32,9 @@ pub enum DatasourceCommonError {
 
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    UrlParseError(#[from] url::ParseError),
 }
 
 pub type Result<T, E = DatasourceCommonError> = std::result::Result<T, E>;

--- a/crates/datasources/src/common/mod.rs
+++ b/crates/datasources/src/common/mod.rs
@@ -3,4 +3,5 @@ pub mod errors;
 pub mod listing;
 pub mod sink;
 pub mod ssh;
+pub mod url;
 pub mod util;

--- a/crates/datasources/src/object_store/local.rs
+++ b/crates/datasources/src/object_store/local.rs
@@ -89,9 +89,7 @@ impl LocalAccessor {
     }
 
     pub async fn validate_table_access(access: LocalTableAccess) -> Result<()> {
-        let store = Arc::new(LocalFileSystem::new());
-
-        let location = ObjectStorePath::from_filesystem_path(access.location)?;
+        let (store, location) = access.store_and_path()?;
         store.head(&location).await?;
         Ok(())
     }

--- a/crates/datasources/src/object_store/registry.rs
+++ b/crates/datasources/src/object_store/registry.rs
@@ -49,13 +49,14 @@ impl GlareDBRegistry {
 }
 
 fn gcs_to_store(opts: &TableOptionsGcs) -> Result<Arc<dyn ObjectStore>> {
-    GcsTableAccess {
+    let (store, _) = GcsTableAccess {
         bucket_name: opts.bucket.clone(),
         service_acccount_key_json: opts.service_account_key.clone(),
         location: opts.location.clone(),
         file_type: None,
     }
-    .into_object_store()
+    .store_and_path()?;
+    Ok(store)
 }
 
 fn s3_to_store(opts: &TableOptionsS3) -> Result<Arc<dyn ObjectStore>> {

--- a/crates/metastore/src/types.rs
+++ b/crates/metastore/src/types.rs
@@ -17,6 +17,14 @@ impl CopyToDestinationOptions {
             Self::S3(_) => Self::S3_STORAGE,
         }
     }
+
+    pub fn location(&self) -> &str {
+        match self {
+            Self::Local(CopyToDestinationOptionsLocal { location }) => location,
+            Self::Gcs(CopyToDestinationOptionsGcs { location, .. }) => location,
+            Self::S3(CopyToDestinationOptionsS3 { location, .. }) => location,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ doc-tests: protoc
 
 # Run SQL Logic Tests.
 sql-logic-tests *args: protoc
-  just test --test sqllogictests {{args}}
+  just test --test sqllogictests -- {{args}}
 
 #  Check formatting.
 fmt-check: protoc

--- a/testdata/sqllogictests_object_store/local/copy_to.slt
+++ b/testdata/sqllogictests_object_store/local/copy_to.slt
@@ -1,0 +1,105 @@
+# Basic test for copy to.
+
+statement ok
+CREATE TEMP TABLE copy_to_table (a INT, b TEXT);
+
+statement ok
+INSERT INTO copy_to_table VALUES
+	(1, 'abc'),
+	(2, 'def');
+
+statement ok
+COPY ( SELECT * FROM copy_to_table LIMIT 1 )
+	TO local
+	OPTIONS (
+		location = '${TMP}/query_copy.csv'
+	);
+
+query IT
+SELECT a, b FROM csv_scan('${TMP}/query_copy.csv');
+----
+1	abc
+
+statement ok
+COPY ( SELECT * FROM copy_to_table LIMIT 1 )
+	TO '${TMP}/query_copy_url.csv';
+
+query IT
+SELECT a, b FROM csv_scan('${TMP}/query_copy_url.csv');
+----
+1	abc
+
+# Copying again overrides the file.
+
+statement ok
+COPY ( SELECT b FROM copy_to_table ORDER BY a DESC )
+	TO '${TMP}/query_copy_url.csv';
+
+query T
+SELECT * FROM csv_scan('${TMP}/query_copy_url.csv');
+----
+def
+abc
+
+statement ok
+COPY current_session.copy_to_table
+	TO '${TMP}/table_copy_url.csv';
+
+query IT
+SELECT a, b FROM csv_scan('${TMP}/table_copy_url.csv');
+----
+1	abc
+2	def
+
+# Test "FORMAT" parameter
+
+statement ok
+COPY copy_to_table
+	TO '${TMP}/csv_copy_without_ext'
+	FORMAT csv;
+
+query IT
+SELECT a, b FROM csv_scan('${TMP}/csv_copy_without_ext');
+----
+1	abc
+2	def
+
+# Test if format is tried by file extension.
+
+# JSON format
+statement ok
+COPY default.current_session.copy_to_table
+	TO '${TMP}/copy_file.json';
+
+query IT
+SELECT a, b FROM ndjson_scan('${TMP}/copy_file.json');
+----
+1	abc
+2	def
+
+# Parquet format
+statement ok
+COPY default.current_session.copy_to_table
+	TO '${TMP}/copy_file.parquet';
+
+query IT
+SELECT a, b FROM parquet_scan('${TMP}/copy_file.parquet');
+----
+1	abc
+2	def
+
+# Use default format if it can't be determined.
+
+statement ok
+COPY copy_to_table TO '${TMP}/random_file';
+
+query IT
+SELECT a, b FROM csv_scan('${TMP}/random_file');
+----
+1	abc
+2	def
+
+# Unsupported format errors
+
+statement error unsupported output format
+COPY copy_to_table TO '${TMP}/random_file.abc' FORMAT abc;


### PR DESCRIPTION
Example:

```
copy ( select * from glare_catalog.tables ) to
    'gs://vrongmeal-public-test/mytestdata/pq.parquet' credentials gcp_creds;
```

Fixes #1260

Also support table as sources.

```
copy glare_catalog.tables to './local.csv';
```

Fixes #1261 