### PR TITLE
feat: Support object store in `*_scan` functions.

### DIFF
--- a/crates/datasources/src/object_store/mod.rs
+++ b/crates/datasources/src/object_store/mod.rs
@@ -20,7 +20,7 @@ pub mod parquet;
 pub mod registry;
 pub mod s3;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum FileType {
     Csv,
     Parquet,

--- a/crates/sqlbuiltins/src/errors.rs
+++ b/crates/sqlbuiltins/src/errors.rs
@@ -29,6 +29,9 @@ pub enum BuiltinError {
     #[error(transparent)]
     Arrow(#[from] datafusion::arrow::error::ArrowError),
 
+    #[error(transparent)]
+    DatasourceCommonError(#[from] datasources::common::errors::DatasourceCommonError),
+
     #[error("{0}")]
     Static(&'static str),
 

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -17,6 +17,7 @@ use datafusion::logical_expr::TableSource;
 use datafusion::sql::TableReference;
 use datafusion_planner::planner::AsyncContextProvider;
 use metastoreproto::types::catalog::CatalogEntry;
+use metastoreproto::types::catalog::CredentialsEntry;
 use metastoreproto::types::catalog::DatabaseEntry;
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
 use sqlbuiltins::functions::TableFunc;
@@ -235,5 +236,9 @@ pub struct TableFnCtxProvider<'a> {
 impl<'a> TableFuncContextProvider for TableFnCtxProvider<'a> {
     fn get_database_entry(&self, name: &str) -> Option<&DatabaseEntry> {
         self.ctx.get_session_catalog().resolve_database(name)
+    }
+
+    fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry> {
+        self.ctx.get_session_catalog().resolve_credentials(name)
     }
 }

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -1052,6 +1052,7 @@ impl<'a> SessionPlanner<'a> {
                 DatasourceUrlScheme::File => CopyToDestinationOptions::LOCAL,
                 DatasourceUrlScheme::Gcs => CopyToDestinationOptions::GCS,
                 DatasourceUrlScheme::S3 => CopyToDestinationOptions::S3_STORAGE,
+                DatasourceUrlScheme::Http => return Err(internal!("invalid URL scheme")),
             };
             (d, Some(u))
         };

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ python cmd *args: protoc
 
 # Run glaredb server
 run *args: protoc
-  cargo run --bin glaredb {{args}}
+  cargo run --bin glaredb -- {{args}}
 
 # Build glaredb.
 build *args: protoc


### PR DESCRIPTION
2 Arguments:

```sql
SELECT * FROM csv_scan('gs://bucket/path/to/object.csv', 'gcp_creds');
```

3 Arguments:

```sql
SELECT * FROM parquet_scan(
  's3://bucket/path/to/object.csv',
  'aws_creds',
  'us-east-1' -- Region
);
```

Fixes #1249