### PR TITLE
fix: Explicitly use `Ident` in table function parameters.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/crates/sqlbuiltins/src/errors.rs
+++ b/crates/sqlbuiltins/src/errors.rs
@@ -15,7 +15,7 @@ pub enum BuiltinError {
     #[error(
         "Unexpected argument for function, expected {}, found '{}'",
         expected,
-        crate::functions::FuncParamValue::multiple_to_string(&params)
+        crate::functions::FuncParamValue::multiple_to_string(params)
     )]
     UnexpectedArgs {
         params: Vec<crate::functions::FuncParamValue>,

--- a/justfile
+++ b/justfile
@@ -38,8 +38,8 @@ test *args: protoc
   cargo test {{args}}
 
 # Run unit tests.
-unit-tests: protoc
-  just test --lib --bins
+unit-tests *args: protoc
+  just test --lib --bins {{args}}
 
 # Run doc tests.
 doc-tests: protoc

--- a/testdata/sqllogictests/virtual_catalog.slt
+++ b/testdata/sqllogictests/virtual_catalog.slt
@@ -4,7 +4,7 @@ statement ok
 CREATE EXTERNAL DATABASE virt_cat FROM debug;
 
 query T rowsort
-SELECT * FROM list_schemas('virt_cat');
+SELECT * FROM list_schemas(virt_cat);
 ----
 schema_0
 schema_1
@@ -12,7 +12,7 @@ schema_1
 # Check if it only fetches for the given schema name.
 
 query TT rowsort
-SELECT * FROM list_tables('virt_cat', 'debug_schema');
+SELECT * FROM list_tables(virt_cat, debug_schema);
 ----
 debug_schema_table_0
 debug_schema_table_1

--- a/testdata/sqllogictests_bigquery/external_database.slt
+++ b/testdata/sqllogictests_bigquery/external_database.slt
@@ -16,14 +16,14 @@ SELECT count(*) FROM external_db.${BIGQUERY_DATASET_ID}.bikeshare_stations;
 # Ensure we can query into the virtual schema.
 
 query T
-SELECT * FROM list_schemas('external_db')
+SELECT * FROM list_schemas(external_db)
 	WHERE schema_name = '${BIGQUERY_DATASET_ID}';
 ----
 ${BIGQUERY_DATASET_ID}
 
 query T
 SELECT table_name
-	FROM list_tables('external_db', '${BIGQUERY_DATASET_ID}')
+	FROM list_tables(external_db, ${BIGQUERY_DATASET_ID})
 	WHERE table_name = 'bikeshare_stations';
 ----
 bikeshare_stations

--- a/testdata/sqllogictests_mysql/external_database.slt
+++ b/testdata/sqllogictests_mysql/external_database.slt
@@ -35,13 +35,13 @@ SELECT count(*) FROM external_database.glaredb_test.bikeshare_stations;
 # Ensure we can query into the virtual schema.
 
 query T
-SELECT * FROM list_schemas('external_database') WHERE schema_name = 'glaredb_test';
+SELECT * FROM list_schemas(external_database) WHERE schema_name = 'glaredb_test';
 ----
 glaredb_test
 
 query T
 SELECT table_name
-	FROM list_tables('external_database', 'glaredb_test')
+	FROM list_tables(external_database, glaredb_test)
 	WHERE table_name = 'bikeshare_stations';
 ----
 bikeshare_stations

--- a/testdata/sqllogictests_postgres/external_database.slt
+++ b/testdata/sqllogictests_postgres/external_database.slt
@@ -37,13 +37,13 @@ SELECT count(*) FROM external_db.public.bikeshare_stations;
 # Ensure we can query into the virtual schema.
 
 query T
-SELECT * FROM list_schemas('external_db') WHERE schema_name = 'public';
+SELECT * FROM list_schemas(external_db) WHERE schema_name = 'public';
 ----
 public
 
 query T
 SELECT table_name
-	FROM list_tables('external_db', 'public')
+	FROM list_tables(external_db, public)
 	WHERE table_name = 'bikeshare_stations';
 ----
 bikeshare_stations

--- a/testdata/sqllogictests_snowflake/external_database.slt
+++ b/testdata/sqllogictests_snowflake/external_database.slt
@@ -20,13 +20,13 @@ SELECT count(*) FROM external_db.public.bikeshare_stations;
 # Ensure we can query into the virtual schema.
 
 query T
-SELECT * FROM list_schemas('external_db') WHERE schema_name = 'PUBLIC';
+SELECT * FROM list_schemas(external_db) WHERE schema_name = 'PUBLIC';
 ----
 PUBLIC
 
 query T
 SELECT table_name
-	FROM list_tables('external_db', 'PUBLIC')
+	FROM list_tables(external_db, "PUBLIC")
 	WHERE table_name = 'BIKESHARE_STATIONS';
 ----
 BIKESHARE_STATIONS


### PR DESCRIPTION
Can only specify identifiers as parameters when required. For example:

```sql
SELECT * FROM list_schemas( ext_db_name );

-- `Ident`s can be quoted.
SELECT * FROM list_tables( ext_db_name, "SchemaName" );

SELECT * FROM csv_scan( '<url>', creds_obj );
```