### PR TITLE
chore: Allow client init session when `--ignore-auth`.

### DIFF
--- a/crates/bench_runner/src/main.rs
+++ b/crates/bench_runner/src/main.rs
@@ -70,6 +70,7 @@ fn main() -> Result<()> {
             None,
             None,
             false,
+            false,
         )
         .await?;
         tokio::spawn(server.serve(server_conf));

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -249,6 +249,7 @@ fn main() -> Result<()> {
                 data_dir,
                 service_account_key,
                 spill_path,
+                ignore_auth,
             )?;
         }
         Commands::PgProxy {
@@ -335,6 +336,7 @@ fn begin_server(
     data_dir: Option<PathBuf>,
     service_account_key: Option<String>,
     spill_path: Option<PathBuf>,
+    ignore_auth: bool,
 ) -> Result<()> {
     let runtime = build_runtime("server")?;
     runtime.block_on(async move {
@@ -351,6 +353,7 @@ fn begin_server(
             service_account_key,
             spill_path,
             /* integration_testing = */ false,
+            ignore_auth,
         )
         .await?;
         server.serve(conf).await

--- a/crates/rpcsrv/src/handler.rs
+++ b/crates/rpcsrv/src/handler.rs
@@ -33,13 +33,19 @@ pub struct RpcHandler {
 
     /// Open sessions.
     sessions: DashMap<Uuid, RemoteSession>,
+
+    /// Allow initialize session messages from client.
+    ///
+    /// By default only messages from proxy are accepted.
+    allow_client_init: bool,
 }
 
 impl RpcHandler {
-    pub fn new(engine: Arc<Engine>) -> Self {
+    pub fn new(engine: Arc<Engine>, allow_client_init: bool) -> Self {
         RpcHandler {
             engine,
             sessions: DashMap::new(),
+            allow_client_init,
         }
     }
 
@@ -66,6 +72,9 @@ impl RpcHandler {
                         .gcs_bucket,
                 };
                 (db_id, storage_conf)
+            }
+            initialize_session_request::Request::Client(_req) if self.allow_client_init => {
+                (Uuid::nil(), SessionStorageConfig::default())
             }
             _ => {
                 return Err(RpcsrvError::SessionInitalizeError(

--- a/crates/testing/src/slt/cli.rs
+++ b/crates/testing/src/slt/cli.rs
@@ -208,6 +208,7 @@ impl Cli {
                     None,
                     None,
                     /* integration_testing = */ true,
+                    /* ignore_auth = */ false,
                 )
                 .await?;
                 tokio::spawn(server.serve(server_conf));


### PR DESCRIPTION
```shell
# In one terminal
> glaredb server --ignore-auth --rpc-bind 0.0.0.0:6789

# In another terminal
> glaredb local --ignore-auth -c http://0.0.0.0:6789
```