### PR TITLE
chore: Add Dependabot configuration for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,48 @@
 version: 2
 updates:
+
   # Maintain deps for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
+
     schedule:
       interval: "weekly"
       day: "friday"
       time: "09:00"
       timezone: "America/New_York"
+
     rebase-strategy: disabled
+
 
   # Maintain deps for Rust.
   - package-ecosystem: "cargo"
     directory: "/"
+
     schedule:
       interval: "weekly"
       day: "friday"
       time: "09:00"
       timezone: "America/New_York"
+    
     rebase-strategy: disabled
     open-pull-requests-limit: 20
+
+    reviewers:
+      - "scsmithr" 
+
+    labels:
+      - "dependencies"
+
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+    target-branch: "cargo-conf"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*" # Maintain all deps.
+        exclude-patterns:
+          - "datafusion"
+          - "deltalake"
+          - "object_store"


### PR DESCRIPTION
## Description:
This pull request improves Dependabot configuration file and assigns @scsmithr for reviews before merge; The updates will be directed to the `cargo-conf` branch first, where they will undergo review befor getting merged into the main branch.

## What This Enables:
Dependabot will open a single pull request to update all cargo dependencies at the same time.

![img](https://github.com/GlareDB/glaredb/assets/100840345/6e8cd195-82ca-4cce-aa66-9b277b0b5b2d)

![img2](https://github.com/GlareDB/glaredb/assets/100840345/65dd85f0-1b9f-4603-8238-35d659ff7473)

## Impacts:
This pull request addresses issue #1281.

## Side note:
Please add the `dependencies` label to this repo as it will allow Dependabot to use it;  otherwise the generated pull requests wont have any labels.
