### PR TITLE
fix: stop parsing datasource and tunnel limits from cloud response

### DIFF
--- a/crates/pgsrv/src/auth.rs
+++ b/crates/pgsrv/src/auth.rs
@@ -84,12 +84,8 @@ pub struct DatabaseDetails {
     pub user_id: String,
     /// Bucket for session storage.
     pub gcs_storage_bucket: String,
-    /// Max number of data sources allowed
-    pub max_datasource_count: usize,
     /// Memory limit applied to session in bytes
     pub memory_limit_bytes: usize,
-    /// Max number of tunnels allowed
-    pub max_tunnel_count: usize,
 }
 
 /// Authenticate connections that go through the proxy.

--- a/crates/pgsrv/src/proxy.rs
+++ b/crates/pgsrv/src/proxy.rs
@@ -257,7 +257,8 @@ impl<A: ProxyAuthenticator> ProxyHandler<A> {
         params.insert(GLAREDB_USER_ID_KEY.key.to_string(), db_details.user_id);
         params.insert(
             GLAREDB_MAX_DATASOURCE_COUNT_KEY.key.to_string(),
-            db_details.max_datasource_count.to_string(),
+            // use default here since we no longer get this from the cloud service
+            GLAREDB_MAX_DATASOURCE_COUNT_KEY.default.to_string(),
         );
         params.insert(
             GLAREDB_MEMORY_LIMIT_BYTES_KEY.key.to_string(),
@@ -265,7 +266,8 @@ impl<A: ProxyAuthenticator> ProxyHandler<A> {
         );
         params.insert(
             GLAREDB_MAX_TUNNEL_COUNT_KEY.key.to_string(),
-            db_details.max_tunnel_count.to_string(),
+            // use default here since we no longer get this from the cloud service
+            GLAREDB_MAX_TUNNEL_COUNT_KEY.default.to_string(),
         );
         params.insert(
             GLAREDB_GCS_STORAGE_BUCKET_KEY.to_string(),


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/1312