### PR TITLE
feat: Support globbed location for external tables as well

### DIFF
--- a/crates/metastore_client/proto/options.proto
+++ b/crates/metastore_client/proto/options.proto
@@ -132,12 +132,16 @@ message TableOptionsMysql {
   string table = 3;
 }
 
-message TableOptionsLocal { string location = 1; }
+message TableOptionsLocal {
+  string location = 1;
+  string file_type = 2;
+}
 
 message TableOptionsGcs {
   optional string service_account_key = 1;
   string bucket = 2;
   string location = 3;
+  string file_type = 4;
 }
 
 message TableOptionsS3 {
@@ -146,6 +150,7 @@ message TableOptionsS3 {
   string region = 3;
   string bucket = 4;
   string location = 5;
+  string file_type = 6;
 }
 
 message TableOptionsMongo {

--- a/crates/metastore_client/src/types/options.rs
+++ b/crates/metastore_client/src/types/options.rs
@@ -669,6 +669,7 @@ impl From<TableOptionsMysql> for options::TableOptionsMysql {
 #[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
 pub struct TableOptionsLocal {
     pub location: String,
+    pub file_type: String,
 }
 
 impl TryFrom<options::TableOptionsLocal> for TableOptionsLocal {
@@ -676,6 +677,7 @@ impl TryFrom<options::TableOptionsLocal> for TableOptionsLocal {
     fn try_from(value: options::TableOptionsLocal) -> Result<Self, Self::Error> {
         Ok(TableOptionsLocal {
             location: value.location,
+            file_type: value.file_type,
         })
     }
 }
@@ -684,6 +686,7 @@ impl From<TableOptionsLocal> for options::TableOptionsLocal {
     fn from(value: TableOptionsLocal) -> Self {
         options::TableOptionsLocal {
             location: value.location,
+            file_type: value.file_type,
         }
     }
 }
@@ -693,6 +696,7 @@ pub struct TableOptionsGcs {
     pub service_account_key: Option<String>,
     pub bucket: String,
     pub location: String,
+    pub file_type: String,
 }
 
 impl TryFrom<options::TableOptionsGcs> for TableOptionsGcs {
@@ -702,6 +706,7 @@ impl TryFrom<options::TableOptionsGcs> for TableOptionsGcs {
             service_account_key: value.service_account_key,
             bucket: value.bucket,
             location: value.location,
+            file_type: value.file_type,
         })
     }
 }
@@ -712,6 +717,7 @@ impl From<TableOptionsGcs> for options::TableOptionsGcs {
             service_account_key: value.service_account_key,
             bucket: value.bucket,
             location: value.location,
+            file_type: value.file_type,
         }
     }
 }
@@ -723,6 +729,7 @@ pub struct TableOptionsS3 {
     pub region: String,
     pub bucket: String,
     pub location: String,
+    pub file_type: String,
 }
 
 impl TryFrom<options::TableOptionsS3> for TableOptionsS3 {
@@ -734,6 +741,7 @@ impl TryFrom<options::TableOptionsS3> for TableOptionsS3 {
             region: value.region,
             bucket: value.bucket,
             location: value.location,
+            file_type: value.file_type,
         })
     }
 }
@@ -746,6 +754,7 @@ impl From<TableOptionsS3> for options::TableOptionsS3 {
             region: value.region,
             bucket: value.bucket,
             location: value.location,
+            file_type: value.file_type,
         }
     }
 }

--- a/crates/sqlexec/src/parser/options.rs
+++ b/crates/sqlexec/src/parser/options.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt};
 
 use datafusion::sql::sqlparser::parser::ParserError;
-use datasources::{debug::DebugTableType, mongodb::MongoProtocol};
+use datasources::{debug::DebugTableType, mongodb::MongoProtocol, object_store::FileType};
 
 /// Contains the value parsed from Options(...).
 ///
@@ -153,6 +153,18 @@ impl ParseOptionValue<DebugTableType> for OptionValue {
                 s.parse().map_err(|e| parser_err!("{e}"))?
             }
             o => return Err(unexpected_type_err!("debug table type", o)),
+        };
+        Ok(opt)
+    }
+}
+
+impl ParseOptionValue<FileType> for OptionValue {
+    fn parse_opt(self) -> Result<FileType, ParserError> {
+        let opt = match self {
+            Self::QuotedLiteral(s) | Self::UnquotedLiteral(s) => {
+                s.parse().map_err(|e| parser_err!("{e}"))?
+            }
+            o => return Err(unexpected_type_err!("file type", o)),
         };
         Ok(opt)
     }

--- a/testdata/sqllogictests_object_store/gcs/copy_to_and_scan.slt
+++ b/testdata/sqllogictests_object_store/gcs/copy_to_and_scan.slt
@@ -88,3 +88,28 @@ SELECT a, b FROM csv_scan(
 1	2
 3	4
 5	6
+
+# Test multiple URLs with globs (and different kinds of globs).
+
+statement ok
+COPY ( SELECT 7 AS a, 8 AS b )
+	TO 'gs://${GCS_BUCKET_NAME}/copy_to_with_creds.csv'
+	CREDENTIALS gcp_creds;
+
+# Found a bug out of the blue, previous code took the prefix for search as
+# "abc" when querying glob pattern "abc*". Since object_store adds a "/",
+# prefix in this case should be None.
+
+query II rowsort
+SELECT a, b FROM csv_scan(
+	[
+		'gs://${GCS_BUCKET_NAME}/copy_to*',
+		'gs://${GCS_BUCKET_NAME}/**/with_*.csv'
+	],
+	gcp_creds
+);
+----
+1	2
+3	4
+5	6
+7	8

--- a/testdata/sqllogictests_object_store/local/copy_to_and_scan.slt
+++ b/testdata/sqllogictests_object_store/local/copy_to_and_scan.slt
@@ -133,3 +133,18 @@ SELECT * FROM parquet_scan('${TMP}/*_glob_*');
 2
 3
 4
+
+# Multiple glob patterns
+
+query I rowsort
+SELECT * FROM parquet_scan([
+	'${TMP}/*_glob_*.parquet',
+	'${TMP}/*_glob_*'
+]);
+----
+1
+1
+2
+2
+3
+4

--- a/testdata/sqllogictests_object_store/s3/copy_to_and_scan.slt
+++ b/testdata/sqllogictests_object_store/s3/copy_to_and_scan.slt
@@ -107,3 +107,26 @@ SELECT a, b FROM csv_scan(
 1	2
 3	4
 5	6
+
+# Test multiple URLs with globs (and different kinds of globs).
+
+statement ok
+COPY ( SELECT 7 AS a, 8 AS b )
+	TO 's3://${AWS_S3_BUCKET_NAME}/copy_to_with_creds.csv'
+	CREDENTIALS aws_creds
+	( region '${AWS_S3_REGION}' );
+
+query II rowsort
+SELECT a, b FROM csv_scan(
+	[
+		's3://${AWS_S3_BUCKET_NAME}/copy_to*.csv',
+		's3://${AWS_S3_BUCKET_NAME}/**/with_*.csv'
+	],
+	aws_creds,
+	region => '${AWS_S3_REGION}'
+);
+----
+1	2
+3	4
+5	6
+7	8


### PR DESCRIPTION
```sql
CREATE EXTERNAL TABLE abc FROM gcs CREDENTIALS gcp_creds (
  location 'some/path/**/to/file.csv',
  -- Optional, if not provided, will be infered from location
  file_type 'csv'
);
```

The change is minor. Found a bug out of the blue, previous code took the prefix for search as "abc" when querying glob pattern "abc*". Since object_store adds a "/", prefix in this case should be None. Fixed that too.

**TODO:**
- [x] Add option to configure file type
- [ ] Add SLTs