### PR TITLE
chore: Remove dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,12 +29,3 @@ updates:
 
     reviewers:
       - "scsmithr" 
-
-    groups:
-      cargo-dependencies:
-        patterns:
-          - "*" # Maintain all deps.
-        exclude-patterns:
-          - "datafusion"
-          - "deltalake"
-          - "object_store"


### PR DESCRIPTION
Well what if there's an incompatability with a dep?