### PR TITLE
fix(datasources): disable reading from local filesystem on remote ins…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion_ext"
+version = "0.2.1"
+dependencies = [
+ "datafusion",
+ "once_cell",
+ "regex",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "datafusion_planner"
 version = "0.2.1"
 dependencies = [
@@ -1715,6 +1727,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "datafusion",
+ "datafusion_ext",
  "decimal",
  "deltalake",
  "futures",
@@ -2438,6 +2451,7 @@ dependencies = [
  "clap",
  "colored",
  "datafusion",
+ "datafusion_ext",
  "futures",
  "logutil",
  "metastore",
@@ -3905,6 +3919,7 @@ dependencies = [
  "bytes",
  "bytesutil",
  "datafusion",
+ "datafusion_ext",
  "futures",
  "pgrepr",
  "reqwest",
@@ -4298,6 +4313,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "datafusion",
+ "datafusion_ext",
  "futures",
  "metastore",
  "once_cell",
@@ -5575,6 +5591,7 @@ version = "0.2.1"
 dependencies = [
  "async-trait",
  "datafusion",
+ "datafusion_ext",
  "datafusion_planner",
  "datasources",
  "futures",

--- a/crates/datafusion_ext/Cargo.toml
+++ b/crates/datafusion_ext/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "datafusion_ext"
+description = "Shared datafusion extensions"
+version = { workspace = true }
+edition = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+datafusion = { workspace = true }
+uuid = { version = "1.4.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+regex = "1.8"
+once_cell = "1.18.0"
+tracing = "0.1"
+thiserror.workspace = true

--- a/crates/datafusion_ext/src/lib.rs
+++ b/crates/datafusion_ext/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod vars;

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -21,11 +21,14 @@ futures = "0.3.28"
 gcp-bigquery-client = "0.17.0"
 logutil = {path = "../logutil"}
 metastore_client = { path = "../metastore_client" }
+datafusion_ext = { path = "../datafusion_ext" }
 mongodb = "2.6.0"
 mysql_async = { version = "0.32.2", default-features = false, features = ["default-rustls"] }
 mysql_common = { version = "0.30.6", features = ["chrono"] }
 object_store = { workspace = true, features = ["gcp", "aws", "http"] }
 object_store_util = { path = "../object_store_util" }
+
+
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 rand = "0.8.5"

--- a/crates/datasources/src/object_store/csv.rs
+++ b/crates/datasources/src/object_store/csv.rs
@@ -73,6 +73,8 @@ where
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
+        self.accessor.validate_access(ctx)?;
+
         let file = self.accessor.object_meta().as_ref().clone();
         let base_url = self.accessor.base_path();
         let url = url::Url::parse(&base_url).unwrap();

--- a/crates/datasources/src/object_store/json.rs
+++ b/crates/datasources/src/object_store/json.rs
@@ -68,11 +68,13 @@ where
 
     async fn scan(
         &self,
-        _ctx: &SessionState,
+        ctx: &SessionState,
         projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
+        self.accessor.validate_access(ctx)?;
+
         let file = self.accessor.object_meta().as_ref().clone().into();
         let base_url = self.accessor.base_path();
 

--- a/crates/datasources/src/object_store/mod.rs
+++ b/crates/datasources/src/object_store/mod.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use datafusion::datasource::TableProvider;
+use datafusion::error::Result as DatafusionResult;
+use datafusion::execution::context::SessionState;
 use errors::ObjectStoreSourceError;
 use object_store::path::Path as ObjectStorePath;
 use object_store::{ObjectMeta, ObjectStore};
@@ -56,6 +58,9 @@ pub trait TableAccessor: Send + Sync {
     /// - s3://bucket_name/path/to/file.parquet -> path/to/file.parquet
     fn location(&self) -> String;
     async fn into_table_provider(self, predicate_pushdown: bool) -> Result<Arc<dyn TableProvider>>;
+    fn validate_access(&self, _ctx: &SessionState) -> DatafusionResult<()> {
+        Ok(())
+    }
 }
 
 pub fn file_type_from_path(path: &ObjectStorePath) -> Result<FileType> {

--- a/crates/datasources/src/object_store/parquet.rs
+++ b/crates/datasources/src/object_store/parquet.rs
@@ -162,6 +162,8 @@ where
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
+        self.accessor.validate_access(ctx)?;
+
         let predicate = if self.predicate_pushdown {
             // Adapted from df...
             if let Some(expr) = conjunction(filters.to_vec()) {

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/bin/main.rs"
 logutil = {path = "../logutil"}
 sqlexec = {path = "../sqlexec"}
 telemetry = {path = "../telemetry"}
+datafusion_ext = {path = "../datafusion_ext"}
 datafusion = {workspace = true}
 pgsrv = {path = "../pgsrv"}
 pgrepr = {path = "../pgrepr"}

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -18,11 +18,11 @@ use once_cell::sync::Lazy;
 use pgrepr::format::Format;
 use reedline::{FileBackedHistory, Reedline, Signal};
 
+use datafusion_ext::vars::SessionVars;
 use sqlexec::engine::EngineStorageConfig;
 use sqlexec::engine::{Engine, SessionStorageConfig, TrackedSession};
 use sqlexec::parser;
 use sqlexec::session::ExecutionResult;
-use sqlexec::vars::SessionVars;
 use std::env;
 use std::fmt::Write as _;
 use std::io::Write;

--- a/crates/pgsrv/Cargo.toml
+++ b/crates/pgsrv/Cargo.toml
@@ -10,6 +10,7 @@ sqlexec = {path = "../sqlexec"}
 serde = { version = "1.0", features = ["derive"] }
 bytesutil = {path = "../bytesutil"}
 pgrepr = {path = "../pgrepr"}
+datafusion_ext = {path = "../datafusion_ext"}
 thiserror.workspace = true
 tracing = "0.1"
 futures = "0.3.28"

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -14,12 +14,12 @@ use crate::ssl::{Connection, SslConfig};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::scalar::ScalarValue;
+use datafusion_ext::vars::{SessionVars, VarSetter};
 use futures::StreamExt;
 use pgrepr::format::Format;
 use pgrepr::scalar::Scalar;
 use sqlexec::context::{OutputFields, Portal, PreparedStatement};
 use sqlexec::engine::SessionStorageConfig;
-use sqlexec::vars::{SessionVars, VarSetter};
 use sqlexec::{
     engine::Engine,
     parser::{self, StatementWithExtensions},
@@ -252,6 +252,7 @@ impl ProtocolHandler {
             .set_and_log(Some(max_tunnel_count), VarSetter::System);
         vars.max_credentials_count
             .set_and_log(Some(max_credentials_count), VarSetter::System);
+        vars.is_cloud_instance.set_and_log(true, VarSetter::System);
 
         // Set other params provided on startup. Note that these are all set as
         // the "user" since these include values set in options.

--- a/crates/sqlexec/Cargo.toml
+++ b/crates/sqlexec/Cargo.toml
@@ -13,6 +13,7 @@ datafusion_planner = { path = "../datafusion_planner" }
 telemetry = {path = "../telemetry"}
 sqlbuiltins = {path = "../sqlbuiltins"}
 datasources = {path = "../datasources"}
+datafusion_ext = {path = "../datafusion_ext"}
 object_store_util = {path = "../object_store_util"}
 thiserror.workspace = true
 tokio = { version = "1", features = ["full"] }

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -6,7 +6,6 @@ use crate::parser::{CustomParser, StatementWithExtensions};
 use crate::planner::errors::PlanError;
 use crate::planner::logical_plan::*;
 use crate::planner::session_planner::SessionPlanner;
-use crate::vars::SessionVars;
 use datafusion::arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{Column as DfColumn, SchemaReference};
@@ -22,6 +21,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
+use datafusion_ext::vars::SessionVars;
 use datasources::native::access::NativeTableStorage;
 use datasources::object_store::registry::GlareDBRegistry;
 use futures::{future::BoxFuture, StreamExt};
@@ -108,7 +108,8 @@ impl SessionContext {
         let mut config_opts = ConfigOptions::new();
         config_opts.catalog = catalog_opts;
         config_opts.optimizer = optimizer_opts;
-        let config: SessionConfig = config_opts.into();
+        let mut config: SessionConfig = config_opts.into();
+        config = config.with_extension(Arc::new(vars.clone()));
 
         // Create a new datafusion runtime env with disk manager and memory pool
         // if needed.

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -2,7 +2,7 @@ use crate::background_jobs::JobRunner;
 use crate::errors::{ExecError, Result};
 use crate::metastore::{Supervisor, DEFAULT_WORKER_CONFIG};
 use crate::session::Session;
-use crate::vars::SessionVars;
+use datafusion_ext::vars::SessionVars;
 
 use std::fs;
 use std::ops::{Deref, DerefMut};

--- a/crates/sqlexec/src/lib.rs
+++ b/crates/sqlexec/src/lib.rs
@@ -6,7 +6,6 @@ pub mod errors;
 pub mod metastore;
 pub mod parser;
 pub mod session;
-pub mod vars;
 
 mod background_jobs;
 mod functions;

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -5,13 +5,13 @@ use crate::metastore::SupervisorClient;
 use crate::metrics::{BatchStreamWithMetricSender, ExecutionStatus, QueryMetrics, SessionMetrics};
 use crate::parser::StatementWithExtensions;
 use crate::planner::logical_plan::*;
-use crate::vars::{SessionVars, VarSetter};
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::insert::DataSink;
 use datafusion::physical_plan::{
     execute_stream, memory::MemoryStream, ExecutionPlan, SendableRecordBatchStream,
 };
 use datafusion::scalar::ScalarValue;
+use datafusion_ext::vars::{SessionVars, VarSetter};
 use datasources::common::sink::csv::{CsvSink, CsvSinkOpts};
 use datasources::common::sink::json::{JsonSink, JsonSinkOpts};
 use datasources::common::sink::parquet::{ParquetSink, ParquetSinkOpts};

--- a/py-glaredb/Cargo.toml
+++ b/py-glaredb/Cargo.toml
@@ -20,6 +20,7 @@ metastore = { path = "../crates/metastore" }
 telemetry = { path = "../crates/telemetry" }
 pgsrv = { path = "../crates/pgsrv" }
 pgrepr = { path = "../crates/pgrepr" }
+datafusion_ext = { path = "../crates/datafusion_ext" }
 futures = "0.3.28"
 url = "2.4.0"
 uuid = "1.4.0"

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -18,12 +18,11 @@ use std::{
 };
 use tokio::runtime::Builder;
 
+use datafusion_ext::vars::SessionVars;
 use metastore::local::{start_inprocess_inmemory, start_inprocess_local};
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
-use sqlexec::{
-    engine::{Engine, EngineStorageConfig, SessionStorageConfig},
-    vars::SessionVars,
-};
+use sqlexec::engine::{Engine, EngineStorageConfig, SessionStorageConfig};
+
 use telemetry::Tracker;
 
 /// Ensure that a directory at the given path exists. Errors if the path exists


### PR DESCRIPTION
…tances


closes #1324

I'm not really sure the best way to properly test this one out, but I've tested it by manually changing the boolean flag & it works as expected.

# Summary:

I had to move the `vars` into a new shared crate `datafusion_ext` as it was resulting in circular dependencies otherwise. The idea is that any native extensions for datafusion could go in here (such as the upcoming protobuf extensions).

other than that, there were a few other small changes to get `vars` to work with datafusion namely implementing `Clone` and adding a description. 

It clones the sessionvars when the session is created, so these are readonly at the moment. We can make them writable if the need arises. 


the actual validation logic happens in `scan` where we have access to `ctx`. I was thinking of passing `ctx` to some of the tableprovider functions, but it seemed to have a ripple effect that i thought would muddle this PR. So it will error when the initial scan occurs. 