### PR TITLE
feat: Read-only session vars

### DIFF
--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -18,8 +18,8 @@ use once_cell::sync::Lazy;
 use pgrepr::format::Format;
 use reedline::{FileBackedHistory, Reedline, Signal};
 
+use sqlexec::engine::EngineStorageConfig;
 use sqlexec::engine::{Engine, SessionStorageConfig, TrackedSession};
-use sqlexec::engine::{EngineStorageConfig, SessionLimits};
 use sqlexec::parser;
 use sqlexec::session::ExecutionResult;
 use sqlexec::vars::SessionVars;
@@ -29,7 +29,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 use telemetry::Tracker;
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum OutputMode {

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -22,6 +22,7 @@ use sqlexec::engine::{Engine, SessionStorageConfig, TrackedSession};
 use sqlexec::engine::{EngineStorageConfig, SessionLimits};
 use sqlexec::parser;
 use sqlexec::session::ExecutionResult;
+use sqlexec::vars::SessionVars;
 use std::env;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -119,15 +120,7 @@ impl LocalSession {
 
         Ok(LocalSession {
             sess: engine
-                .new_session(
-                    Uuid::nil(),
-                    "glaredb".to_string(),
-                    Uuid::nil(),
-                    Uuid::nil(),
-                    "glaredb".to_string(),
-                    SessionLimits::default(),
-                    SessionStorageConfig::default(),
-                )
+                .new_session(SessionVars::default(), SessionStorageConfig::default())
                 .await?,
             _engine: engine,
             opts,

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 use pgrepr::format::Format;
 use pgrepr::scalar::Scalar;
 use sqlexec::context::{OutputFields, Portal, PreparedStatement};
-use sqlexec::engine::{SessionLimits, SessionStorageConfig};
+use sqlexec::engine::SessionStorageConfig;
 use sqlexec::vars::{SessionVars, VarSetter};
 use sqlexec::{
     engine::Engine,

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -19,6 +19,7 @@ use pgrepr::format::Format;
 use pgrepr::scalar::Scalar;
 use sqlexec::context::{OutputFields, Portal, PreparedStatement};
 use sqlexec::engine::{SessionLimits, SessionStorageConfig};
+use sqlexec::vars::VarSetter;
 use sqlexec::{
     engine::Engine,
     parser::{self, StatementWithExtensions},
@@ -274,7 +275,7 @@ impl ProtocolHandler {
         // logs.
         let vars = sess.get_session_vars_mut();
         for (key, val) in &params {
-            if let Err(e) = vars.set(key, val) {
+            if let Err(e) = vars.set(key, val, VarSetter::User) {
                 debug!(%e, %key, %val, "unable to set session variable from startup param");
             }
         }

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -67,8 +67,8 @@ pub struct SessionContext {
     prepared: HashMap<String, PreparedStatement>,
     /// Bound portals.
     portals: HashMap<String, Portal>,
-    // /// Track query metrics for this session.
-    // metrics: SessionMetrics,
+    /// Track query metrics for this session.
+    metrics: SessionMetrics,
     /// Datafusion session state used for planning and execution.
     ///
     /// This session state makes a ton of assumptions, try to keep usage of it
@@ -92,6 +92,7 @@ impl SessionContext {
         catalog: SessionCatalog,
         metastore: SupervisorClient,
         native_tables: NativeTableStorage,
+        metrics: SessionMetrics,
         spill_path: Option<PathBuf>,
     ) -> SessionContext {
         // NOTE: We handle catalog/schema defaults and information schemas
@@ -142,6 +143,7 @@ impl SessionContext {
             vars,
             prepared: HashMap::new(),
             portals: HashMap::new(),
+            metrics,
             df_state: state,
             env_reader: None,
         }
@@ -156,13 +158,11 @@ impl SessionContext {
     }
 
     pub fn get_metrics(&self) -> &SessionMetrics {
-        // &self.metrics
-        unimplemented!()
+        &self.metrics
     }
 
     pub fn get_metrics_mut(&mut self) -> &mut SessionMetrics {
-        // &mut self.metrics
-        unimplemented!()
+        &mut self.metrics
     }
 
     pub fn get_native_tables(&self) -> &NativeTableStorage {

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -17,26 +17,6 @@ use tonic::transport::Channel;
 use tracing::{debug, info};
 use uuid::Uuid;
 
-/// Static information for database sessions.
-#[derive(Debug, Clone)]
-pub struct SessionInfo {
-    /// Database id that this session is connected to.
-    pub database_id: Uuid,
-    // Name of the database we're connected to.
-    pub database_name: String,
-    /// ID of the user who initiated the connection. This maps to a user account
-    /// on Cloud.
-    pub user_id: Uuid,
-    /// Name of the (database) user.
-    pub user_name: String,
-    /// Unique connection id.
-    pub conn_id: Uuid,
-    /// Limits that should be applied for this session.
-    pub limits: SessionLimits,
-    /// Storage for this session.
-    pub storage: SessionStorageConfig,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct SessionStorageConfig {
     /// The bucket that should be used for database storage for a session.
@@ -153,7 +133,8 @@ impl Engine {
         self.session_counter.load(Ordering::Relaxed)
     }
 
-    /// Create a new session.
+    /// Create a new session, initializing it with the provided session
+    /// variables.
     pub async fn new_session(
         &self,
         vars: SessionVars,

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -26,18 +26,6 @@ pub struct SessionStorageConfig {
     pub gcs_bucket: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct SessionLimits {
-    /// Max datasource count allowed.
-    pub max_datasource_count: Option<usize>,
-    /// Memory limit applied to the session.
-    pub memory_limit_bytes: Option<usize>,
-    /// Max tunnel count allowed.
-    pub max_tunnel_count: Option<usize>,
-    /// Max credentials count.
-    pub max_credentials_count: Option<usize>,
-}
-
 /// Storage configuration for the compute engine.
 ///
 /// The configuration defined here alongside the configuration passed in through

--- a/crates/sqlexec/src/functions.rs
+++ b/crates/sqlexec/src/functions.rs
@@ -180,11 +180,11 @@ impl PgFunctionBuilder {
         let func = match name {
             "array_to_string" => pg_array_to_string(),
             "current_database" | "current_catalog" => {
-                pg_current_database(&ctx.get_session_vars().database_name.value())
+                pg_current_database(ctx.get_session_vars().database_name.value())
             }
             "current_schema" => pg_current_schema(ctx.search_path_iter().next()),
             "current_user" | "current_role" | "user" => {
-                pg_current_user(&ctx.get_session_vars().user_name.value())
+                pg_current_user(ctx.get_session_vars().user_name.value())
             }
             "has_database_privilege" => pg_has_database_privilege(),
             "has_schema_privilege" => pg_has_schema_privilege(),

--- a/crates/sqlexec/src/functions.rs
+++ b/crates/sqlexec/src/functions.rs
@@ -128,7 +128,7 @@ impl BuiltinScalarFunction {
                 })
             }
             BuiltinScalarFunction::ConnectionId => {
-                let id = sess.get_info().conn_id;
+                let id = *sess.get_session_vars().connection_id.value();
                 Arc::new(move |_| {
                     Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
                         id.to_string(),
@@ -180,10 +180,12 @@ impl PgFunctionBuilder {
         let func = match name {
             "array_to_string" => pg_array_to_string(),
             "current_database" | "current_catalog" => {
-                pg_current_database(&ctx.get_info().database_name)
+                pg_current_database(&ctx.get_session_vars().database_name.value())
             }
             "current_schema" => pg_current_schema(ctx.search_path_iter().next()),
-            "current_user" | "current_role" | "user" => pg_current_user(&ctx.get_info().user_name),
+            "current_user" | "current_role" | "user" => {
+                pg_current_user(&ctx.get_session_vars().user_name.value())
+            }
             "has_database_privilege" => pg_has_database_privilege(),
             "has_schema_privilege" => pg_has_schema_privilege(),
             "has_table_privilege" => pg_has_table_privilege(),

--- a/crates/sqlexec/src/lib.rs
+++ b/crates/sqlexec/src/lib.rs
@@ -6,11 +6,11 @@ pub mod errors;
 pub mod metastore;
 pub mod parser;
 pub mod session;
+pub mod vars;
 
 mod functions;
 mod metrics;
 mod planner;
-mod vars;
 pub use planner::logical_plan::LogicalPlan;
 
 pub mod export {

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -1,5 +1,4 @@
 use crate::context::{Portal, PreparedStatement, SessionContext};
-use crate::engine::SessionInfo;
 use crate::environment::EnvironmentReader;
 use crate::errors::{ExecError, Result};
 use crate::metastore::SupervisorClient;
@@ -188,8 +187,13 @@ impl Session {
         tracker: Arc<Tracker>,
         spill_path: Option<PathBuf>,
     ) -> Result<Session> {
-        // let metrics = SessionMetrics::new(info.clone(), tracker);
-        let ctx = SessionContext::new(vars, catalog, metastore, native_tables, spill_path);
+        let metrics = SessionMetrics::new(
+            *vars.user_id.value(),
+            *vars.database_id.value(),
+            *vars.connection_id.value(),
+            tracker,
+        );
+        let ctx = SessionContext::new(vars, catalog, metastore, native_tables, metrics, spill_path);
         Ok(Session { ctx })
     }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -6,7 +6,7 @@ use crate::metastore::SupervisorClient;
 use crate::metrics::{BatchStreamWithMetricSender, ExecutionStatus, QueryMetrics, SessionMetrics};
 use crate::parser::StatementWithExtensions;
 use crate::planner::logical_plan::*;
-use crate::vars::SessionVars;
+use crate::vars::{SessionVars, VarSetter};
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::insert::DataSink;
 use datafusion::physical_plan::{
@@ -309,9 +309,11 @@ impl Session {
     }
 
     pub(crate) fn set_variable(&mut self, plan: SetVariable) -> Result<()> {
-        self.ctx
-            .get_session_vars_mut()
-            .set(&plan.variable, plan.try_value_into_string()?.as_str())?;
+        self.ctx.get_session_vars_mut().set(
+            &plan.variable,
+            plan.try_value_into_string()?.as_str(),
+            VarSetter::User,
+        )?;
         Ok(())
     }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -181,15 +181,15 @@ impl Session {
     /// All system schemas (including `information_schema`) should already be in
     /// the provided catalog.
     pub fn new(
-        info: Arc<SessionInfo>,
+        vars: SessionVars,
         catalog: SessionCatalog,
         metastore: SupervisorClient,
         native_tables: NativeTableStorage,
         tracker: Arc<Tracker>,
         spill_path: Option<PathBuf>,
     ) -> Result<Session> {
-        let metrics = SessionMetrics::new(info.clone(), tracker);
-        let ctx = SessionContext::new(info, catalog, metastore, native_tables, metrics, spill_path);
+        // let metrics = SessionMetrics::new(info.clone(), tracker);
+        let ctx = SessionContext::new(vars, catalog, metastore, native_tables, spill_path);
         Ok(Session { ctx })
     }
 

--- a/crates/sqlexec/src/vars.rs
+++ b/crates/sqlexec/src/vars.rs
@@ -13,87 +13,104 @@ use std::sync::Arc;
 const SERVER_VERSION: ServerVar<str> = ServerVar {
     name: "server_version",
     value: "15.1",
+    group: "postgres",
+    user_configurable: false,
 };
 
 const APPLICATION_NAME: ServerVar<str> = ServerVar {
     name: "application_name",
     value: "",
+    group: "postgres",
+    user_configurable: true,
 };
 
 const CLIENT_ENCODING: ServerVar<str> = ServerVar {
     name: "client_encoding",
     value: "UTF8",
+    group: "postgres",
+    user_configurable: true,
 };
 
 const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
     name: "extra_float_digits",
     value: &1,
+    group: "postgres",
+    user_configurable: true,
 };
 
 const STATEMENT_TIMEOUT: ServerVar<i32> = ServerVar {
     name: "statement_timeout",
     value: &0,
+    group: "postgres",
+    user_configurable: true,
 };
 
 const TIMEZONE: ServerVar<str> = ServerVar {
     name: "TimeZone",
     value: "UTC",
+    group: "postgres",
+    user_configurable: true,
 };
 
 const DATESTYLE: ServerVar<str> = ServerVar {
     name: "DateStyle",
     value: "ISO",
+    group: "postgres",
+    user_configurable: true,
 };
 
 const TRANSACTION_ISOLATION: ServerVar<str> = ServerVar {
     name: "transaction_isolation",
     value: "read uncommitted",
+    group: "postgres",
+    user_configurable: false,
 };
 
 static DEFAULT_SEARCH_PATH: Lazy<[String; 1]> = Lazy::new(|| [DEFAULT_SCHEMA.to_owned()]);
 static SEARCH_PATH: Lazy<ServerVar<[String]>> = Lazy::new(|| ServerVar {
     name: "search_path",
     value: &*DEFAULT_SEARCH_PATH,
+    group: "postgres",
+    user_configurable: true,
 });
 
-// GlareDB specific.
 static GLAREDB_VERSION_OWNED: Lazy<String> =
     Lazy::new(|| format!("v{}", env!("CARGO_PKG_VERSION")));
 static GLAREDB_VERSION: Lazy<ServerVar<str>> = Lazy::new(|| ServerVar {
     name: "glaredb_version",
     value: &GLAREDB_VERSION_OWNED,
+    group: "glaredb",
+    user_configurable: false,
 });
 
-// GlareDB specific.
 const ENABLE_DEBUG_DATASOURCES: ServerVar<bool> = ServerVar {
     name: "enable_debug_datasources",
     value: &false,
+    group: "glaredb",
+    user_configurable: true,
 };
 
-// GlareDB specific.
 const FORCE_CATALOG_REFRESH: ServerVar<bool> = ServerVar {
     name: "force_catalog_refresh",
     value: &false,
+    group: "glaredb",
+    user_configurable: true,
 };
 
 /// Variables for a session.
-///
-/// Variables that can be changed are of the `SessionVar` type, and default to
-/// the system default if left unset. Variables that cannot be changed are of
-/// the `SystemVar` type.
 pub struct SessionVars {
-    pub server_version: ServerVar<str>,
+    pub server_version: SessionVar<str>,
     pub application_name: SessionVar<str>,
     pub client_encoding: SessionVar<str>,
     pub extra_floating_digits: SessionVar<i32>,
     pub statement_timeout: SessionVar<i32>,
     pub timezone: SessionVar<str>,
     pub datestyle: SessionVar<str>,
-    pub transaction_isolation: ServerVar<str>,
+    pub transaction_isolation: SessionVar<str>,
     pub search_path: SessionVar<[String]>,
     pub enable_debug_datasources: SessionVar<bool>,
     pub force_catalog_refresh: SessionVar<bool>,
-    pub glaredb_version: &'static ServerVar<str>,
+    pub glaredb_version: SessionVar<str>,
 }
 
 impl SessionVars {
@@ -133,40 +150,38 @@ impl SessionVars {
         } else if name.eq_ignore_ascii_case(FORCE_CATALOG_REFRESH.name) {
             Ok(&self.force_catalog_refresh)
         } else if name.eq_ignore_ascii_case(GLAREDB_VERSION.name) {
-            Ok(self.glaredb_version)
+            Ok(&self.glaredb_version)
         } else {
             Err(ExecError::UnknownVariable(name.to_string()))
         }
     }
 
     /// Try to set a value for a variable.
-    pub fn set(&mut self, name: &str, val: &str) -> Result<()> {
+    pub fn set(&mut self, name: &str, val: &str, setter: VarSetter) -> Result<()> {
         if name.eq_ignore_ascii_case(SERVER_VERSION.name) {
-            Err(ExecError::VariableReadonly(SERVER_VERSION.name.to_string()))
+            self.server_version.set(val, setter)
         } else if name.eq_ignore_ascii_case(APPLICATION_NAME.name) {
-            self.application_name.set(val)
+            self.application_name.set(val, setter)
         } else if name.eq_ignore_ascii_case(CLIENT_ENCODING.name) {
-            self.client_encoding.set(val)
+            self.client_encoding.set(val, setter)
         } else if name.eq_ignore_ascii_case(EXTRA_FLOAT_DIGITS.name) {
-            self.extra_floating_digits.set(val)
+            self.extra_floating_digits.set(val, setter)
         } else if name.eq_ignore_ascii_case(STATEMENT_TIMEOUT.name) {
-            self.statement_timeout.set(val)
+            self.statement_timeout.set(val, setter)
         } else if name.eq_ignore_ascii_case(TIMEZONE.name) {
-            self.timezone.set(val)
+            self.timezone.set(val, setter)
         } else if name.eq_ignore_ascii_case(DATESTYLE.name) {
-            self.datestyle.set(val)
+            self.datestyle.set(val, setter)
         } else if name.eq_ignore_ascii_case(TRANSACTION_ISOLATION.name) {
-            Err(ExecError::VariableReadonly(SERVER_VERSION.name.to_string()))
+            self.transaction_isolation.set(val, setter)
         } else if name.eq_ignore_ascii_case(SEARCH_PATH.name) {
-            self.search_path.set(val)
+            self.search_path.set(val, setter)
         } else if name.eq_ignore_ascii_case(ENABLE_DEBUG_DATASOURCES.name) {
-            self.enable_debug_datasources.set(val)
+            self.enable_debug_datasources.set(val, setter)
         } else if name.eq_ignore_ascii_case(FORCE_CATALOG_REFRESH.name) {
-            self.force_catalog_refresh.set(val)
+            self.force_catalog_refresh.set(val, setter)
         } else if name.eq_ignore_ascii_case(GLAREDB_VERSION.name) {
-            Err(ExecError::VariableReadonly(
-                GLAREDB_VERSION.name.to_string(),
-            ))
+            self.glaredb_version.set(val, setter)
         } else {
             Err(ExecError::UnknownVariable(name.to_string()))
         }
@@ -176,18 +191,18 @@ impl SessionVars {
 impl Default for SessionVars {
     fn default() -> Self {
         SessionVars {
-            server_version: SERVER_VERSION,
+            server_version: SessionVar::new(&SERVER_VERSION),
             application_name: SessionVar::new(&APPLICATION_NAME),
             client_encoding: SessionVar::new(&CLIENT_ENCODING),
             extra_floating_digits: SessionVar::new(&EXTRA_FLOAT_DIGITS),
             statement_timeout: SessionVar::new(&STATEMENT_TIMEOUT),
             timezone: SessionVar::new(&TIMEZONE),
             datestyle: SessionVar::new(&DATESTYLE),
-            transaction_isolation: TRANSACTION_ISOLATION,
+            transaction_isolation: SessionVar::new(&TRANSACTION_ISOLATION),
             search_path: SessionVar::new(&SEARCH_PATH),
             enable_debug_datasources: SessionVar::new(&ENABLE_DEBUG_DATASOURCES),
             force_catalog_refresh: SessionVar::new(&FORCE_CATALOG_REFRESH),
-            glaredb_version: &GLAREDB_VERSION,
+            glaredb_version: SessionVar::new(&GLAREDB_VERSION),
         }
     }
 }
@@ -208,12 +223,36 @@ pub trait AnyVar {
     }
 }
 
+/// Who's trying to set the variable.
+#[derive(Debug, Clone, Copy)]
+pub enum VarSetter {
+    /// The user is trying to set the variable.
+    ///
+    /// Attempting to set a variable that's not user-configurable as a user
+    /// should return an error.
+    User,
+    /// The system is trying to set the variable.
+    System,
+}
+
 /// Static configuration variables. These are all defined in code and are not
 /// persisted.
 #[derive(Debug)]
 pub struct ServerVar<T: Value + ?Sized + 'static> {
+    /// Name of the variable.
     name: &'static str,
+
+    /// Starting value of the variable.
     value: &'static T,
+
+    /// Variable group.
+    ///
+    /// This allows us to differentiate between variables needed for postgres
+    /// compat, and variables custom to glaredb.
+    group: &'static str,
+
+    /// Whether or not this variable can be set by the user.
+    user_configurable: bool,
 }
 
 impl<T: Value + ?Sized + 'static> ServerVar<T> {
@@ -258,7 +297,11 @@ impl<T: Value + ?Sized + 'static> SessionVar<T> {
     }
 
     /// Set a value for this variable.
-    fn set(&mut self, s: &str) -> Result<()> {
+    fn set(&mut self, s: &str, setter: VarSetter) -> Result<()> {
+        if !self.inherit.user_configurable && matches!(setter, VarSetter::User) {
+            return Err(ExecError::VariableReadonly(self.inherit.name.to_string()));
+        }
+
         match T::try_parse(s) {
             Some(v) => self.value = Some(v),
             None => {
@@ -384,5 +427,41 @@ mod tests {
             let out = split_comma_delimited(test.input);
             assert_eq!(test.expected, out);
         }
+    }
+
+    #[test]
+    fn user_configurable() {
+        const SETTABLE: ServerVar<str> = ServerVar {
+            name: "unsettable",
+            value: "test",
+            group: "test",
+            user_configurable: true,
+        };
+        let mut var = SessionVar::new(&SETTABLE);
+        var.set("user", VarSetter::User).unwrap();
+        assert_eq!("user", var.value());
+
+        // Should also be able to be set by the system.
+        var.set("system", VarSetter::System).unwrap();
+        assert_eq!("system", var.value());
+    }
+
+    #[test]
+    fn not_user_configurable() {
+        const UNSETTABLE: ServerVar<str> = ServerVar {
+            name: "unsettable",
+            value: "test",
+            group: "test",
+            user_configurable: false,
+        };
+        let mut var = SessionVar::new(&UNSETTABLE);
+        var.set("custom", VarSetter::User)
+            .expect_err("Unsettable var should not be allowed to be set by user");
+
+        assert_eq!("test", var.value());
+
+        // System should be able to set the var.
+        var.set("custom", VarSetter::System).unwrap();
+        assert_eq!("custom", var.value());
     }
 }

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -21,7 +21,10 @@ use uuid::Uuid;
 
 use metastore::local::{start_inprocess_inmemory, start_inprocess_local};
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
-use sqlexec::engine::{Engine, EngineStorageConfig, SessionLimits, SessionStorageConfig};
+use sqlexec::{
+    engine::{Engine, EngineStorageConfig, SessionLimits, SessionStorageConfig},
+    vars::SessionVars,
+};
 use telemetry::Tracker;
 
 /// Ensure that a directory at the given path exists. Errors if the path exists
@@ -98,15 +101,7 @@ fn connect(
             .map_err(PyGlareDbError::from)?;
 
         let mut session = engine
-            .new_session(
-                Uuid::nil(),
-                "glaredb".to_string(),
-                Uuid::nil(),
-                Uuid::nil(),
-                "glaredb".to_string(),
-                SessionLimits::default(),
-                SessionStorageConfig::default(),
-            )
+            .new_session(SessionVars::default(), SessionStorageConfig::default())
             .await
             .map_err(PyGlareDbError::from)?;
 

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -17,12 +17,11 @@ use std::{
     },
 };
 use tokio::runtime::Builder;
-use uuid::Uuid;
 
 use metastore::local::{start_inprocess_inmemory, start_inprocess_local};
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
 use sqlexec::{
-    engine::{Engine, EngineStorageConfig, SessionLimits, SessionStorageConfig},
+    engine::{Engine, EngineStorageConfig, SessionStorageConfig},
     vars::SessionVars,
 };
 use telemetry::Tracker;


### PR DESCRIPTION
Adds read-only session variables, and moves a bunch of session configuration to `SessionVars`.

Moving session configuration to `SessionVars` provides the following benefits:

- Centralizes session configuration. This still _some_ amount of configuration not stored here, but we can work on moving stuff into this as needed.
- Allows users to inspect variables.

As a user, I can now view session limits (and more) via the `SHOW` command:

```sql
〉show memory_limit_bytes;
+--------------------+
| memory_limit_bytes |
+--------------------+
| None               |
+--------------------+
```

Attempting to set a read-only session var will error:

```sql
〉set memory_limit_bytes to 9999;
Error: Variable is readonly: memory_limit_bytes
```

This may be useful with https://github.com/GlareDB/glaredb/issues/1324 in that we can add an `enable_local_datasources` variable that gets set to false in pgsrv.