### PR TITLE
feat: Use pretty tables with `show` in python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ name = "py-glaredb"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "arrow_util",
  "async-trait",
  "datafusion",
  "datafusion_ext",

--- a/py-glaredb/Cargo.toml
+++ b/py-glaredb/Cargo.toml
@@ -22,6 +22,7 @@ telemetry = { path = "../crates/telemetry" }
 pgsrv = { path = "../crates/pgsrv" }
 pgrepr = { path = "../crates/pgrepr" }
 datafusion_ext = { path = "../crates/datafusion_ext" }
+arrow_util = { path = "../crates/arrow_util" }
 futures = "0.3.28"
 uuid = "1.4.1"
 async-trait = "0.1.72"


### PR DESCRIPTION
```
% ./.venv/bin/python3 examples/show.py
┌───────┬───────────┬───────┬───────────┐
│ A     │ fruits    │ B     │ cars      │
│ ──    │ ──        │ ──    │ ──        │
│ Int64 │ LargeUtf8 │ Int64 │ LargeUtf8 │
╞═══════╪═══════════╪═══════╪═══════════╡
│ 1     │ banana    │ 5     │ beetle    │
│ 2     │ banana    │ 4     │ audi      │
│ 5     │ banana    │ 1     │ beetle    │
└───────┴───────────┴───────┴───────────┘
┌───────┬────────┬───────┬────────┐
│ A     │ fruits │ B     │ cars   │
│ ──    │ ──     │ ──    │ ──     │
│ Int64 │ Utf8   │ Int64 │ Utf8   │
╞═══════╪════════╪═══════╪════════╡
│ 1     │ banana │ 5     │ beetle │
│ 2     │ banana │ 4     │ audi   │
│ 5     │ banana │ 1     │ beetle │
└───────┴────────┴───────┴────────┘
```