### PR TITLE
feat: Support aliasing/casting in `CREATE TABLE .. AS ..`

### DIFF
--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -5,6 +5,7 @@ use datafusion::arrow::datatypes::{
     DataType, Field, TimeUnit, DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
 };
 use datafusion::common::{OwnedSchemaReference, OwnedTableReference};
+use datafusion::logical_expr::{cast, col, LogicalPlanBuilder};
 use datafusion::sql::planner::{object_name_to_table_reference, IdentNormalizer};
 use datafusion::sql::sqlparser::ast::AlterTableOperation;
 use datafusion::sql::sqlparser::ast::{self, Ident, ObjectName, ObjectType};
@@ -663,15 +664,46 @@ impl<'a> SessionPlanner<'a> {
 
                 let (source, arrow_cols) = if let Some(q) = query {
                     let source = planner.query_to_plan(*q).await?;
-                    let fields = source.schema().fields();
-                    let fields: Vec<_> =
-                        fields.iter().map(|f| f.field().as_ref().clone()).collect();
+                    let df_fields = source.schema().fields();
+
+                    let mut columns = columns.into_iter();
+                    let mut fields = Vec::with_capacity(df_fields.len());
+                    for df_field in df_fields {
+                        let field = df_field.field().as_ref().clone();
+                        let field = if let Some(column) = columns.next() {
+                            // If we have a cast for the column, we can update the schema.
+                            validate_ident(&column.name)?;
+                            let name = normalize_ident(column.name);
+                            let data_type = convert_data_type(&column.data_type)?;
+                            field.with_name(name).with_data_type(data_type)
+                        } else {
+                            field
+                        };
+                        fields.push(field);
+                    }
+
+                    // Update the source plan with the new schema casts and alias.
+                    let project_exprs: Vec<_> = fields
+                        .iter()
+                        .zip(df_fields.iter())
+                        .map(|(field, df_field)| {
+                            cast(col(df_field.name()), field.data_type().clone())
+                                .alias(field.name())
+                        })
+                        .collect();
+
+                    let source = LogicalPlanBuilder::from(source)
+                        .project(project_exprs)?
+                        .build()?;
+
                     (Some(source), fields)
                 } else {
                     let mut arrow_cols = Vec::with_capacity(columns.len());
                     for column in columns.into_iter() {
-                        let dt = convert_data_type(&column.data_type)?;
-                        let field = Field::new(&column.name.value, dt, /* nullable = */ true);
+                        validate_ident(&column.name)?;
+                        let name = normalize_ident(column.name);
+                        let data_type = convert_data_type(&column.data_type)?;
+                        let field = Field::new(name, data_type, /* nullable = */ true);
                         arrow_cols.push(field);
                     }
                     (None, arrow_cols)

--- a/testdata/sqllogictests/table.slt
+++ b/testdata/sqllogictests/table.slt
@@ -29,3 +29,35 @@ select * from t1;
 1
 3
 5
+
+# Cast and alias in "CREATE TABLE .. AS .."
+
+statement ok
+create table t2 as values (1, 2);
+
+query II
+select column1, column2 from t2;
+----
+1	2
+
+statement ok
+create table t3 (a int) as values (3, 4);
+
+query II
+select a, column2 from t3;
+----
+3	4
+
+statement error No field named column1
+select column1 from t3;
+
+statement ok
+create table t4 (a int, b text) as values (5, 6);
+
+query IT
+select a, b from t4;
+----
+5	6
+
+statement error No field named column2
+select column2 from t4;


### PR DESCRIPTION
**Without any alias/casting:**

```
> create table t1 as values (1, 2);
create table
> select * from t1;
┌─────────┬─────────┐
│ column1 │ column2 │
│ ──      │ ──      │
│ Int64   │ Int64   │
╞═════════╪═════════╡
│ 1       │ 2       │
└─────────┴─────────┘
```

**With alias/casting:**

```
> create table t2 (a int, b text) as values (1, 2);
create table
> select * from t2;
┌───────┬──────┐
│ a     │ b    │
│ ──    │ ──   │
│ Int32 │ Utf8 │
╞═══════╪══════╡
│ 1     │ 2    │
└───────┴──────┘
```

**With few columns aliased/cast:**

```
> create table t3 (a int) as values (1, 2);
create table
> select * from t3;
┌───────┬─────────┐
│ a     │ column2 │
│ ──    │ ──      │
│ Int32 │ Int64   │
╞═══════╪═════════╡
│ 1     │ 2       │
└───────┴─────────┘
```

Fixes #1425