### PR TITLE
fix: error with truncate logic

### DIFF
--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -27,6 +27,13 @@ pub fn pretty_format_batches(
     create_table(batches, &TABLE_FORMAT_OPTS, width, max_rows, max_columns)
 }
 
+fn default_table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(DEFAULT_PRESET);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
 fn create_table(
     batches: &[RecordBatch],
     opts: &FormatOptions,
@@ -34,6 +41,9 @@ fn create_table(
     max_rows: Option<usize>,
     max_columns: Option<usize>,
 ) -> Result<Table, ArrowError> {
+    if batches.is_empty() {
+        return Ok(default_table());
+    }
     let num_columns = batches[0].num_columns();
     let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
 
@@ -50,17 +60,10 @@ fn create_table(
     // todo: make this configurable
     let str_truncate = 32;
 
-    let mut table = Table::new();
-
-    table.load_preset(DEFAULT_PRESET);
-    table.set_content_arrangement(ContentArrangement::Dynamic);
+    let mut table = default_table();
 
     if let Some(width) = width {
         table.set_width(width as u16);
-    }
-
-    if batches.is_empty() {
-        return Ok(table);
     }
 
     table.set_constraints(

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -128,13 +128,14 @@ fn create_table(
             )?;
             tbl_rows += rows_to_take;
         }
+
         if tbl_rows == row_split && needs_split {
-            // Add placeholder
+            // Add continuation
             let dots: Vec<_> = (0..max_cols).map(|_| Cell::new("…")).collect();
             table.add_row(dots);
             needs_split = false;
-            tbl_rows += 1;
         }
+
         processed_rows += num_rows;
 
         if processed_rows >= n_last_rows {


### PR DESCRIPTION
closes #1420 

```sh
glaredb universalmind303/truncate-logic ≡34s 
λ just run local --max-rows 10  
GlareDB (v0.2.1)
Type \help for help.
Using in-memory catalog
〉select * from generate_series(1, 100000);
┌────────────────────────┐
│ generate_series        │
│ ──                     │
│ Int64                  │
╞════════════════════════╡
│ 1                      │
│ 2                      │
│ 3                      │
│ 4                      │
│ 5                      │
│ …                      │
│ 99997                  │
│ 99998                  │
│ 99999                  │
│ 100000                 │
│ ───                    │
│ 100000 rows (10 shown) │
└────────────────────────┘
〉
```

I did have one note. 

would you expect the continuation row to count towards the `max_rows`? 
like if i ran `select * from generate_series(1, 100);`
with max-rows = 4
would you expect `[1,2,..,99,100]` or would you expect `[1,2,..,100]`
