### PR TITLE
feat: Make 'glaredb' behave as 'glaredb local'

### DIFF
--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -61,6 +61,7 @@ pub struct LocalClientOpts {
     pub mode: OutputMode,
 
     /// Max width for tables to display.
+    #[clap(long)]
     pub width: Option<usize>,
 
     /// Max number of rows to display.


### PR DESCRIPTION
Adds in some arg flattening to make it happen. Now you can just run `glaredb` and get dropped into a local session.

This _does_ move some arguments to be visible top-level, but which end up being ignored if any of the subcommands are used. But I thought that's acceptable for now.

```
$ ./glaredb --help
CLI for GlareDB

Usage: glaredb [OPTIONS] [COMMAND]

Commands:
  local   Starts a local version of GlareDB (default)
  server  Starts the sql server portion of GlareDB
  help    Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...
          Log verbosity

      --json-logging
          Output logs in json format

  -q, --query <QUERY>
          Execute a query, exiting upon completion.

          Multiple statements may be provided, and results will be printed out one after another.

  -m, --metastore-addr <METASTORE_ADDR>
          Address to the Metastore.

          If not provided, an in-process metastore will be started.

      --spill-path <SPILL_PATH>
          Path to spill temporary files to

  -f, --data-dir <DATA_DIR>
          Optional file path for persisting data.

          Catalog data and user data will be stored in this directory.

      --mode <MODE>
          Display output mode

          [default: table]
          [possible values: table, json, ndjson, csv]

      --width <WIDTH>
          Max width for tables to display

      --max-rows <MAX_ROWS>
          Max number of rows to display

      --max-columns <MAX_COLUMNS>
          Max number of columns to display

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

```