### PR TITLE
chore: Swap bracket character in prompt

### DIFF
--- a/crates/glaredb/src/prompt.rs
+++ b/crates/glaredb/src/prompt.rs
@@ -17,7 +17,7 @@ impl Prompt for SQLPrompt {
         &self,
         _prompt_mode: reedline::PromptEditMode,
     ) -> std::borrow::Cow<str> {
-        "〉".into()
+        "> ".into()
     }
 
     fn render_prompt_multiline_indicator(&self) -> std::borrow::Cow<str> {


### PR DESCRIPTION
"〉" is actually pretty uncommon for fonts. We could go with "⟩" since it's typically preferred over "〉", but it still lacks support in some popular monospace fonts like Source Code Pro and Fira Mono.

As someone who likes to make everything "just right", I wouldn't like for a tool that I'm using to use a glyph not support by my font. And so a basic ">" seems like the most straightforward pick for the prompt character.