### PR TITLE
feat: Support named arguments and idents in table functions.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[alias]
-dev = "run --bin glaredb --"
-xtask = "run --package xtask --"
-x = "run --quiet --package xtask --"

--- a/crates/datafusion_planner/src/relation/mod.rs
+++ b/crates/datafusion_planner/src/relation/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::planner::{AsyncContextProvider, SqlQueryPlanner};
@@ -25,6 +26,7 @@ use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::planner::PlannerContext;
 use datafusion::sql::sqlparser::ast;
+use sqlbuiltins::functions::FuncParamValue;
 
 mod join;
 
@@ -48,10 +50,16 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                         // Table factor has arguments, look up table returning
                         // function.
 
-                        let scalars = args
-                            .into_iter()
-                            .map(|arg| self.get_constant_function_arg(arg))
-                            .collect::<Result<Vec<_>, _>>()?;
+                        let mut unnamed_args = Vec::new();
+                        let mut named_args = HashMap::new();
+                        for arg in args {
+                            let (name, val) = self.get_constant_function_arg(arg)?;
+                            if let Some(name) = name {
+                                named_args.insert(name, val);
+                            } else {
+                                unnamed_args.push(val);
+                            }
+                        }
 
                         let func = self
                             .schema_provider
@@ -64,7 +72,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
 
                         let table_fn_provider = self.schema_provider.table_fn_ctx_provider();
                         let provider = func
-                            .create_provider(&table_fn_provider, scalars)
+                            .create_provider(&table_fn_provider, unnamed_args, named_args)
                             .await
                             .map_err(|e| DataFusionError::Plan(e.to_string()))?;
 
@@ -126,45 +134,66 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
     }
 
     /// Get a constant expression literal from a function argument.
-    fn get_constant_function_arg(&mut self, arg: ast::FunctionArg) -> Result<ScalarValue> {
+    ///
+    /// Returns an optional name for the argument.
+    fn get_constant_function_arg(
+        &mut self,
+        arg: ast::FunctionArg,
+    ) -> Result<(Option<String>, FuncParamValue)> {
         match arg {
-            ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(expr)) => match expr {
-                ast::Expr::UnaryOp { op, expr } => match op {
-                    ast::UnaryOperator::Minus => {
-                        match *expr {
-                            // optimization: if it's a number literal, we apply the negative operator
-                            // here directly to calculate the new literal.
-                            ast::Expr::Value(ast::Value::Number(n, _)) => match n.parse::<i64>() {
-                                Ok(n) => Ok(ScalarValue::Int64(Some(-n))),
-                                Err(_) => {
-                                    let n = n.parse::<f64>().map_err(|_e| {
-                                        DataFusionError::Internal(format!(
-                                            "negative operator can be only applied to integer and float operands, got: {n}"))
-                                    })?;
-                                    Ok(ScalarValue::Float64(Some(-n)))
-                                }
-                            },
-                            other => Err(DataFusionError::NotImplemented(format!(
-                                "Non-constant function argument: {other:?}",
-                            ))),
-                        }
-                    }
-                    other => Err(DataFusionError::NotImplemented(format!(
-                        "Non-constant function argument: {other:?}",
-                    ))),
-                },
+            ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(expr)) => {
+                Ok((None, self.get_param_val(expr)?))
+            }
+            ast::FunctionArg::Named {
+                name,
+                arg: ast::FunctionArgExpr::Expr(expr),
+            } => {
+                let name = self.normalizer.normalize(name);
+                Ok((Some(name), self.get_param_val(expr)?))
+            }
+            other => Err(DataFusionError::NotImplemented(format!(
+                "Non-constant function argument: {other:?}",
+            ))),
+        }
+    }
 
-                ast::Expr::Value(v) => match self.parse_value(v, &[]) {
-                    Ok(Expr::Literal(lit)) => Ok(lit),
-                    Ok(v) => Err(DataFusionError::NotImplemented(format!(
-                        "Non-constant function argument: {v:?}"
-                    ))),
-                    Err(e) => Err(e),
-                },
+    /// Get the parameter value from expr.
+    fn get_param_val(&self, expr: ast::Expr) -> Result<FuncParamValue> {
+        match expr {
+            ast::Expr::Identifier(ident) => Ok(self.normalizer.normalize(ident).into()),
+            ast::Expr::UnaryOp { op, expr } => match op {
+                ast::UnaryOperator::Minus => {
+                    match *expr {
+                        // optimization: if it's a number literal, we apply the negative operator
+                        // here directly to calculate the new literal.
+                        ast::Expr::Value(ast::Value::Number(n, _)) => match n.parse::<i64>() {
+                            Ok(n) => Ok(ScalarValue::Int64(Some(-n)).into()),
+                            Err(_) => {
+                                let n = n.parse::<f64>().map_err(|_e| {
+                                    DataFusionError::Internal(format!(
+                                        "negative operator can be only applied to integer and float operands, got: {n}"))
+                                })?;
+                                Ok(ScalarValue::Float64(Some(-n)).into())
+                            }
+                        },
+                        other => Err(DataFusionError::NotImplemented(format!(
+                            "Non-constant function argument: {other:?}",
+                        ))),
+                    }
+                }
                 other => Err(DataFusionError::NotImplemented(format!(
                     "Non-constant function argument: {other:?}",
                 ))),
             },
+
+            ast::Expr::Value(v) => match self.parse_value(v, &[]) {
+                Ok(Expr::Literal(lit)) => Ok(lit.into()),
+                Ok(v) => Err(DataFusionError::NotImplemented(format!(
+                    "Non-constant function argument: {v:?}"
+                ))),
+                Err(e) => Err(e),
+            },
+
             other => Err(DataFusionError::NotImplemented(format!(
                 "Non-constant function argument: {other:?}",
             ))),

--- a/crates/sqlbuiltins/src/errors.rs
+++ b/crates/sqlbuiltins/src/errors.rs
@@ -1,20 +1,25 @@
-use datafusion::{arrow::datatypes::DataType, scalar::ScalarValue};
-
 #[derive(Debug, thiserror::Error)]
 pub enum BuiltinError {
     #[error("Invalid number of arguments.")]
     InvalidNumArgs,
 
-    #[error("Unexpected argument for function. Got '{scalar}', need value of type '{expected}'")]
+    #[error("Missing named argument: '{0}'")]
+    MissingNamedArgument(&'static str),
+
+    #[error("Unexpected argument for function. Got '{param}', need value of type '{expected}'")]
     UnexpectedArg {
-        scalar: ScalarValue,
-        expected: DataType,
+        param: crate::functions::FuncParamValue,
+        expected: datafusion::arrow::datatypes::DataType,
     },
 
-    #[error("Unexpected argument for function, expected {expected}, found '{scalars:?}'")]
+    #[error(
+        "Unexpected argument for function, expected {}, found '{}'",
+        expected,
+        crate::functions::FuncParamValue::multiple_to_string(&params)
+    )]
     UnexpectedArgs {
+        params: Vec<crate::functions::FuncParamValue>,
         expected: String,
-        scalars: Vec<ScalarValue>,
     },
 
     #[error("Unable to find {obj_typ}: '{name}'")]

--- a/crates/sqlbuiltins/src/functions.rs
+++ b/crates/sqlbuiltins/src/functions.rs
@@ -32,6 +32,7 @@ use metastore_client::types::options::{
 use num_traits::Zero;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::fmt::{self, Write};
 use std::ops::{Add, AddAssign};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -104,6 +105,161 @@ pub trait TableFuncContextProvider: Sync + Send {
     fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry>;
 }
 
+/// Value from a function parameter.
+#[derive(Debug, Clone)]
+pub enum FuncParamValue {
+    /// Normalized value from an ident.
+    Ident(String),
+    /// Scalar value.
+    Scalar(ScalarValue),
+}
+
+impl fmt::Display for FuncParamValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ident(s) => write!(f, "{s}"),
+            Self::Scalar(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl FuncParamValue {
+    /// Print multiple function parameter values.
+    pub fn multiple_to_string(vals: &[Self]) -> String {
+        let mut s = String::new();
+        write!(&mut s, "(").unwrap();
+        let mut sep = "";
+        for val in vals {
+            write!(&mut s, "{sep}{val}").unwrap();
+            sep = ", ";
+        }
+        write!(&mut s, ")").unwrap();
+        s
+    }
+
+    /// Wrapper over `FromFuncParamValue::from_param`.
+    fn param_into<T>(self) -> Result<T>
+    where
+        T: FromFuncParamValue,
+    {
+        T::from_param(self)
+    }
+}
+
+trait FromFuncParamValue: Sized {
+    /// Get the value from parameter.
+    fn from_param(value: FuncParamValue) -> Result<Self>;
+
+    /// Check if the value is valid (able to convert).
+    fn is_param_valid(value: &FuncParamValue) -> bool;
+}
+
+impl FromFuncParamValue for String {
+    fn from_param(value: FuncParamValue) -> Result<Self> {
+        match value {
+            FuncParamValue::Ident(s) => Ok(s),
+            FuncParamValue::Scalar(ScalarValue::Utf8(Some(s))) => Ok(s),
+            other => Err(BuiltinError::UnexpectedArg {
+                param: other,
+                expected: DataType::Utf8,
+            }),
+        }
+    }
+
+    fn is_param_valid(value: &FuncParamValue) -> bool {
+        matches!(
+            value,
+            FuncParamValue::Ident(_) | FuncParamValue::Scalar(ScalarValue::Utf8(Some(_)))
+        )
+    }
+}
+
+impl FromFuncParamValue for i64 {
+    fn from_param(value: FuncParamValue) -> Result<Self> {
+        match value {
+            FuncParamValue::Scalar(s) => match s {
+                ScalarValue::Int8(Some(v)) => Ok(v as i64),
+                ScalarValue::Int16(Some(v)) => Ok(v as i64),
+                ScalarValue::Int32(Some(v)) => Ok(v as i64),
+                ScalarValue::Int64(Some(v)) => Ok(v),
+                ScalarValue::UInt8(Some(v)) => Ok(v as i64),
+                ScalarValue::UInt16(Some(v)) => Ok(v as i64),
+                ScalarValue::UInt32(Some(v)) => Ok(v as i64),
+                ScalarValue::UInt64(Some(v)) => Ok(v as i64), // TODO: Handle overflow?
+                other => Err(BuiltinError::UnexpectedArg {
+                    param: other.into(),
+                    expected: DataType::Int64,
+                }),
+            },
+            other => Err(BuiltinError::UnexpectedArg {
+                param: other,
+                expected: DataType::Int64,
+            }),
+        }
+    }
+
+    fn is_param_valid(value: &FuncParamValue) -> bool {
+        matches!(
+            value,
+            FuncParamValue::Scalar(ScalarValue::Int8(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::Int16(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::Int32(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::Int64(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::UInt8(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::UInt16(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::UInt32(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::UInt64(Some(_)))
+        )
+    }
+}
+
+impl FromFuncParamValue for f64 {
+    fn from_param(value: FuncParamValue) -> Result<Self> {
+        match value {
+            FuncParamValue::Scalar(s) => match s {
+                ScalarValue::Int8(Some(v)) => Ok(v as f64),
+                ScalarValue::Int16(Some(v)) => Ok(v as f64),
+                ScalarValue::Int32(Some(v)) => Ok(v as f64),
+                ScalarValue::Int64(Some(v)) => Ok(v as f64),
+                ScalarValue::UInt8(Some(v)) => Ok(v as f64),
+                ScalarValue::UInt16(Some(v)) => Ok(v as f64),
+                ScalarValue::UInt32(Some(v)) => Ok(v as f64),
+                ScalarValue::UInt64(Some(v)) => Ok(v as f64),
+                ScalarValue::Float32(Some(v)) => Ok(v as f64),
+                ScalarValue::Float64(Some(v)) => Ok(v),
+                other => Err(BuiltinError::UnexpectedArg {
+                    param: other.into(),
+                    expected: DataType::Float64,
+                }),
+            },
+            other => Err(BuiltinError::UnexpectedArg {
+                param: other,
+                expected: DataType::Float64,
+            }),
+        }
+    }
+
+    fn is_param_valid(value: &FuncParamValue) -> bool {
+        matches!(
+            value,
+            FuncParamValue::Scalar(ScalarValue::Float32(Some(_)))
+                | FuncParamValue::Scalar(ScalarValue::Float64(Some(_)))
+        ) || i64::is_param_valid(value)
+    }
+}
+
+impl From<String> for FuncParamValue {
+    fn from(value: String) -> Self {
+        Self::Ident(value)
+    }
+}
+
+impl From<ScalarValue> for FuncParamValue {
+    fn from(value: ScalarValue) -> Self {
+        Self::Scalar(value)
+    }
+}
+
 #[async_trait]
 pub trait TableFunc: Sync + Send {
     /// The name for this table function. This name will be used when looking up
@@ -125,7 +281,8 @@ pub trait TableFunc: Sync + Send {
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>>;
 }
 
@@ -162,14 +319,15 @@ impl TableFunc for ReadPostgres {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             3 => {
                 let mut args = args.into_iter();
-                let conn_str = string_from_scalar(args.next().unwrap())?;
-                let schema = string_from_scalar(args.next().unwrap())?;
-                let table = string_from_scalar(args.next().unwrap())?;
+                let conn_str: String = args.next().unwrap().param_into()?;
+                let schema: String = args.next().unwrap().param_into()?;
+                let table: String = args.next().unwrap().param_into()?;
 
                 let access = PostgresAccessor::connect(&conn_str, None)
                     .await
@@ -229,15 +387,16 @@ impl TableFunc for ReadBigQuery {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             4 => {
                 let mut args = args.into_iter();
-                let service_account = string_from_scalar(args.next().unwrap())?;
-                let project_id = string_from_scalar(args.next().unwrap())?;
-                let dataset_id = string_from_scalar(args.next().unwrap())?;
-                let table_id = string_from_scalar(args.next().unwrap())?;
+                let service_account: String = args.next().unwrap().param_into()?;
+                let project_id: String = args.next().unwrap().param_into()?;
+                let dataset_id: String = args.next().unwrap().param_into()?;
+                let table_id: String = args.next().unwrap().param_into()?;
 
                 let access = BigQueryAccessor::connect(service_account, project_id)
                     .await
@@ -293,14 +452,15 @@ impl TableFunc for ReadMongoDb {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             3 => {
                 let mut args = args.into_iter();
-                let conn_str = string_from_scalar(args.next().unwrap())?;
-                let database = string_from_scalar(args.next().unwrap())?;
-                let collection = string_from_scalar(args.next().unwrap())?;
+                let conn_str: String = args.next().unwrap().param_into()?;
+                let database: String = args.next().unwrap().param_into()?;
+                let collection: String = args.next().unwrap().param_into()?;
 
                 let access = MongoAccessor::connect(&conn_str)
                     .await
@@ -354,14 +514,15 @@ impl TableFunc for ReadMysql {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             3 => {
                 let mut args = args.into_iter();
-                let conn_str = string_from_scalar(args.next().unwrap())?;
-                let schema = string_from_scalar(args.next().unwrap())?;
-                let table = string_from_scalar(args.next().unwrap())?;
+                let conn_str: String = args.next().unwrap().param_into()?;
+                let schema: String = args.next().unwrap().param_into()?;
+                let table: String = args.next().unwrap().param_into()?;
 
                 let access = MysqlAccessor::connect(&conn_str, None)
                     .await
@@ -437,19 +598,20 @@ impl TableFunc for ReadSnowflake {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             8 => {
                 let mut args = args.into_iter();
-                let account = string_from_scalar(args.next().unwrap())?;
-                let username = string_from_scalar(args.next().unwrap())?;
-                let password = string_from_scalar(args.next().unwrap())?;
-                let database = string_from_scalar(args.next().unwrap())?;
-                let warehouse = string_from_scalar(args.next().unwrap())?;
-                let role = string_from_scalar(args.next().unwrap())?;
-                let schema = string_from_scalar(args.next().unwrap())?;
-                let table = string_from_scalar(args.next().unwrap())?;
+                let account: String = args.next().unwrap().param_into()?;
+                let username: String = args.next().unwrap().param_into()?;
+                let password: String = args.next().unwrap().param_into()?;
+                let database: String = args.next().unwrap().param_into()?;
+                let warehouse: String = args.next().unwrap().param_into()?;
+                let role: String = args.next().unwrap().param_into()?;
+                let schema: String = args.next().unwrap().param_into()?;
+                let table: String = args.next().unwrap().param_into()?;
 
                 let conn_params = SnowflakeDbConnection {
                     account_name: account,
@@ -514,22 +676,6 @@ impl TableFunc for ObjScanTableFunc {
                     },
                 ],
             },
-            TableFuncParameters {
-                params: &[
-                    TableFuncParameter {
-                        name: "url",
-                        typ: DataType::Utf8,
-                    },
-                    TableFuncParameter {
-                        name: "credentials",
-                        typ: DataType::Utf8,
-                    },
-                    TableFuncParameter {
-                        name: "region",
-                        typ: DataType::Utf8,
-                    },
-                ],
-            },
         ];
 
         PARAMS
@@ -538,10 +684,11 @@ impl TableFunc for ObjScanTableFunc {
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         let Self(file_type, _) = self;
-        create_provider_for_filetype(ctx, *file_type, args).await
+        create_provider_for_filetype(ctx, *file_type, args, opts).await
     }
 }
 
@@ -551,12 +698,13 @@ pub struct ListSchemas;
 async fn create_provider_for_filetype(
     ctx: &dyn TableFuncContextProvider,
     file_type: FileType,
-    args: Vec<ScalarValue>,
+    args: Vec<FuncParamValue>,
+    mut opts: HashMap<String, FuncParamValue>,
 ) -> Result<Arc<dyn TableProvider>> {
     let store = match args.len() {
         1 => {
             let mut args = args.into_iter();
-            let url_string = string_from_scalar(args.next().unwrap())?;
+            let url_string: String = args.next().unwrap().param_into()?;
             let source_url = DatasourceUrl::new(&url_string)?;
 
             match source_url.scheme() {
@@ -578,21 +726,78 @@ async fn create_provider_for_filetype(
                     .await
                     .map_err(|e| BuiltinError::Access(Box::new(e)))?
                 }
-                // TODO: GCS, S3 without auth (though can use HTTP URL if
-                // objects are public).
-                _ => {
-                    return Err(BuiltinError::Static(
-                        "Unsupported datasource URL for given parameters",
-                    ))
+                DatasourceUrlScheme::Gcs => {
+                    let service_account_key = opts
+                        .remove("service_account_key")
+                        .map(FuncParamValue::param_into)
+                        .transpose()?;
+
+                    let bucket_name = source_url
+                        .host()
+                        .map(|b| b.to_owned())
+                        .ok_or(BuiltinError::Static("expected bucket name in URL"))?;
+
+                    let location = source_url.path().into_owned();
+
+                    GcsAccessor::new(GcsTableAccess {
+                        bucket_name,
+                        service_acccount_key_json: service_account_key,
+                        location,
+                        file_type: Some(file_type),
+                    })
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                    .into_table_provider(true)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                }
+                DatasourceUrlScheme::S3 => {
+                    let access_key_id = opts
+                        .remove("access_key_id")
+                        .map(FuncParamValue::param_into)
+                        .transpose()?;
+
+                    let secret_access_key = opts
+                        .remove("secret_access_key")
+                        .map(FuncParamValue::param_into)
+                        .transpose()?;
+
+                    let bucket_name = source_url
+                        .host()
+                        .map(|b| b.to_owned())
+                        .ok_or(BuiltinError::Static("expected bucket name in URL"))?;
+
+                    let location = source_url.path().into_owned();
+
+                    // S3 requires a region parameter.
+                    const REGION_KEY: &str = "region";
+                    let region = opts
+                        .remove(REGION_KEY)
+                        .ok_or(BuiltinError::MissingNamedArgument(REGION_KEY))?
+                        .param_into()?;
+
+                    S3Accessor::new(S3TableAccess {
+                        bucket_name,
+                        location,
+                        file_type: Some(file_type),
+                        region,
+                        access_key_id,
+                        secret_access_key,
+                    })
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?
+                    .into_table_provider(true)
+                    .await
+                    .map_err(|e| BuiltinError::Access(Box::new(e)))?
                 }
             }
         }
         2 => {
             let mut args = args.into_iter();
-            let url_string = string_from_scalar(args.next().unwrap())?;
+            let url_string: String = args.next().unwrap().param_into()?;
             let source_url = DatasourceUrl::new(url_string)?;
 
-            let creds = string_from_scalar(args.next().unwrap())?;
+            let creds: String = args.next().unwrap().param_into()?;
             let creds = ctx
                 .get_credentials_entry(&creds)
                 .ok_or(BuiltinError::Static("missing credentials object"))?;
@@ -623,24 +828,6 @@ async fn create_provider_for_filetype(
                     .await
                     .map_err(|e| BuiltinError::Access(Box::new(e)))?
                 }
-                _ => {
-                    return Err(BuiltinError::Static(
-                        "Unsupported datasource URL for given parameters",
-                    ))
-                }
-            }
-        }
-        3 => {
-            let mut args = args.into_iter();
-            let url_string = string_from_scalar(args.next().unwrap())?;
-            let source_url = DatasourceUrl::new(url_string)?;
-
-            let creds = string_from_scalar(args.next().unwrap())?;
-            let creds = ctx
-                .get_credentials_entry(&creds)
-                .ok_or(BuiltinError::Static("missing credentials object"))?;
-
-            match source_url.scheme() {
                 DatasourceUrlScheme::S3 => {
                     let (access_key_id, secret_access_key) = match &creds.options {
                         CredentialsOptions::Aws(o) => {
@@ -657,7 +844,11 @@ async fn create_provider_for_filetype(
                     let location = source_url.path().into_owned();
 
                     // S3 requires a region parameter.
-                    let region = string_from_scalar(args.next().unwrap())?;
+                    const REGION_KEY: &str = "region";
+                    let region = opts
+                        .remove(REGION_KEY)
+                        .ok_or(BuiltinError::MissingNamedArgument(REGION_KEY))?
+                        .param_into()?;
 
                     S3Accessor::new(S3TableAccess {
                         bucket_name,
@@ -705,12 +896,13 @@ impl TableFunc for ListSchemas {
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             1 => {
                 let mut args = args.into_iter();
-                let database = string_from_scalar(args.next().unwrap())?;
+                let database: String = args.next().unwrap().param_into()?;
 
                 let fields = vec![Field::new("schema_name", DataType::Utf8, false)];
                 let schema = Arc::new(Schema::new(fields));
@@ -763,13 +955,14 @@ impl TableFunc for ListTables {
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             2 => {
                 let mut args = args.into_iter();
-                let database = string_from_scalar(args.next().unwrap())?;
-                let schema_name = string_from_scalar(args.next().unwrap())?;
+                let database: String = args.next().unwrap().param_into()?;
+                let schema_name: String = args.next().unwrap().param_into()?;
 
                 let fields = vec![Field::new("table_name", DataType::Utf8, false)];
                 let schema = Arc::new(Schema::new(fields));
@@ -945,29 +1138,31 @@ impl TableFunc for GenerateSeries {
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,
-        args: Vec<ScalarValue>,
+        args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             2 => {
                 let mut args = args.into_iter();
                 let start = args.next().unwrap();
                 let stop = args.next().unwrap();
-                if is_scalar_int(&start) && is_scalar_int(&stop) {
+
+                if i64::is_param_valid(&start) && i64::is_param_valid(&stop) {
                     create_straming_table::<GenerateSeriesTypeInt>(
-                        i64_from_scalar(start)?,
-                        i64_from_scalar(stop)?,
+                        start.param_into()?,
+                        stop.param_into()?,
                         1,
                     )
-                } else if is_scalar_float(&start) && is_scalar_float(&stop) {
+                } else if f64::is_param_valid(&start) && f64::is_param_valid(&stop) {
                     create_straming_table::<GenerateSeriesTypeFloat>(
-                        f64_from_scalar(start)?,
-                        f64_from_scalar(stop)?,
-                        1.0f64,
+                        start.param_into()?,
+                        stop.param_into()?,
+                        1.0_f64,
                     )
                 } else {
                     return Err(BuiltinError::UnexpectedArgs {
                         expected: String::from("ints or floats"),
-                        scalars: vec![start, stop],
+                        params: vec![start, stop],
                     });
                 }
             }
@@ -976,25 +1171,29 @@ impl TableFunc for GenerateSeries {
                 let start = args.next().unwrap();
                 let stop = args.next().unwrap();
                 let step = args.next().unwrap();
-                if is_scalar_int(&start) && is_scalar_int(&stop) && is_scalar_int(&step) {
+
+                if i64::is_param_valid(&start)
+                    && i64::is_param_valid(&stop)
+                    && i64::is_param_valid(&step)
+                {
                     create_straming_table::<GenerateSeriesTypeInt>(
-                        i64_from_scalar(start)?,
-                        i64_from_scalar(stop)?,
-                        i64_from_scalar(step)?,
+                        start.param_into()?,
+                        stop.param_into()?,
+                        step.param_into()?,
                     )
-                } else if is_scalar_float(&start)
-                    && is_scalar_float(&stop)
-                    && is_scalar_float(&step)
+                } else if f64::is_param_valid(&start)
+                    && f64::is_param_valid(&stop)
+                    && f64::is_param_valid(&step)
                 {
                     create_straming_table::<GenerateSeriesTypeFloat>(
-                        f64_from_scalar(start)?,
-                        f64_from_scalar(stop)?,
-                        f64_from_scalar(step)?,
+                        start.param_into()?,
+                        stop.param_into()?,
+                        step.param_into()?,
                     )
                 } else {
                     return Err(BuiltinError::UnexpectedArgs {
                         expected: String::from("ints or floats"),
-                        scalars: vec![start, stop, step],
+                        params: vec![start, stop, step],
                     });
                 }
             }
@@ -1149,68 +1348,4 @@ impl<T: GenerateSeriesType> RecordBatchStream for GenerateSeriesStream<T> {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
-}
-
-fn i64_from_scalar(val: ScalarValue) -> Result<i64> {
-    match val {
-        ScalarValue::Int8(Some(v)) => Ok(v as i64),
-        ScalarValue::Int16(Some(v)) => Ok(v as i64),
-        ScalarValue::Int32(Some(v)) => Ok(v as i64),
-        ScalarValue::Int64(Some(v)) => Ok(v),
-        ScalarValue::UInt8(Some(v)) => Ok(v as i64),
-        ScalarValue::UInt16(Some(v)) => Ok(v as i64),
-        ScalarValue::UInt32(Some(v)) => Ok(v as i64),
-        ScalarValue::UInt64(Some(v)) => Ok(v as i64), // TODO: Handle overflow?
-        other => Err(BuiltinError::UnexpectedArg {
-            scalar: other,
-            expected: DataType::Int64,
-        }),
-    }
-}
-
-fn f64_from_scalar(val: ScalarValue) -> Result<f64> {
-    match val {
-        ScalarValue::Int8(Some(v)) => Ok(v as f64),
-        ScalarValue::Int16(Some(v)) => Ok(v as f64),
-        ScalarValue::Int32(Some(v)) => Ok(v as f64),
-        ScalarValue::Int64(Some(v)) => Ok(v as f64),
-        ScalarValue::UInt8(Some(v)) => Ok(v as f64),
-        ScalarValue::UInt16(Some(v)) => Ok(v as f64),
-        ScalarValue::UInt32(Some(v)) => Ok(v as f64),
-        ScalarValue::UInt64(Some(v)) => Ok(v as f64),
-        ScalarValue::Float32(Some(v)) => Ok(v as f64),
-        ScalarValue::Float64(Some(v)) => Ok(v),
-        other => Err(BuiltinError::UnexpectedArg {
-            scalar: other,
-            expected: DataType::Float64,
-        }),
-    }
-}
-
-fn string_from_scalar(val: ScalarValue) -> Result<String> {
-    match val {
-        ScalarValue::Utf8(Some(s)) => Ok(s),
-        other => Err(BuiltinError::UnexpectedArg {
-            scalar: other,
-            expected: DataType::Utf8,
-        }),
-    }
-}
-
-fn is_scalar_int(val: &ScalarValue) -> bool {
-    matches!(
-        *val,
-        ScalarValue::Int8(_)
-            | ScalarValue::Int16(_)
-            | ScalarValue::Int32(_)
-            | ScalarValue::Int64(_)
-            | ScalarValue::UInt8(_)
-            | ScalarValue::UInt16(_)
-            | ScalarValue::UInt32(_)
-            | ScalarValue::UInt64(_)
-    )
-}
-
-fn is_scalar_float(val: &ScalarValue) -> bool {
-    matches!(*val, ScalarValue::Float32(_) | ScalarValue::Float64(_)) | is_scalar_int(val)
 }

--- a/testdata/sqllogictests_object_store/gcs/copy_to.slt
+++ b/testdata/sqllogictests_object_store/gcs/copy_to.slt
@@ -1,0 +1,50 @@
+# Basic tests for copy to.
+
+statement ok
+COPY ( SELECT 1 AS a, 2 AS b ) TO gcs
+	OPTIONS (
+        service_account_key = '${GCP_SERVICE_ACCOUNT_KEY}',
+        bucket = '${GCS_BUCKET_NAME}',
+        location = 'copy_to/with_opts.csv'
+	);
+
+query II
+SELECT * FROM csv_scan(
+	'gs://${GCS_BUCKET_NAME}/copy_to/with_opts.csv',
+	service_account_key => '${GCP_SERVICE_ACCOUNT_KEY}'
+);
+----
+1	2
+
+statement ok
+COPY ( SELECT 3 AS a, 4 AS b )
+	TO 'gs://${GCS_BUCKET_NAME}/copy_to/with_url.csv'
+	OPTIONS (
+        service_account_key = '${GCP_SERVICE_ACCOUNT_KEY}',
+	);
+
+query II
+SELECT b, a FROM csv_scan(
+	'gs://${GCS_BUCKET_NAME}/copy_to/with_url.csv',
+	service_account_key => '${GCP_SERVICE_ACCOUNT_KEY}'
+);
+----
+4	3
+
+# Credentials
+statement ok
+CREATE CREDENTIALS gcp_creds PROVIDER gcp
+	( service_account_key '${GCP_SERVICE_ACCOUNT_KEY}' );
+
+statement ok
+COPY ( SELECT 5 AS a, 6 AS b )
+	TO 'gs://${GCS_BUCKET_NAME}/copy_to/with_creds.csv'
+	CREDENTIALS gcp_creds;
+
+query II
+SELECT a, b FROM csv_scan(
+	'gs://${GCS_BUCKET_NAME}/copy_to/with_creds.csv',
+	gcp_creds
+);
+----
+5	6

--- a/testdata/sqllogictests_object_store/s3/copy_to.slt
+++ b/testdata/sqllogictests_object_store/s3/copy_to.slt
@@ -1,0 +1,63 @@
+# Basic tests for copy to.
+
+statement ok
+COPY ( SELECT 1 AS a, 2 AS b ) TO s3
+	OPTIONS (
+        access_key_id = '${AWS_ACCESS_KEY_ID}',
+        secret_access_key = '${AWS_SECRET_ACCESS_KEY}',
+        region = '${AWS_S3_REGION}',
+        bucket = '${AWS_S3_BUCKET_NAME}',
+        location = 'copy_to/with_opts.csv'
+	);
+
+query II
+SELECT * FROM csv_scan(
+	's3://${AWS_S3_BUCKET_NAME}/copy_to/with_opts.csv',
+    access_key_id => '${AWS_ACCESS_KEY_ID}',
+    secret_access_key => '${AWS_SECRET_ACCESS_KEY}',
+    region => '${AWS_S3_REGION}'
+);
+----
+1	2
+
+statement ok
+COPY ( SELECT 3 AS a, 4 AS b )
+	TO 's3://${AWS_S3_BUCKET_NAME}/copy_to/with_url.csv'
+	OPTIONS (
+        access_key_id = '${AWS_ACCESS_KEY_ID}',
+        secret_access_key = '${AWS_SECRET_ACCESS_KEY}',
+        region = '${AWS_S3_REGION}',
+	);
+
+query II
+SELECT b, a FROM csv_scan(
+	's3://${AWS_S3_BUCKET_NAME}/copy_to/with_url.csv',
+    access_key_id => '${AWS_ACCESS_KEY_ID}',
+    secret_access_key => '${AWS_SECRET_ACCESS_KEY}',
+    region => '${AWS_S3_REGION}'
+);
+----
+4	3
+
+# Credentials
+statement ok
+CREATE CREDENTIALS aws_creds PROVIDER aws
+	OPTIONS (
+        access_key_id = '${AWS_ACCESS_KEY_ID}',
+        secret_access_key = '${AWS_SECRET_ACCESS_KEY}',
+	);
+
+statement ok
+COPY ( SELECT 5 AS a, 6 AS b )
+	TO 's3://${AWS_S3_BUCKET_NAME}/copy_to/with_creds.csv'
+	CREDENTIALS aws_creds
+	( region '${AWS_S3_REGION}' );
+
+query II
+SELECT a, b FROM csv_scan(
+	's3://${AWS_S3_BUCKET_NAME}/copy_to/with_creds.csv',
+	aws_Creds,
+    region => '${AWS_S3_REGION}'
+);
+----
+5	6


### PR DESCRIPTION
We can now add named arguments that can be passed into table functions which act like options basically.

Passing identifiers as arguments is also supported now.

```sql
SELECT * FROM csv_scan(
  's3://bucket/object',
  aws_creds,      -- Identifier, can also be quoted: "aws_creds"
  region => '...' -- Named argument, can be passed as `key => val`
);
```

Fixes #1308, #1297 

---

### ☑️ TODO

- [x] Raw credentials as named arguments.