### PR TITLE
chore: simplify feat template

### DIFF
--- a/.github/ISSUE_TEMPLATE/planned-feature.md
+++ b/.github/ISSUE_TEMPLATE/planned-feature.md
@@ -6,23 +6,14 @@ labels: "feat :sparkler:"
 assignees: ""
 ---
 
-## Summary
+## Description
 
-### Specifications
-
-<!--- Mandatory
-  Seek to define "what" more than "how", though sometimes "how" is necessary
-  to. If we don't know "what", we need more research or design.
--->
+<!-- Mandatory - Answer "What" most importantly, possibly "How" -->
 
 ## Rationale
 
 <!--- Mandatory - why are we doing this? -->
 
-## Impact
+## Breaking effects
 
 <!--- OPTIONAL - only if affects other systems/people etc -->
-
-## Tasks
-
-<!--- OPTIONAL - only if separate from Specifications -->

--- a/.github/ISSUE_TEMPLATE/planned-feature.md
+++ b/.github/ISSUE_TEMPLATE/planned-feature.md
@@ -12,8 +12,8 @@ assignees: ""
 
 ## Rationale
 
-<!--- Mandatory - why are we doing this? -->
+<!-- Mandatory - why are we doing this? -->
 
 ## Breaking effects
 
-<!--- OPTIONAL - only if affects other systems/people etc -->
+<!-- OPTIONAL - only if affects other systems/people etc -->


### PR DESCRIPTION
1. Make lang of Impacts more clear (it's more about breaking systems or people)
2. Remove Tasks (we don't use it or rarely enough to justify)
3. Merge specs/sujmmary, since we rarely distinguish