### PR TITLE
fix: Add xtask alias back (for zip)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --bin xtask --"


### PR DESCRIPTION
I removed this in another PR, didn't realize we're still using it for zipping.