### PR TITLE
fix: Use python print for `show` method

### DIFF
--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -3,6 +3,8 @@ mod error;
 mod logical_plan;
 mod runtime;
 mod session;
+mod util;
+
 use environment::PyEnvironmentReader;
 use error::PyGlareDbError;
 use futures::lock::Mutex;

--- a/py-glaredb/src/session.rs
+++ b/py-glaredb/src/session.rs
@@ -5,6 +5,7 @@ use datafusion::arrow::{datatypes::Schema, pyarrow::ToPyArrow};
 use futures::lock::Mutex;
 use futures::StreamExt;
 use pgrepr::format::Format;
+use pyo3::types::PyDict;
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyTuple};
 use sqlexec::{
     engine::{Engine, TrackedSession},
@@ -143,7 +144,10 @@ fn print_batch(result: &mut ExecutionResult, py: Python<'_>) -> PyResult<()> {
 
             let disp = pretty_format_batches(&batches, None, None, None)
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-            println!("{disp}");
+
+            let locals = PyDict::new(py);
+            locals.set_item("batch_str", disp.to_string())?;
+            py.run("print(batch_str)", None, Some(locals))?;
             Ok(())
         }
         _ => Err(PyRuntimeError::new_err("Not able to show executed result")),

--- a/py-glaredb/src/session.rs
+++ b/py-glaredb/src/session.rs
@@ -1,3 +1,4 @@
+use crate::util::pyprint;
 use anyhow::Result;
 use arrow_util::pretty::pretty_format_batches;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -5,7 +6,6 @@ use datafusion::arrow::{datatypes::Schema, pyarrow::ToPyArrow};
 use futures::lock::Mutex;
 use futures::StreamExt;
 use pgrepr::format::Format;
-use pyo3::types::PyDict;
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyTuple};
 use sqlexec::{
     engine::{Engine, TrackedSession},
@@ -145,10 +145,7 @@ fn print_batch(result: &mut ExecutionResult, py: Python<'_>) -> PyResult<()> {
             let disp = pretty_format_batches(&batches, None, None, None)
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
-            let locals = PyDict::new(py);
-            locals.set_item("batch_str", disp.to_string())?;
-            py.run("print(batch_str)", None, Some(locals))?;
-            Ok(())
+            pyprint(disp, py)
         }
         _ => Err(PyRuntimeError::new_err("Not able to show executed result")),
     }

--- a/py-glaredb/src/util.rs
+++ b/py-glaredb/src/util.rs
@@ -1,0 +1,11 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::fmt::Display;
+
+/// Use python's builtin `print` to display an item.
+pub fn pyprint(item: impl Display, py: Python) -> PyResult<()> {
+    let locals = PyDict::new(py);
+    locals.set_item("__display_item", item.to_string())?;
+    py.run("print(__display_item)", None, Some(locals))?;
+    Ok(())
+}

--- a/py-glaredb/tests/test_show.py
+++ b/py-glaredb/tests/test_show.py
@@ -1,0 +1,9 @@
+import glaredb
+import pytest
+
+
+def test_show():
+    con = glaredb.connect()
+    # Just make sure we don't error right now. We could error if we reference
+    # the incorrect local during the print.
+    con.sql("select 1").show()


### PR DESCRIPTION
This is a fix for `show` not outputting anything in Google Colab. Stdout in colab gets routed through a few different layers, and just flushing wasn't doing anything. Using python's builtin `print` was just the easiest path for this, and since this isn't performance sensitive, I think it's reasonable to do.

Closes https://github.com/GlareDB/glaredb/issues/1470