### PR TITLE
feat: select exclude/except

### DIFF
--- a/crates/datafusion_ext/src/planner/select.rs
+++ b/crates/datafusion_ext/src/planner/select.rs
@@ -365,7 +365,6 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
             }
             SelectItem::QualifiedWildcard(ref object_name, options) => {
                 Self::check_wildcard_options(&options)?;
-
                 let qualifier = format!("{object_name}");
                 // do not expand from outer schema
                 expand_qualified_wildcard(&qualifier, plan.schema().as_ref(), Some(options))

--- a/crates/sqlexec/src/parser.rs
+++ b/crates/sqlexec/src/parser.rs
@@ -2,7 +2,7 @@ pub mod options;
 
 use crate::errors::Result;
 use datafusion::sql::sqlparser::ast::{self, Ident, ObjectName};
-use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::keywords::Keyword;
 use datafusion::sql::sqlparser::parser::{Parser, ParserError};
 use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer, Word};
@@ -360,7 +360,7 @@ pub struct CustomParser<'a> {
 
 impl<'a> CustomParser<'a> {
     pub fn parse_sql(sql: &str) -> Result<VecDeque<StatementWithExtensions>, ParserError> {
-        let dialect = PostgreSqlDialect {};
+        let dialect = GenericDialect {};
         let tokens = Tokenizer::new(&dialect, sql).tokenize()?;
         let mut parser = CustomParser {
             parser: Parser::new(&dialect).with_tokens(tokens),

--- a/crates/sqlexec/src/parser.rs
+++ b/crates/sqlexec/src/parser.rs
@@ -1229,7 +1229,7 @@ mod tests {
         ];
 
         for (sql, map) in test_cases {
-            let d = PostgreSqlDialect {};
+            let d = GenericDialect {};
             let t = Tokenizer::new(&d, sql).tokenize().unwrap();
             let mut p = CustomParser {
                 parser: Parser::new(&d).with_tokens(t),

--- a/testdata/sqllogictests/select.slt
+++ b/testdata/sqllogictests/select.slt
@@ -1,0 +1,91 @@
+# Basic select tests.
+
+# Below exclude/except tests taken from datafusion.
+# <https://github.com/apache/arrow-datafusion/blob/354202922889502cf51cabf630b05003fddd2ec7/datafusion/core/tests/sqllogictests/test_files/select.slt#L762-L844>
+
+# create a table to test SELECT * EXCLUDE, SELECT * EXCEPT syntax
+statement ok
+CREATE TABLE table1 (
+  a int,
+  b int,
+  c int,
+  d int
+);
+
+statement ok
+INSERT INTO table1 VALUES
+  (1, 10, 100, 1000),
+  (2, 20, 200, 2000);
+
+# Below query should emit all the columns except a and b
+# The syntax is as follows: `SELECT * EXCLUDE(<col_name>, ...)`
+# when only single column is excluded, we can either use
+# `EXCLUDE <col_name>` or `EXCLUDE(<col_name>)` syntax
+query II
+SELECT * EXCLUDE(b) FROM (
+  SELECT * EXCLUDE a
+    FROM table1
+    ORDER BY c
+    LIMIT 5
+  )
+----
+100 1000
+200 2000
+
+# Below query should emit all the columns except a and b
+# To exclude some columns, we can use except clause also,
+# the behavior is similar to EXCLUDE clause.
+# The syntax is as follows: `SELECT * EXCEPT(<col_name>, ...)`
+query II
+SELECT * EXCEPT(a, b)
+FROM table1
+ORDER BY c
+LIMIT 5
+----
+100 1000
+200 2000
+
+# below query should emit all the columns except a and b
+query II
+SELECT * EXCLUDE(a, b)
+FROM table1
+ORDER BY c
+LIMIT 5
+----
+100 1000
+200 2000
+
+# when wildcard is prepended with table name, exclude should still work
+# below query should emit all the columns except a and b
+query II
+SELECT table1.* EXCLUDE(a, b)
+FROM table1
+ORDER BY c
+LIMIT 5
+----
+100 1000
+200 2000
+
+# Trying to exclude non-existing column should give error
+statement error Schema error: No field named e. Valid fields are table1.a, table1.b, table1.c, table1.d.
+SELECT * EXCLUDE e
+FROM table1
+
+# similarly, except should raise error if excluded column is not in the table
+statement error Schema error: No field named e. Valid fields are table1.a, table1.b, table1.c, table1.d.
+SELECT * EXCEPT(e)
+FROM table1
+
+# EXCEPT, or EXCLUDE can only be used after wildcard *
+# below query should give 4 columns, a1, b1, b, c, d
+query IIIII
+SELECT a as a1, b as b1, * EXCEPT(a)
+FROM table1
+----
+1 10 10 100 1000
+2 20 20 200 2000
+
+# EXCEPT, or EXCLUDE shouldn't contain duplicate column names
+statement error Error during planning: EXCLUDE or EXCEPT contains duplicate column names
+SELECT * EXCLUDE(a, a)
+FROM table1


### PR DESCRIPTION
```
〉select * exclude column1 from t1;
┌─────────┐
│ column2 │
│ ──      │
│ Int64   │
╞═════════╡
│ 2       │
└─────────┘
```

We already had it (given that we're using datafusion's planner), but sqlparser will only try to parse it for a hard-coded subset of dialects, and so I switched to `GenericDialect`.