### PR TITLE
feat: Add background job to track storage usage

### DIFF
--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -2,8 +2,8 @@
 use crate::errors::{MetastoreError, Result};
 use crate::storage::persist::Storage;
 use metastore_client::types::catalog::{
-    CatalogEntry, CatalogState, CredentialsEntry, DatabaseEntry, EntryMeta, EntryType,
-    FunctionEntry, FunctionType, SchemaEntry, TableEntry, TunnelEntry, ViewEntry,
+    CatalogEntry, CatalogState, CredentialsEntry, DatabaseEntry, DeploymentMetadata, EntryMeta,
+    EntryType, FunctionEntry, FunctionType, SchemaEntry, TableEntry, TunnelEntry, ViewEntry,
 };
 use metastore_client::types::options::{
     DatabaseOptions, DatabaseOptionsInternal, TableOptions, TunnelOptions,
@@ -149,6 +149,7 @@ impl DatabaseCatalog {
         CatalogState {
             version: guard.version,
             entries: guard.entries.as_ref().clone(),
+            deployment: guard.deployment.clone(),
         }
     }
 
@@ -284,6 +285,8 @@ enum CreatePolicy {
 struct State {
     /// Version incremented on every update.
     version: u64,
+    /// Deployment metadata.
+    deployment: DeploymentMetadata,
     /// Next OID to use.
     oid_counter: u32,
     /// All entries in the catalog.
@@ -435,6 +438,7 @@ impl State {
 
         let internal_state = State {
             version: state.version,
+            deployment: state.deployment,
             oid_counter: persisted.extra.oid_counter,
             entries: state.entries.into(),
             database_names,
@@ -455,6 +459,7 @@ impl State {
         PersistedCatalog {
             state: CatalogState {
                 version: self.version,
+                deployment: self.deployment.clone(),
                 entries: self
                     .entries
                     .as_ref()
@@ -924,6 +929,10 @@ impl State {
                         },
                         _ => unreachable!("entry should be a tunnel"),
                     };
+                }
+                Mutation::UpdateDeploymentStorage(update_deployment_storage) => {
+                    // Update the new storage size
+                    self.deployment.storage_size = update_deployment_storage.new_storage_size;
                 }
             }
         }

--- a/crates/metastore/src/storage/persist.rs
+++ b/crates/metastore/src/storage/persist.rs
@@ -4,7 +4,7 @@ use crate::storage::{
 };
 use bytes::BytesMut;
 use metastore_client::proto::storage;
-use metastore_client::types::catalog::CatalogState;
+use metastore_client::types::catalog::{CatalogState, DeploymentMetadata};
 use metastore_client::types::storage::{CatalogMetadata, ExtraState, PersistedCatalog};
 use object_store::{Error as ObjectStoreError, ObjectStore};
 use pgrepr::oid::FIRST_AVAILABLE_ID;
@@ -68,6 +68,7 @@ impl Storage {
             state: CatalogState {
                 version: 0,
                 entries: HashMap::new(),
+                deployment: DeploymentMetadata { storage_size: 0 },
             },
             extra: ExtraState {
                 oid_counter: FIRST_AVAILABLE_ID,

--- a/crates/metastore_client/proto/catalog.proto
+++ b/crates/metastore_client/proto/catalog.proto
@@ -43,7 +43,16 @@ message CatalogState {
   // ID -> Entry
   map<uint32, CatalogEntry> entries = 2;
 
-  // next: 3
+  // Metadata for the deployment.
+  DeploymentMetadata deployment = 3;
+  
+  // next: 4
+}
+
+// Metadata for the deployment.
+message DeploymentMetadata {
+  // Current (native) storage used by the deployment.
+  uint64 storage_size = 1;
 }
 
 // Possible top-level catalog entries.

--- a/crates/metastore_client/proto/service.proto
+++ b/crates/metastore_client/proto/service.proto
@@ -50,8 +50,9 @@ message Mutation {
     CreateTable create_table = 14;
     CreateCredentials create_credentials = 15;
     DropCredentials drop_credentials = 16;
+    UpdateDeploymentStorage update_deployment_storage = 17;
   }
-  // next: 17
+  // next: 18
 }
 
 message DropDatabase {
@@ -144,6 +145,10 @@ message CreateCredentials {
 message DropCredentials {
   string name = 1;
   bool if_exists = 2;
+}
+
+message UpdateDeploymentStorage {
+  uint64 new_storage_size = 1;
 }
 
 message MutateRequest {

--- a/crates/metastore_client/src/session.rs
+++ b/crates/metastore_client/src/session.rs
@@ -1,6 +1,6 @@
 use crate::types::catalog::{
-    CatalogEntry, CatalogState, CredentialsEntry, DatabaseEntry, EntryType, SchemaEntry,
-    TunnelEntry,
+    CatalogEntry, CatalogState, CredentialsEntry, DatabaseEntry, DeploymentMetadata, EntryType,
+    SchemaEntry, TunnelEntry,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -48,6 +48,11 @@ impl SessionCatalog {
     pub fn swap_state(&mut self, new_state: Arc<CatalogState>) {
         self.state = new_state;
         self.rebuild_name_maps();
+    }
+
+    /// Returns the deployment metadata.
+    pub fn deployment_metadata(&self) -> DeploymentMetadata {
+        self.state.deployment.clone()
     }
 
     /// Resolve a database by name.

--- a/crates/metastore_client/src/types/catalog.rs
+++ b/crates/metastore_client/src/types/catalog.rs
@@ -12,6 +12,7 @@ use std::fmt;
 pub struct CatalogState {
     pub version: u64,
     pub entries: HashMap<u32, CatalogEntry>,
+    pub deployment: DeploymentMetadata,
 }
 
 impl TryFrom<catalog::CatalogState> for CatalogState {
@@ -24,6 +25,7 @@ impl TryFrom<catalog::CatalogState> for CatalogState {
         Ok(CatalogState {
             version: value.version,
             entries,
+            deployment: value.deployment.required("deployment")?,
         })
     }
 }
@@ -41,6 +43,31 @@ impl TryFrom<CatalogState> for catalog::CatalogState {
                     Err(e) => Err(e),
                 })
                 .collect::<Result<_, _>>()?,
+            deployment: Some(value.deployment.try_into()?),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DeploymentMetadata {
+    pub storage_size: u64,
+}
+
+impl TryFrom<catalog::DeploymentMetadata> for DeploymentMetadata {
+    type Error = ProtoConvError;
+    fn try_from(value: catalog::DeploymentMetadata) -> Result<Self, Self::Error> {
+        Ok(Self {
+            storage_size: value.storage_size,
+        })
+    }
+}
+
+impl TryFrom<DeploymentMetadata> for catalog::DeploymentMetadata {
+    type Error = ProtoConvError;
+
+    fn try_from(value: DeploymentMetadata) -> Result<Self, Self::Error> {
+        Ok(Self {
+            storage_size: value.storage_size,
         })
     }
 }

--- a/crates/metastore_client/src/types/service.rs
+++ b/crates/metastore_client/src/types/service.rs
@@ -22,6 +22,8 @@ pub enum Mutation {
     AlterTunnelRotateKeys(AlterTunnelRotateKeys),
     CreateCredentials(CreateCredentials),
     DropCredentials(DropCredentials),
+    // Deployment metadata updates
+    UpdateDeploymentStorage(UpdateDeploymentStorage),
 }
 
 impl TryFrom<service::Mutation> for Mutation {
@@ -64,6 +66,9 @@ impl TryFrom<service::mutation::Mutation> for Mutation {
             service::mutation::Mutation::DropCredentials(v) => {
                 Mutation::DropCredentials(v.try_into()?)
             }
+            service::mutation::Mutation::UpdateDeploymentStorage(v) => {
+                Mutation::UpdateDeploymentStorage(v.try_into()?)
+            }
         })
     }
 }
@@ -99,6 +104,9 @@ impl TryFrom<Mutation> for service::mutation::Mutation {
                 service::mutation::Mutation::CreateCredentials(v.into())
             }
             Mutation::DropCredentials(v) => service::mutation::Mutation::DropCredentials(v.into()),
+            Mutation::UpdateDeploymentStorage(v) => {
+                service::mutation::Mutation::UpdateDeploymentStorage(v.into())
+            }
         })
     }
 }
@@ -533,6 +541,28 @@ impl From<DropCredentials> for service::DropCredentials {
         service::DropCredentials {
             name: value.name,
             if_exists: value.if_exists,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+pub struct UpdateDeploymentStorage {
+    pub new_storage_size: u64,
+}
+
+impl TryFrom<service::UpdateDeploymentStorage> for UpdateDeploymentStorage {
+    type Error = ProtoConvError;
+    fn try_from(value: service::UpdateDeploymentStorage) -> Result<Self, Self::Error> {
+        Ok(Self {
+            new_storage_size: value.new_storage_size,
+        })
+    }
+}
+
+impl From<UpdateDeploymentStorage> for service::UpdateDeploymentStorage {
+    fn from(value: UpdateDeploymentStorage) -> Self {
+        Self {
+            new_storage_size: value.new_storage_size,
         }
     }
 }

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -200,6 +200,15 @@ pub static GLARE_SSH_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     ]),
 });
 
+pub static GLARE_DEPLOYMENT_METADATA: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    schema: INTERNAL_SCHEMA,
+    name: "deployment_metadata",
+    columns: InternalColumnDefinition::from_tuples([
+        ("key", DataType::Utf8, false),
+        ("value", DataType::Utf8, false),
+    ]),
+});
+
 impl BuiltinTable {
     /// Check if this table matches the provided schema and name.
     pub fn matches(&self, schema: &str, name: &str) -> bool {
@@ -229,6 +238,7 @@ impl BuiltinTable {
             &GLARE_FUNCTIONS,
             &GLARE_SESSION_QUERY_METRICS,
             &GLARE_SSH_KEYS,
+            &GLARE_DEPLOYMENT_METADATA,
         ]
     }
 }

--- a/crates/sqlexec/src/background_jobs/storage.rs
+++ b/crates/sqlexec/src/background_jobs/storage.rs
@@ -1,0 +1,130 @@
+//! Background jobs for storage tracking.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use datasources::native::access::NativeTableStorage;
+use metastore_client::types::service::{Mutation, UpdateDeploymentStorage};
+use tokio::time::Instant;
+
+use crate::{errors::Result, metastore::SupervisorClient};
+
+use super::BgJob;
+
+#[derive(Debug)]
+pub struct BackgroundJobStorageTracker {
+    native_store: NativeTableStorage,
+    metastore: SupervisorClient,
+}
+
+impl BackgroundJobStorageTracker {
+    pub fn new(native_store: NativeTableStorage, metastore: SupervisorClient) -> Arc<Self> {
+        Arc::new(Self {
+            native_store,
+            metastore,
+        })
+    }
+}
+
+#[async_trait]
+impl BgJob for BackgroundJobStorageTracker {
+    fn name(&self) -> String {
+        format!("storage_tracker_{}", self.native_store.db_id())
+    }
+
+    fn start_at(&self) -> Instant {
+        // Start after 5 minutes of scheduling the job, so we can batch jobs for
+        // frequently updating tables.
+        Instant::now() + Duration::from_secs(5 * 60)
+    }
+
+    async fn start(&self) -> Result<()> {
+        let total_size = self.native_store.calculate_db_size().await?;
+
+        // Update the storage size in metastore.
+        self.metastore.refresh_cached_state().await?;
+        let state = self.metastore.get_cached_state().await?;
+        self.metastore
+            .try_mutate(
+                state.version,
+                vec![Mutation::UpdateDeploymentStorage(UpdateDeploymentStorage {
+                    new_storage_size: total_size as u64,
+                })],
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::DataType;
+    use datasources::native::access::NativeTableStorage;
+    use metastore::local::start_inprocess_inmemory;
+    use metastore_client::types::{
+        catalog::{EntryMeta, EntryType, TableEntry},
+        options::{InternalColumnDefinition, TableOptions, TableOptionsInternal},
+    };
+    use object_store_util::conf::StorageConfig;
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    use crate::{
+        background_jobs::JobRunner,
+        metastore::{Supervisor, DEFAULT_WORKER_CONFIG},
+    };
+
+    use super::BackgroundJobStorageTracker;
+
+    #[tokio::test]
+    async fn test_background_job_storage_tracker() {
+        let db_id = Uuid::new_v4();
+        let dir = tempdir().unwrap();
+
+        let storage = NativeTableStorage::from_config(
+            db_id,
+            StorageConfig::Local {
+                path: dir.path().to_path_buf(),
+            },
+        )
+        .unwrap();
+
+        // Add some tables inside the temp dir to get a non-zero storage size.
+        storage
+            .create_table(&TableEntry {
+                meta: EntryMeta {
+                    entry_type: EntryType::Table,
+                    id: 12345,
+                    parent: 54321,
+                    name: "table_1".to_string(),
+                    builtin: false,
+                    external: false,
+                },
+                options: TableOptions::Internal(TableOptionsInternal {
+                    columns: vec![InternalColumnDefinition {
+                        name: "id".to_string(),
+                        nullable: true,
+                        arrow_type: DataType::Int32,
+                    }],
+                }),
+                tunnel_id: None,
+            })
+            .await
+            .unwrap();
+
+        let meta_chan = start_inprocess_inmemory().await.unwrap();
+        let metastore = Supervisor::new(meta_chan, DEFAULT_WORKER_CONFIG);
+        let metastore = metastore.init_client(Uuid::new_v4(), db_id).await.unwrap();
+
+        let tracker = BackgroundJobStorageTracker::new(storage, metastore.clone());
+        let jobs = JobRunner::new(Default::default());
+        jobs.add(tracker).unwrap();
+        jobs.close().await.unwrap();
+
+        // Check if data exists in metastore.
+        metastore.refresh_cached_state().await.unwrap();
+        let state = metastore.get_cached_state().await.unwrap();
+        assert_ne!(state.deployment.storage_size, 0);
+    }
+}

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -1,3 +1,5 @@
+use crate::background_jobs::storage::BackgroundJobStorageTracker;
+use crate::background_jobs::JobRunner;
 use crate::environment::EnvironmentReader;
 use crate::errors::{internal, ExecError, Result};
 use crate::metastore::SupervisorClient;
@@ -79,6 +81,8 @@ pub struct SessionContext {
     df_state: SessionState,
     /// Read tables from the environment.
     env_reader: Option<Box<dyn EnvironmentReader>>,
+    /// Job runner for background jobs.
+    background_jobs: JobRunner,
 }
 
 impl SessionContext {
@@ -97,6 +101,7 @@ impl SessionContext {
         native_tables: NativeTableStorage,
         metrics: SessionMetrics,
         spill_path: Option<PathBuf>,
+        background_jobs: JobRunner,
     ) -> SessionContext {
         // NOTE: We handle catalog/schema defaults and information schemas
         // ourselves.
@@ -149,6 +154,7 @@ impl SessionContext {
             metrics,
             df_state: state,
             env_reader: None,
+            background_jobs,
         }
     }
 
@@ -313,6 +319,11 @@ impl SessionContext {
         while let Some(res) = stream.next().await {
             let _ = res?;
         }
+
+        // Add the storage tracker job once data is inserted.
+        let tracker = BackgroundJobStorageTracker::new(self.tables.clone(), self.metastore.clone());
+        self.background_jobs.add(tracker)?;
+
         Ok(())
     }
 

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -118,7 +118,7 @@ impl Engine {
             storage,
             spill_path,
             session_counter: Arc::new(AtomicU64::new(0)),
-            background_jobs: JobRunner::new(),
+            background_jobs: JobRunner::new(Default::default()),
         })
     }
 
@@ -157,6 +157,7 @@ impl Engine {
             native,
             self.tracker.clone(),
             self.spill_path.clone(),
+            self.background_jobs.clone(),
         )?;
 
         let prev = self.session_counter.fetch_add(1, Ordering::Relaxed);

--- a/crates/sqlexec/src/metastore.rs
+++ b/crates/sqlexec/src/metastore.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_WORKER_CONFIG: WorkerRunConfig = WorkerRunConfig {
 };
 
 /// Worker client. This client can only make requests for a single database.
+#[derive(Debug, Clone)]
 pub struct SupervisorClient {
     /// Shared with worker. Used to hint if this client should get the latest
     /// state from the worker.

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -32,8 +32,9 @@ use metastore_client::types::options::{
 };
 use sqlbuiltins::builtins::{
     CURRENT_SESSION_SCHEMA, DATABASE_DEFAULT, DEFAULT_CATALOG, GLARE_COLUMNS, GLARE_CREDENTIALS,
-    GLARE_DATABASES, GLARE_FUNCTIONS, GLARE_SCHEMAS, GLARE_SESSION_QUERY_METRICS, GLARE_SSH_KEYS,
-    GLARE_TABLES, GLARE_TUNNELS, GLARE_VIEWS, SCHEMA_CURRENT_SESSION,
+    GLARE_DATABASES, GLARE_DEPLOYMENT_METADATA, GLARE_FUNCTIONS, GLARE_SCHEMAS,
+    GLARE_SESSION_QUERY_METRICS, GLARE_SSH_KEYS, GLARE_TABLES, GLARE_TUNNELS, GLARE_VIEWS,
+    SCHEMA_CURRENT_SESSION,
 };
 use std::str::FromStr;
 use std::sync::Arc;
@@ -533,6 +534,8 @@ impl<'a> SystemTableDispatcher<'a> {
             Arc::new(self.build_session_query_metrics())
         } else if GLARE_SSH_KEYS.matches(schema, name) {
             Arc::new(self.build_ssh_keys()?)
+        } else if GLARE_DEPLOYMENT_METADATA.matches(schema, name) {
+            Arc::new(self.build_glare_deployment_metadata()?)
         } else {
             return Err(DispatchError::MissingBuiltinTable {
                 schema: schema.to_string(),
@@ -1013,6 +1016,26 @@ impl<'a> SystemTableDispatcher<'a> {
                 Arc::new(ssh_tunnel_name.finish()),
                 Arc::new(public_key.finish()),
             ],
+        )
+        .unwrap();
+
+        Ok(MemTable::try_new(arrow_schema, vec![vec![batch]]).unwrap())
+    }
+
+    fn build_glare_deployment_metadata(&self) -> Result<MemTable> {
+        let arrow_schema = Arc::new(GLARE_DEPLOYMENT_METADATA.arrow_schema());
+        let deployment = self.catalog().deployment_metadata();
+
+        let (mut key, mut value): (StringBuilder, StringBuilder) = [(
+            Some("storage_size"),
+            Some(deployment.storage_size.to_string()),
+        )]
+        .into_iter()
+        .unzip();
+
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(key.finish()), Arc::new(value.finish())],
         )
         .unwrap();
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -1,3 +1,4 @@
+use crate::background_jobs::JobRunner;
 use crate::context::{Portal, PreparedStatement, SessionContext};
 use crate::environment::EnvironmentReader;
 use crate::errors::Result;
@@ -184,6 +185,7 @@ impl Session {
         native_tables: NativeTableStorage,
         tracker: Arc<Tracker>,
         spill_path: Option<PathBuf>,
+        background_jobs: JobRunner,
     ) -> Result<Session> {
         let metrics = SessionMetrics::new(
             *vars.user_id.value(),
@@ -191,7 +193,15 @@ impl Session {
             *vars.connection_id.value(),
             tracker,
         );
-        let ctx = SessionContext::new(vars, catalog, metastore, native_tables, metrics, spill_path);
+        let ctx = SessionContext::new(
+            vars,
+            catalog,
+            metastore,
+            native_tables,
+            metrics,
+            spill_path,
+            background_jobs,
+        );
         Ok(Session { ctx })
     }
 


### PR DESCRIPTION
Runs a background job on `INSERT`s (with a batch delay of 5 minutes) for the deployment.

```
〉select * from glare_catalog.deployment_metadata;
+--------------+-------+
| key          | value |
+--------------+-------+
| storage_size | 3852  |
+--------------+-------+
```

Fixes #1155