### PR TITLE
feat: Support drops for temp tables

### DIFF
--- a/crates/sqlexec/src/background_jobs.rs
+++ b/crates/sqlexec/src/background_jobs.rs
@@ -112,9 +112,13 @@ impl JobRunner {
                         let _ = sleep_receiver.await;
 
                         let res = job.start().await;
-                        sender
-                            .send(RequestMessage::JobComplete(job_name, res))
-                            .unwrap();
+                        if sender
+                            .send(RequestMessage::JobComplete(job_name.clone(), res))
+                            .is_err()
+                        {
+                            // The job is complete (after close is called).
+                            info!(%job_name, "background job exited");
+                        }
                     });
 
                     // Insert the job in the collection.

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -132,6 +132,9 @@ pub enum ExecError {
     #[error("Unable to send message over channel: {0}")]
     ChannelSendError(Box<dyn std::error::Error + Send + Sync>),
 
+    #[error("Invalid temporary table: {reason}")]
+    InvalidTempTable { reason: String },
+
     #[error("internal error: {0}")]
     Internal(String),
 

--- a/testdata/sqllogictests/temp_table.slt
+++ b/testdata/sqllogictests/temp_table.slt
@@ -73,3 +73,27 @@ select * from t1;
 1
 3
 5
+
+# Dropping temp tables
+
+statement error Missing database object
+drop table t1, t2;
+
+# t1 shouldn't be dropped
+query I
+select * from t1
+----
+1
+3
+5
+
+statement ok
+drop table t1, current_session.abc;
+
+# Both t1 and abc shouldn't exist.
+
+statement error Unable to fetch table provider
+select * from abc;
+
+statement error Unable to fetch table provider
+select * from t1;


### PR DESCRIPTION
```sql
create temp table abc as values (1, 2);

-- Valid table refs are:
-- * abc
-- * current_session.abc
-- * default.current_session.abc
drop table abc;
```