### PR TITLE
chore: Remove unnecessary lock from bigquery stream thread.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,6 @@ dependencies = [
  "object_store_util",
  "once_cell",
  "openssh",
- "parking_lot",
  "protogen",
  "rand 0.8.5",
  "regex",

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -30,7 +30,6 @@ object_store = { workspace = true, features = ["gcp", "aws", "http"] }
 object_store_util = { path = "../object_store_util" }
 glob = "0.3.1"
 once_cell = "1.18.0"
-parking_lot = "0.12.1"
 rand = "0.8.5"
 regex = "1.9.1"
 repr = { path = "../repr" }

--- a/crates/datasources/src/bigquery/mod.rs
+++ b/crates/datasources/src/bigquery/mod.rs
@@ -38,7 +38,6 @@ use gcp_bigquery_client::{
     project::GetOptions,
     table,
 };
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::fmt::{self, Write};
@@ -312,9 +311,9 @@ impl TableProvider for BigQueryTableProvider {
                 if let Some(stream) = stream_opt {
                     match send.send(stream).await {
                         Ok(_) => {}
-                        Err(_e /* : closed or full channel error */) => {
+                        Err(error /* : closed or full channel error */) => {
                             tracing::error!(
-                                "cannot send stream over the buffered channel [programming error]"
+                                %error, "cannot send stream over the buffered channel [programming error]"
                             );
                             break;
                         }
@@ -331,7 +330,7 @@ impl TableProvider for BigQueryTableProvider {
         Ok(Arc::new(BigQueryExec {
             predicate,
             arrow_schema: projected_schema,
-            receiver: RwLock::new(recv),
+            receiver: recv,
             num_partitions,
         }))
     }
@@ -340,7 +339,7 @@ impl TableProvider for BigQueryTableProvider {
 struct BigQueryExec {
     predicate: String,
     arrow_schema: ArrowSchemaRef,
-    receiver: RwLock<Receiver<BufferedArrowIpcReader>>,
+    receiver: Receiver<BufferedArrowIpcReader>,
     num_partitions: usize,
 }
 
@@ -379,14 +378,9 @@ impl ExecutionPlan for BigQueryExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> DatafusionResult<SendableRecordBatchStream> {
-        let recv = {
-            let guard = self.receiver.read();
-            Receiver::clone(&guard)
-        };
-
         Ok(Box::pin(BufferedIpcStream::new(
             self.schema(),
-            recv,
+            self.receiver.clone(),
             partition,
         )))
     }


### PR DESCRIPTION
Also add `%error` to log when unable to send message over channel. Should help in debugging.