### PR TITLE
feat: Support remote execution for queries with tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,6 +4355,7 @@ name = "protogen"
 version = "0.4.0"
 dependencies = [
  "datafusion",
+ "datafusion-proto",
  "proptest",
  "proptest-derive",
  "prost",

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -20,7 +20,7 @@ use datafusion_ext::vars::SessionVars;
 use sqlexec::engine::EngineStorageConfig;
 use sqlexec::engine::{Engine, SessionStorageConfig, TrackedSession};
 use sqlexec::parser;
-use sqlexec::remote::client::{AuthenticatedExecutionServiceClient, ProxyAuthParamsAndDst};
+use sqlexec::remote::client::RemoteClient;
 use sqlexec::session::ExecutionResult;
 use std::env;
 use std::fmt::Write as _;
@@ -65,12 +65,14 @@ pub struct LocalClientOpts {
 
     /// Ignores the proxy and directly goes to the server for remote execution.
     ///
+    /// (Internal)
+    ///
     /// Note that:
     /// * `cloud_url` in this case should be a valid HTTP RPC URL (`--rpc-bind`
     ///   for the server).
-    /// * Server should be started with `--ignore-auth` arg as well.
+    /// * Server should be started with `--allow-client-rpc-init` arg as well.
     #[clap(long, hide = true)]
-    pub ignore_auth: bool,
+    pub ignore_rpc_auth: bool,
 
     /// Display output mode.
     #[arg(long, value_enum, default_value_t=OutputMode::Table)]
@@ -156,22 +158,21 @@ impl LocalSession {
         .await?;
 
         let sess = if let Some(url) = opts.cloud_url.clone() {
-            let exec_client = if opts.ignore_auth {
-                AuthenticatedExecutionServiceClient::connect(url.to_string()).await?
+            let exec_client = if opts.ignore_rpc_auth {
+                RemoteClient::connect(url).await?
             } else {
-                let params_and_dst = ProxyAuthParamsAndDst::try_from_url(url)?;
-                AuthenticatedExecutionServiceClient::connect_with_proxy_auth_params(
-                    params_and_dst.dst.to_string(),
-                    params_and_dst.params,
-                )
-                .await?
+                RemoteClient::connect_with_proxy_destination(url.try_into()?).await?
             };
             engine
                 .new_session_with_remote_connection(SessionVars::default(), exec_client)
                 .await?
         } else {
             engine
-                .new_session(SessionVars::default(), SessionStorageConfig::default())
+                .new_session(
+                    SessionVars::default(),
+                    SessionStorageConfig::default(),
+                    /* remote_ctx = */ false,
+                )
                 .await?
         };
 

--- a/crates/glaredb/src/server.rs
+++ b/crates/glaredb/src/server.rs
@@ -29,7 +29,7 @@ pub struct ServerConfig {
 
 pub struct ComputeServer {
     integration_testing: bool,
-    ignore_auth: bool,
+    disable_rpc_auth: bool,
     pg_handler: Arc<ProtocolHandler>,
     engine: Arc<Engine>,
 }
@@ -46,7 +46,7 @@ impl ComputeServer {
         service_account_key: Option<String>,
         spill_path: Option<PathBuf>,
         integration_testing: bool,
-        ignore_auth: bool,
+        disable_rpc_auth: bool,
     ) -> Result<Self> {
         // Our bare container image doesn't have a '/tmp' dir on startup (nor
         // does it specify an alternate dir to use via `TMPDIR`).
@@ -107,7 +107,7 @@ impl ComputeServer {
         };
         Ok(ComputeServer {
             integration_testing,
-            ignore_auth,
+            disable_rpc_auth,
             pg_handler: Arc::new(ProtocolHandler::new(engine.clone(), handler_conf)),
             engine,
         })
@@ -161,7 +161,7 @@ impl ComputeServer {
 
         // Start rpc service.
         if let Some(addr) = conf.rpc_addr {
-            let handler = RpcHandler::new(self.engine.clone(), self.ignore_auth);
+            let handler = RpcHandler::new(self.engine.clone(), self.disable_rpc_auth);
             info!("Starting rpc service");
             tokio::spawn(async move {
                 if let Err(e) = Server::builder()

--- a/crates/metastore/src/errors.rs
+++ b/crates/metastore/src/errors.rs
@@ -83,7 +83,7 @@ pub enum MetastoreError {
     Storage(#[from] crate::storage::StorageError),
 
     #[error(transparent)]
-    ProtoConv(#[from] protogen::metastore::types::ProtoConvError),
+    ProtoConv(#[from] protogen::errors::ProtoConvError),
 
     #[error(transparent)]
     ObjectStore(#[from] object_store::Error),

--- a/crates/metastore/src/storage/mod.rs
+++ b/crates/metastore/src/storage/mod.rs
@@ -49,7 +49,7 @@ pub enum StorageError {
     LeaseRenewerExited,
 
     #[error(transparent)]
-    ProtoConv(#[from] protogen::metastore::types::ProtoConvError),
+    ProtoConv(#[from] protogen::errors::ProtoConvError),
 
     #[error("Failed to encode protobuf for storage: {0}")]
     ProstEncode(#[from] prost::EncodeError),

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -276,6 +276,7 @@ impl ProtocolHandler {
                 SessionStorageConfig {
                     gcs_bucket: storage_bucket,
                 },
+                /* remote_ctx = */ false,
             )
             .await
         {

--- a/crates/protogen/Cargo.toml
+++ b/crates/protogen/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [dependencies]
 datafusion = { workspace = true }
+datafusion-proto = { workspace = true }
 thiserror.workspace = true
 tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
 prost = "0.11"

--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -79,23 +79,67 @@ message InitializeSessionResponse {
   // requests.
   bytes session_id = 1;
 
-  // // The initial catalog for the database.
+  // The initial catalog for the database.
   metastore.catalog.CatalogState catalog = 2;
 }
 
-message ExecuteRequest {
-  // Which session to execute this on.
+// Create a physical plan from the logical plan (used by `QueryPlanner`).
+message CreatePhysicalPlanRequest {
   bytes session_id = 1;
-
-  oneof plan {
-    bytes logical_plan = 2;
-    bytes physical_plan = 3;
-  }
+  bytes logical_plan = 2;
 }
 
-message ExecuteResponse {
+// Dispatch the table access on remote server.
+message DispatchAccessRequest {
+  bytes session_id = 1;
+  TableReference table_ref = 2;
+}
+
+// To scan the table provider.
+message TableProviderScanRequest {
+  // Provider information.
+  bytes session_id = 1;
+  bytes provider_id = 2;
+  // Scan parameters.
+  optional uint64 projection = 3;
+  repeated bytes filters = 4;
+  optional uint64 limit = 5; 
+}
+
+// To `insert_into` a table provider.
+message TableProviderInsertIntoRequest {
+  // Provider information.
+  bytes session_id = 1;
+  bytes provider_id = 2;
+  // Physical plan ID to be used as input.
+  bytes input_exec_id = 3;
+}
+
+// Execute a physical plan and get the stream.
+message PhysicalPlanExecuteRequest {
+  bytes session_id = 1;
+  bytes exec_id = 2;
+}
+
+message TableProviderResponse {
+  bytes id = 1;
+  bytes schema = 2;
+}
+
+message PhysicalPlanResponse {
+  bytes id = 1;
+  bytes schema = 2;
+}
+
+message RecordBatchResponse {
   // Results of the execution.
   bytes arrow_ipc = 1;
+}
+
+message TableReference {
+  optional string catalog = 1;
+  optional string schema = 2;
+  string table = 3;
 }
 
 message CloseSessionRequest {
@@ -110,8 +154,24 @@ service ExecutionService {
   rpc InitializeSession(InitializeSessionRequest)
       returns (InitializeSessionResponse);
 
-  // Execute a query plan, returning a stream of IPC encoded batches.
-  rpc Execute(ExecuteRequest) returns (stream ExecuteResponse);
+  // Create a physical plan on the remote server.
+  rpc CreatePhysicalPlan(CreatePhysicalPlanRequest)
+      returns (PhysicalPlanResponse);
+
+  // Dispatch and create a table provider on the remote server.
+  rpc DispatchAccess(DispatchAccessRequest) returns (TableProviderResponse);
+
+  // Scan the table provider.
+  rpc TableProviderScan(TableProviderScanRequest)
+      returns (PhysicalPlanResponse);
+
+  // Insert into the table provider.
+  rpc TableProviderInsertInto(TableProviderInsertIntoRequest)
+      returns (PhysicalPlanResponse);
+
+  // Execute a physical plan.
+  rpc PhysicalPlanExecute(PhysicalPlanExecuteRequest)
+      returns (stream RecordBatchResponse);
 
   // Close the remote session.
   rpc CloseSession(CloseSessionRequest) returns (CloseSessionResponse);

--- a/crates/protogen/src/metastore/types/mod.rs
+++ b/crates/protogen/src/metastore/types/mod.rs
@@ -4,36 +4,13 @@
 //! protobuf definitions, except without some optionals. Conversion from protobuf
 //! to the types defined in this module should ensure the values validity.
 
+use crate::errors::ProtoConvError;
+
 pub mod arrow;
 pub mod catalog;
 pub mod options;
 pub mod service;
 pub mod storage;
-
-/// Errors related to converting to/from protobuf types.
-#[derive(thiserror::Error, Debug)]
-pub enum ProtoConvError {
-    #[error("Field required: {0}")]
-    RequiredField(String),
-
-    #[error("Unknown enum variant for '{0}': {1}")]
-    UnknownEnumVariant(&'static str, i32),
-
-    #[error("Received zero-value enum variant for '{0}'")]
-    ZeroValueEnumVariant(&'static str),
-
-    #[error("Unsupported serialization: {0}")]
-    UnsupportedSerialization(&'static str),
-
-    #[error(transparent)]
-    TimestampError(#[from] prost_types::TimestampError),
-
-    #[error(transparent)]
-    Uuid(#[from] uuid::Error),
-
-    #[error(transparent)]
-    TryFromIntError(#[from] std::num::TryFromIntError),
-}
 
 /// An extension trait that adds the methods `optional` and `required` to any
 /// Option containing a type implementing `TryInto<U, Error = ProtoConvError>`

--- a/crates/protogen/src/rpcsrv/mod.rs
+++ b/crates/protogen/src/rpcsrv/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/crates/protogen/src/rpcsrv/types/mod.rs
+++ b/crates/protogen/src/rpcsrv/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/crates/protogen/src/rpcsrv/types/service.rs
+++ b/crates/protogen/src/rpcsrv/types/service.rs
@@ -1,0 +1,362 @@
+use datafusion::{arrow::datatypes::Schema, common::OwnedTableReference, sql::TableReference};
+use prost::Message;
+use uuid::Uuid;
+
+use crate::{
+    errors::ProtoConvError,
+    gen::rpcsrv::service,
+    metastore::types::{catalog::CatalogState, FromOptionalField},
+};
+
+pub struct SessionStorageConfig {
+    pub gcs_bucket: Option<String>,
+}
+
+impl TryFrom<service::SessionStorageConfig> for SessionStorageConfig {
+    type Error = ProtoConvError;
+    fn try_from(value: service::SessionStorageConfig) -> Result<Self, Self::Error> {
+        Ok(SessionStorageConfig {
+            gcs_bucket: value.gcs_bucket,
+        })
+    }
+}
+
+impl From<SessionStorageConfig> for service::SessionStorageConfig {
+    fn from(value: SessionStorageConfig) -> Self {
+        service::SessionStorageConfig {
+            gcs_bucket: value.gcs_bucket,
+        }
+    }
+}
+
+pub struct InitializeSessionRequestFromClient {}
+
+impl From<service::InitializeSessionRequestFromClient> for InitializeSessionRequestFromClient {
+    fn from(_value: service::InitializeSessionRequestFromClient) -> Self {
+        Self {}
+    }
+}
+
+impl From<InitializeSessionRequestFromClient> for service::InitializeSessionRequestFromClient {
+    fn from(_value: InitializeSessionRequestFromClient) -> Self {
+        Self {}
+    }
+}
+
+pub struct InitializeSessionRequestFromProxy {
+    pub storage_conf: SessionStorageConfig,
+    pub db_id: Uuid,
+}
+
+impl TryFrom<service::InitializeSessionRequestFromProxy> for InitializeSessionRequestFromProxy {
+    type Error = ProtoConvError;
+    fn try_from(value: service::InitializeSessionRequestFromProxy) -> Result<Self, Self::Error> {
+        Ok(Self {
+            storage_conf: value.storage_conf.required("storage configuration")?,
+            db_id: Uuid::from_slice(&value.db_id)?,
+        })
+    }
+}
+
+impl From<InitializeSessionRequestFromProxy> for service::InitializeSessionRequestFromProxy {
+    fn from(value: InitializeSessionRequestFromProxy) -> Self {
+        Self {
+            storage_conf: Some(value.storage_conf.into()),
+            db_id: value.db_id.into_bytes().into(),
+        }
+    }
+}
+
+pub enum InitializeSessionRequest {
+    Client(InitializeSessionRequestFromClient),
+    Proxy(InitializeSessionRequestFromProxy),
+}
+
+impl TryFrom<service::initialize_session_request::Request> for InitializeSessionRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::initialize_session_request::Request) -> Result<Self, Self::Error> {
+        Ok(match value {
+            service::initialize_session_request::Request::Client(c) => {
+                InitializeSessionRequest::Client(c.into())
+            }
+            service::initialize_session_request::Request::Proxy(c) => {
+                InitializeSessionRequest::Proxy(c.try_into()?)
+            }
+        })
+    }
+}
+
+impl From<InitializeSessionRequest> for service::initialize_session_request::Request {
+    fn from(value: InitializeSessionRequest) -> Self {
+        match value {
+            InitializeSessionRequest::Client(c) => Self::Client(c.into()),
+            InitializeSessionRequest::Proxy(c) => Self::Proxy(c.into()),
+        }
+    }
+}
+
+impl TryFrom<service::InitializeSessionRequest> for InitializeSessionRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::InitializeSessionRequest) -> Result<Self, Self::Error> {
+        value.request.required("initialize session request")
+    }
+}
+
+impl From<InitializeSessionRequest> for service::InitializeSessionRequest {
+    fn from(value: InitializeSessionRequest) -> Self {
+        Self {
+            request: Some(value.into()),
+        }
+    }
+}
+
+pub struct InitializeSessionResponse {
+    pub session_id: Uuid,
+    pub catalog: CatalogState,
+}
+
+impl TryFrom<service::InitializeSessionResponse> for InitializeSessionResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: service::InitializeSessionResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: Uuid::from_slice(&value.session_id)?,
+            catalog: value.catalog.required("catalog state")?,
+        })
+    }
+}
+
+impl TryFrom<InitializeSessionResponse> for service::InitializeSessionResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: InitializeSessionResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: value.session_id.into_bytes().into(),
+            catalog: Some(value.catalog.try_into()?),
+        })
+    }
+}
+
+pub struct CreatePhysicalPlanRequest {
+    pub session_id: Uuid,
+    pub logical_plan: Vec<u8>,
+}
+
+impl TryFrom<service::CreatePhysicalPlanRequest> for CreatePhysicalPlanRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::CreatePhysicalPlanRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: Uuid::from_slice(&value.session_id)?,
+            logical_plan: value.logical_plan,
+        })
+    }
+}
+
+impl From<CreatePhysicalPlanRequest> for service::CreatePhysicalPlanRequest {
+    fn from(value: CreatePhysicalPlanRequest) -> Self {
+        Self {
+            session_id: value.session_id.into_bytes().into(),
+            logical_plan: value.logical_plan,
+        }
+    }
+}
+
+pub struct DispatchAccessRequest {
+    pub session_id: Uuid,
+    pub table_ref: OwnedTableReference,
+}
+
+impl TryFrom<service::DispatchAccessRequest> for DispatchAccessRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::DispatchAccessRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: Uuid::from_slice(&value.session_id)?,
+            table_ref: value.table_ref.required("table reference")?,
+        })
+    }
+}
+
+impl From<DispatchAccessRequest> for service::DispatchAccessRequest {
+    fn from(value: DispatchAccessRequest) -> Self {
+        Self {
+            session_id: value.session_id.into_bytes().into(),
+            table_ref: Some(value.table_ref.into()),
+        }
+    }
+}
+
+// TODO: More types...
+
+pub struct PhysicalPlanExecuteRequest {
+    pub session_id: Uuid,
+    pub exec_id: Uuid,
+}
+
+impl TryFrom<service::PhysicalPlanExecuteRequest> for PhysicalPlanExecuteRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::PhysicalPlanExecuteRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: Uuid::from_slice(&value.session_id)?,
+            exec_id: Uuid::from_slice(&value.exec_id)?,
+        })
+    }
+}
+
+impl From<PhysicalPlanExecuteRequest> for service::PhysicalPlanExecuteRequest {
+    fn from(value: PhysicalPlanExecuteRequest) -> Self {
+        Self {
+            session_id: value.session_id.into_bytes().into(),
+            exec_id: value.exec_id.into_bytes().into(),
+        }
+    }
+}
+
+pub struct TableProviderResponse {
+    pub id: Uuid,
+    pub schema: Schema,
+}
+
+impl TryFrom<service::TableProviderResponse> for TableProviderResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: service::TableProviderResponse) -> Result<Self, Self::Error> {
+        let schema = datafusion_proto::protobuf::Schema::decode(value.schema.as_slice())?;
+        let schema = (&schema).try_into()?;
+        Ok(Self {
+            id: Uuid::from_slice(&value.id)?,
+            schema,
+        })
+    }
+}
+
+impl TryFrom<TableProviderResponse> for service::TableProviderResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: TableProviderResponse) -> Result<Self, Self::Error> {
+        let schema = datafusion_proto::protobuf::Schema::try_from(&value.schema)?;
+        Ok(Self {
+            id: value.id.into_bytes().into(),
+            schema: schema.encode_to_vec(),
+        })
+    }
+}
+
+pub struct PhysicalPlanResponse {
+    pub id: Uuid,
+    pub schema: Schema,
+}
+
+impl TryFrom<service::PhysicalPlanResponse> for PhysicalPlanResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: service::PhysicalPlanResponse) -> Result<Self, Self::Error> {
+        let schema = datafusion_proto::protobuf::Schema::decode(value.schema.as_slice())?;
+        let schema = (&schema).try_into()?;
+        Ok(Self {
+            id: Uuid::from_slice(&value.id)?,
+            schema,
+        })
+    }
+}
+
+impl TryFrom<PhysicalPlanResponse> for service::PhysicalPlanResponse {
+    type Error = ProtoConvError;
+    fn try_from(value: PhysicalPlanResponse) -> Result<Self, Self::Error> {
+        let schema = datafusion_proto::protobuf::Schema::try_from(&value.schema)?;
+        Ok(Self {
+            id: value.id.into_bytes().into(),
+            schema: schema.encode_to_vec(),
+        })
+    }
+}
+
+// Table Reference
+
+impl TryFrom<service::TableReference> for OwnedTableReference {
+    type Error = ProtoConvError;
+    fn try_from(value: service::TableReference) -> Result<Self, Self::Error> {
+        let service::TableReference {
+            catalog,
+            schema,
+            table,
+        } = value;
+        let table_ref = match (catalog, schema, table) {
+            (None, None, table) => OwnedTableReference::Bare {
+                table: table.into(),
+            },
+            (None, Some(schema), table) => OwnedTableReference::Partial {
+                table: table.into(),
+                schema: schema.into(),
+            },
+            (Some(catalog), Some(schema), table) => OwnedTableReference::Full {
+                table: table.into(),
+                schema: schema.into(),
+                catalog: catalog.into(),
+            },
+            (catalog, schema, table) => {
+                return Err(ProtoConvError::InvalidTableReference(
+                    catalog.unwrap_or_default(),
+                    schema.unwrap_or_default(),
+                    table,
+                ))
+            }
+        };
+        Ok(table_ref)
+    }
+}
+
+impl<'a> From<TableReference<'a>> for service::TableReference {
+    fn from(value: TableReference<'a>) -> Self {
+        match value {
+            TableReference::Bare { table } => service::TableReference {
+                table: table.into_owned(),
+                schema: None,
+                catalog: None,
+            },
+            TableReference::Partial { schema, table } => service::TableReference {
+                table: table.into_owned(),
+                schema: Some(schema.into_owned()),
+                catalog: None,
+            },
+            TableReference::Full {
+                catalog,
+                schema,
+                table,
+            } => service::TableReference {
+                table: table.into_owned(),
+                schema: Some(schema.into_owned()),
+                catalog: Some(catalog.into_owned()),
+            },
+        }
+    }
+}
+
+pub struct CloseSessionRequest {
+    pub session_id: Uuid,
+}
+
+impl TryFrom<service::CloseSessionRequest> for CloseSessionRequest {
+    type Error = ProtoConvError;
+    fn try_from(value: service::CloseSessionRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: Uuid::from_slice(&value.session_id)?,
+        })
+    }
+}
+
+impl From<CloseSessionRequest> for service::CloseSessionRequest {
+    fn from(value: CloseSessionRequest) -> Self {
+        Self {
+            session_id: value.session_id.into_bytes().into(),
+        }
+    }
+}
+
+pub struct CloseSessionResponse {}
+
+impl From<service::CloseSessionResponse> for CloseSessionResponse {
+    fn from(_value: service::CloseSessionResponse) -> Self {
+        Self {}
+    }
+}
+
+impl From<CloseSessionResponse> for service::CloseSessionResponse {
+    fn from(_value: CloseSessionResponse) -> Self {
+        Self {}
+    }
+}

--- a/crates/rpcsrv/src/errors.rs
+++ b/crates/rpcsrv/src/errors.rs
@@ -19,7 +19,7 @@ pub enum RpcsrvError {
     TonicMetadataToStr(#[from] tonic::metadata::errors::ToStrError),
 
     #[error(transparent)]
-    ProtoConvError(#[from] protogen::metastore::types::ProtoConvError),
+    ProtoConvError(#[from] protogen::errors::ProtoConvError),
 
     #[error(transparent)]
     ExecError(#[from] sqlexec::errors::ExecError),
@@ -38,6 +38,9 @@ pub enum RpcsrvError {
 
     #[error(transparent)]
     InvalidMetadataValue(#[from] tonic::metadata::errors::InvalidMetadataValue),
+
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
 
     #[error("{0}")]
     Internal(String),

--- a/crates/rpcsrv/src/handler.rs
+++ b/crates/rpcsrv/src/handler.rs
@@ -9,12 +9,13 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion_ext::vars::{SessionVars, VarSetter};
 use futures::{Stream, StreamExt};
-use protogen::gen::{
-    metastore::catalog::CatalogState,
-    rpcsrv::service::{
-        execution_service_server::ExecutionService, initialize_session_request,
-        CloseSessionRequest, CloseSessionResponse, ExecuteRequest, ExecuteResponse,
-        InitializeSessionRequest, InitializeSessionResponse,
+use protogen::{
+    gen::rpcsrv::service,
+    metastore::types::catalog::CatalogState,
+    rpcsrv::types::service::{
+        CloseSessionRequest, CloseSessionResponse, CreatePhysicalPlanRequest,
+        DispatchAccessRequest, InitializeSessionRequest, InitializeSessionResponse,
+        PhysicalPlanExecuteRequest, PhysicalPlanResponse, TableProviderResponse,
     },
 };
 use sqlexec::engine::{Engine, SessionStorageConfig};
@@ -57,23 +58,14 @@ impl RpcHandler {
         //
         // This will check that we actually received a proxy request, and not a
         // request from the client.
-        let (db_id, storage_conf) = match req.request.ok_or_else(|| {
-            RpcsrvError::SessionInitalizeError("missing initialize request".to_string())
-        })? {
-            initialize_session_request::Request::Proxy(req) => {
-                let db_id = Uuid::from_slice(&req.db_id)
-                    .map_err(|e| RpcsrvError::InvalidId("database", e))?;
+        let (db_id, storage_conf) = match req {
+            InitializeSessionRequest::Proxy(req) => {
                 let storage_conf = SessionStorageConfig {
-                    gcs_bucket: req
-                        .storage_conf
-                        .ok_or_else(|| {
-                            RpcsrvError::SessionInitalizeError("missing storage config".to_string())
-                        })?
-                        .gcs_bucket,
+                    gcs_bucket: req.storage_conf.gcs_bucket,
                 };
-                (db_id, storage_conf)
+                (req.db_id, storage_conf)
             }
-            initialize_session_request::Request::Client(_req) if self.allow_client_init => {
+            InitializeSessionRequest::Client(_req) if self.allow_client_init => {
                 (Uuid::nil(), SessionStorageConfig::default())
             }
             _ => {
@@ -85,83 +77,144 @@ impl RpcHandler {
         };
 
         let conn_id = Uuid::new_v4();
+        info!(session_id=%conn_id, "initializing remote session");
 
         let mut vars = SessionVars::default();
         // TODO: handle error instead
         vars.database_id.set_and_log(db_id, VarSetter::System);
         vars.connection_id.set_and_log(conn_id, VarSetter::System);
 
-        let sess = self.engine.new_session(vars, storage_conf).await?;
+        let sess = self
+            .engine
+            .new_session(vars, storage_conf, /* remote_ctx = */ true)
+            .await?;
 
         let sess = RemoteSession::new(sess);
-        let initial_state: CatalogState = sess.get_catalog_state().await.try_into()?;
+        let initial_state: CatalogState = sess.get_catalog_state().await;
 
         self.sessions.insert(conn_id, sess);
 
         Ok(InitializeSessionResponse {
-            session_id: conn_id.into_bytes().to_vec(),
-            catalog: Some(initial_state),
+            session_id: conn_id,
+            catalog: initial_state,
         })
     }
 
-    async fn execute_inner(&self, req: ExecuteRequest) -> Result<ExecutionResponseBatchStream> {
-        let session_id =
-            Uuid::from_slice(&req.session_id).map_err(|e| RpcsrvError::InvalidId("session", e))?;
-
+    async fn create_physical_plan_inner(
+        &self,
+        req: CreatePhysicalPlanRequest,
+    ) -> Result<PhysicalPlanResponse> {
         // TODO(perf): This actually ends being two/three locks that we need to acquire.
         // 1. The hashmap
         // 2. The session itself
         // 3. (soon) Datafusion's context once we start using that
 
-        let sess = self
-            .sessions
-            .get(&session_id)
-            .ok_or_else(|| RpcsrvError::MissingSession(session_id))?;
+        let session = self.get_session(req.session_id)?;
+        info!(session_id=%req.session_id, "creating physical plan");
+        session.create_physical_plan(req.logical_plan).await
+    }
 
-        let batches = sess.execute_serialized_plan(req).await?;
+    async fn dispatch_access_inner(
+        &self,
+        req: DispatchAccessRequest,
+    ) -> Result<TableProviderResponse> {
+        let session = self.get_session(req.session_id)?;
+        info!(session_id=%req.session_id, table_ref=%req.table_ref, "dispatching table access");
+        session.dispatch_access(req.table_ref).await
+    }
+
+    async fn physical_plan_execute_inner(
+        &self,
+        req: PhysicalPlanExecuteRequest,
+    ) -> Result<ExecutionResponseBatchStream> {
+        let session = self.get_session(req.session_id)?;
+        info!(session_id=%req.session_id, exec_id=%req.exec_id, "executing physical plan");
+        let batches = session.physical_plan_execute(req.exec_id).await?;
         Ok(ExecutionResponseBatchStream {
             batches,
             buf: Vec::new(),
         })
     }
 
-    async fn close_session_inner(&self, req: CloseSessionRequest) -> Result<CloseSessionResponse> {
-        let session_id =
-            Uuid::from_slice(&req.session_id).map_err(|e| RpcsrvError::InvalidId("session", e))?;
-        self.sessions.remove(&session_id);
+    fn close_session_inner(&self, req: CloseSessionRequest) -> Result<CloseSessionResponse> {
+        info!(session_id=%req.session_id, "closing session");
+        self.sessions.remove(&req.session_id);
         Ok(CloseSessionResponse {})
+    }
+
+    fn get_session(&self, session_id: Uuid) -> Result<RemoteSession> {
+        self.sessions
+            .get(&session_id)
+            .ok_or_else(|| RpcsrvError::MissingSession(session_id))
+            .map(|s| s.value().clone())
     }
 }
 
 #[async_trait]
-impl ExecutionService for RpcHandler {
-    type ExecuteStream = Pin<Box<dyn Stream<Item = Result<ExecuteResponse, Status>> + Send>>;
+impl service::execution_service_server::ExecutionService for RpcHandler {
+    type PhysicalPlanExecuteStream =
+        Pin<Box<dyn Stream<Item = Result<service::RecordBatchResponse, Status>> + Send>>;
 
     async fn initialize_session(
         &self,
-        request: Request<InitializeSessionRequest>,
-    ) -> Result<Response<InitializeSessionResponse>, Status> {
-        info!("initializing session");
-        let resp = self.initialize_session_inner(request.into_inner()).await?;
-        Ok(Response::new(resp))
+        request: Request<service::InitializeSessionRequest>,
+    ) -> Result<Response<service::InitializeSessionResponse>, Status> {
+        let resp = self
+            .initialize_session_inner(request.into_inner().try_into()?)
+            .await?;
+        Ok(Response::new(resp.try_into()?))
     }
 
-    async fn execute(
+    async fn create_physical_plan(
         &self,
-        request: Request<ExecuteRequest>,
-    ) -> Result<Response<Self::ExecuteStream>, Status> {
-        info!("executing");
-        let stream = self.execute_inner(request.into_inner()).await?;
-        Ok(Response::new(Box::pin(stream)))
+        request: Request<service::CreatePhysicalPlanRequest>,
+    ) -> Result<Response<service::PhysicalPlanResponse>, Status> {
+        let resp = self
+            .create_physical_plan_inner(request.into_inner().try_into()?)
+            .await?;
+        Ok(Response::new(resp.try_into()?))
+    }
+
+    async fn dispatch_access(
+        &self,
+        request: Request<service::DispatchAccessRequest>,
+    ) -> Result<Response<service::TableProviderResponse>, Status> {
+        let resp = self
+            .dispatch_access_inner(request.into_inner().try_into()?)
+            .await?;
+        Ok(Response::new(resp.try_into()?))
+    }
+
+    async fn table_provider_scan(
+        &self,
+        _request: Request<service::TableProviderScanRequest>,
+    ) -> Result<Response<service::PhysicalPlanResponse>, Status> {
+        todo!()
+    }
+
+    async fn table_provider_insert_into(
+        &self,
+        _request: Request<service::TableProviderInsertIntoRequest>,
+    ) -> Result<Response<service::PhysicalPlanResponse>, Status> {
+        todo!()
+    }
+
+    async fn physical_plan_execute(
+        &self,
+        request: Request<service::PhysicalPlanExecuteRequest>,
+    ) -> Result<Response<Self::PhysicalPlanExecuteStream>, Status> {
+        let resp = self
+            .physical_plan_execute_inner(request.into_inner().try_into()?)
+            .await?;
+        Ok(Response::new(Box::pin(resp)))
     }
 
     async fn close_session(
         &self,
-        request: Request<CloseSessionRequest>,
-    ) -> Result<Response<CloseSessionResponse>, Status> {
-        info!("closing session");
-        let resp = self.close_session_inner(request.into_inner()).await?;
-        Ok(Response::new(resp))
+        request: Request<service::CloseSessionRequest>,
+    ) -> Result<Response<service::CloseSessionResponse>, Status> {
+        let resp = self.close_session_inner(request.into_inner().try_into()?)?;
+        Ok(Response::new(resp.into()))
     }
 }
 
@@ -175,7 +228,7 @@ struct ExecutionResponseBatchStream {
 }
 
 impl ExecutionResponseBatchStream {
-    fn write_batch(&mut self, batch: &RecordBatch) -> Result<ExecuteResponse> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<service::RecordBatchResponse> {
         self.buf.clear();
 
         let schema = batch.schema();
@@ -185,14 +238,14 @@ impl ExecutionResponseBatchStream {
 
         let _ = writer.into_inner()?;
 
-        Ok(ExecuteResponse {
+        Ok(service::RecordBatchResponse {
             arrow_ipc: self.buf.clone(),
         })
     }
 }
 
 impl Stream for ExecutionResponseBatchStream {
-    type Item = Result<ExecuteResponse, Status>;
+    type Item = Result<service::RecordBatchResponse, Status>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.batches.poll_next_unpin(cx) {

--- a/crates/rpcsrv/src/session.rs
+++ b/crates/rpcsrv/src/session.rs
@@ -1,15 +1,16 @@
-use crate::errors::{Result, RpcsrvError};
+use crate::errors::Result;
+use datafusion::arrow::datatypes::Schema;
+use datafusion::common::OwnedTableReference;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::protobuf::LogicalPlanNode;
-use protogen::gen::rpcsrv::service::execute_request::Plan;
-use protogen::gen::rpcsrv::service::ExecuteRequest;
 use protogen::metastore::types::catalog::CatalogState;
+use protogen::rpcsrv::types::service::{PhysicalPlanResponse, TableProviderResponse};
 use sqlexec::engine::TrackedSession;
-use sqlexec::extension_codec::GlareDBExtensionCodec;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
 /// A wrapper around a normal session for sql execution.
 #[derive(Clone)]
@@ -35,25 +36,48 @@ impl RemoteSession {
         session.get_session_catalog().get_state().as_ref().clone()
     }
 
-    pub async fn execute_serialized_plan(
+    pub async fn create_physical_plan(
         &self,
-        req: ExecuteRequest,
-    ) -> Result<SendableRecordBatchStream> {
-        match req.plan {
-            Some(Plan::LogicalPlan(buf)) => {
-                // TODO: Use a context that actually matters.
-                let fake_ctx = SessionContext::new();
-                let plan = LogicalPlanNode::try_decode(&buf)?
-                    .try_into_logical_plan(&fake_ctx, &GlareDBExtensionCodec)?;
+        logical_plan: impl AsRef<[u8]>,
+    ) -> Result<PhysicalPlanResponse> {
+        let mut session = self.session.lock().await;
 
-                let mut session = self.session.lock().await;
-                let physical = session.create_physical_plan(plan).await?;
-                let stream = session.execute_physical(physical)?;
+        // TODO: Use a context that actually matters.
+        let fake_ctx = SessionContext::new();
+        let codec = session.extension_codec()?;
+        let plan = LogicalPlanNode::try_decode(logical_plan.as_ref())?
+            .try_into_logical_plan(&fake_ctx, &codec)?;
 
-                Ok(stream)
-            }
-            Some(Plan::PhysicalPlan(_)) => Err(RpcsrvError::PhysicalPlansNotSupported),
-            None => Err(RpcsrvError::Internal("missing plan on request".to_string())),
-        }
+        let physical = session.create_physical_plan(plan).await?;
+        let schema = physical.schema();
+        let exec_id = session.add_physical_plan(physical)?;
+
+        Ok(PhysicalPlanResponse {
+            id: exec_id,
+            schema: Schema::clone(&schema),
+        })
+    }
+
+    pub async fn dispatch_access(
+        &self,
+        table_ref: OwnedTableReference,
+    ) -> Result<TableProviderResponse> {
+        let mut session = self.session.lock().await;
+        let provider = session.dispatch_access(table_ref).await?;
+        let schema = provider.schema();
+        let provider_id = session.add_table_provider(provider)?;
+
+        Ok(TableProviderResponse {
+            id: provider_id,
+            schema: Schema::clone(&schema),
+        })
+    }
+
+    pub async fn physical_plan_execute(&self, exec_id: Uuid) -> Result<SendableRecordBatchStream> {
+        let session = self.session.lock().await;
+        let plan = session.get_physical_plan(&exec_id)?;
+        // TODO: Use a context that actually matters.
+        let stream = session.execute_physical(plan)?;
+        Ok(stream)
     }
 }

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -84,7 +84,11 @@ impl TableFunc for ObjScanTableFunc {
             FileType::JSON => {
                 Arc::new(JsonFormat::default().with_file_compression_type(file_compression))
             }
-            _ => todo!(),
+            ft => {
+                return Err(ExtensionError::String(format!(
+                    "Unsuppored file type: {ft:?}"
+                )))
+            }
         };
 
         // Optimize creating a table provider for objects by clubbing the same

--- a/crates/sqlexec/src/context.rs
+++ b/crates/sqlexec/src/context.rs
@@ -108,6 +108,7 @@ impl SessionContext {
     ///
     /// If `info.memory_limit_bytes` is non-zero, a new memory pool will be
     /// created with the max set to this value.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vars: SessionVars,
         catalog: SessionCatalog,

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -6,8 +6,11 @@ pub enum ExecError {
     #[error("Unsupported feature: '{0}'. Check back soon!")]
     UnsupportedFeature(&'static str),
 
-    #[error("Invalid remote session id: {0}")]
-    InvalidRemoteSessionId(uuid::Error),
+    #[error("Invalid remote {0} id: {1}")]
+    InvalidRemoteId(&'static str, uuid::Error),
+
+    #[error("Cannot convert proto to {0}: {1}")]
+    ProtoConvCustom(&'static str, Box<dyn std::error::Error + Send + Sync>),
 
     #[error("Invalid value for session variable: Variable name: {name}, Value: {val}")]
     InvalidSessionVarValue { name: String, val: String },
@@ -38,6 +41,9 @@ pub enum ExecError {
 
     #[error("Missing connection by oid: {oid}")]
     MissingConnectionByOid { oid: u32 },
+
+    #[error("Invalid {0} id: {1} not found")]
+    MissingRemoteId(&'static str, uuid::Uuid),
 
     #[error("Invalid connection type; expected: {expected}, got: {got}")]
     InvalidConnectionType {
@@ -77,6 +83,9 @@ pub enum ExecError {
 
     #[error(transparent)]
     VarError(#[from] std::env::VarError),
+
+    #[error(transparent)]
+    ProtoConvError(#[from] protogen::errors::ProtoConvError),
 
     #[error("Unable to retrieve ssh tunnel connection: {0}")]
     MissingSshTunnel(Box<crate::errors::ExecError>),
@@ -126,6 +135,9 @@ pub enum ExecError {
 
     #[error(transparent)]
     PlanError(#[from] crate::planner::errors::PlanError),
+
+    #[error(transparent)]
+    DispatchError(#[from] crate::planner::dispatch::DispatchError),
 
     #[error(transparent)]
     MetastoreWorker(#[from] crate::metastore::client::WorkerError),

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -1,16 +1,43 @@
+use core::fmt;
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
+use uuid::Uuid;
 
+use crate::errors::ExecError;
 use crate::planner::extension::ExtensionConversion;
 use crate::planner::logical_plan::CreateTable;
+use crate::remote::table::RemoteTableProvider;
 
-#[derive(Debug)]
-pub struct GlareDBExtensionCodec;
+pub struct GlareDBExtensionCodec<'a> {
+    table_providers: Option<&'a HashMap<Uuid, Arc<dyn TableProvider>>>,
+}
 
-impl LogicalExtensionCodec for GlareDBExtensionCodec {
+impl<'a> GlareDBExtensionCodec<'a> {
+    pub fn new_decoder(table_providers: &'a HashMap<Uuid, Arc<dyn TableProvider>>) -> Self {
+        Self {
+            table_providers: Some(table_providers),
+        }
+    }
+
+    pub fn new_encoder() -> Self {
+        Self {
+            table_providers: None,
+        }
+    }
+}
+
+impl<'a> fmt::Debug for GlareDBExtensionCodec<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GlareDBExtensionCodec").finish()
+    }
+}
+
+impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
     fn try_decode(
         &self,
         _buf: &[u8],
@@ -40,18 +67,39 @@ impl LogicalExtensionCodec for GlareDBExtensionCodec {
 
     fn try_decode_table_provider(
         &self,
-        _buf: &[u8],
+        buf: &[u8],
         _schema: datafusion::arrow::datatypes::SchemaRef,
         _ctx: &SessionContext,
     ) -> datafusion::error::Result<Arc<dyn datafusion::datasource::TableProvider>> {
-        todo!()
+        let provider_id = Uuid::from_slice(buf).map_err(|e| {
+            DataFusionError::External(Box::new(ExecError::InvalidRemoteId("provider", e)))
+        })?;
+
+        let provider = self
+            .table_providers
+            .and_then(|table_providers| table_providers.get(&provider_id))
+            .ok_or_else(|| {
+                DataFusionError::External(Box::new(ExecError::Internal(format!(
+                    "cannot decode the table provider for id: {provider_id}"
+                ))))
+            })?;
+
+        Ok(Arc::clone(provider))
     }
 
     fn try_encode_table_provider(
         &self,
-        _node: Arc<dyn datafusion::datasource::TableProvider>,
-        _buf: &mut Vec<u8>,
+        node: Arc<dyn datafusion::datasource::TableProvider>,
+        buf: &mut Vec<u8>,
     ) -> datafusion::error::Result<()> {
-        todo!()
+        if let Some(remote_provider) = node.as_any().downcast_ref::<RemoteTableProvider>() {
+            remote_provider
+                .encode(buf)
+                .map_err(|e| DataFusionError::External(Box::new(e)))
+        } else {
+            Err(DataFusionError::External(Box::new(ExecError::Internal(
+                "can only encode `RemoteTableProvider`".to_string(),
+            ))))
+        }
     }
 }

--- a/crates/sqlexec/src/metastore/client.rs
+++ b/crates/sqlexec/src/metastore/client.rs
@@ -42,7 +42,7 @@ pub enum WorkerError {
     },
 
     #[error(transparent)]
-    ProtoConvError(#[from] protogen::metastore::types::ProtoConvError),
+    ProtoConvError(#[from] protogen::errors::ProtoConvError),
 
     // TODO: Need to be more granular about errors from Metastore.
     #[error("Failed Metastore request: {message}")]

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -75,6 +75,9 @@ pub enum DispatchError {
     InvalidDispatch(&'static str),
 
     #[error(transparent)]
+    RemoteDispatch(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error(transparent)]
     Datafusion(#[from] datafusion::error::DataFusionError),
     #[error(transparent)]
     DebugDatasource(#[from] datasources::debug::errors::DebugError),

--- a/crates/sqlexec/src/planner/mod.rs
+++ b/crates/sqlexec/src/planner/mod.rs
@@ -1,8 +1,9 @@
+pub mod dispatch;
 pub mod errors;
 pub mod extension;
 pub mod logical_plan;
 pub mod session_planner;
 
-mod context_builder;
-mod dispatch;
+pub(crate) mod context_builder;
+
 mod preprocess;

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -826,14 +826,7 @@ impl<'a> SessionPlanner<'a> {
                     .insert_to_source_plan(&table_name, &columns, source)
                     .await?;
 
-                // This provider should be available in the context provider
-                // cache since we have successfully generated the insert plan.
-                //
-                // TODO: Get rid of context_provider when moving DF code into
-                // sqlexec. Will get rid of a lot of weirdness.
-                let table_provider = context_provider
-                    .table_provider(table_name)
-                    .ok_or(internal!("unable to get table provider to insert into"))?;
+                let table_provider = context_provider.table_provider(table_name).await?;
 
                 Ok(WritePlan::Insert(Insert {
                     table_provider,

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -1,7 +1,17 @@
-use crate::errors::{ExecError, Result};
-use protogen::gen::rpcsrv::service::{
-    execution_service_client::ExecutionServiceClient, CloseSessionRequest, CloseSessionResponse,
-    ExecuteRequest, ExecuteResponse, InitializeSessionRequest, InitializeSessionResponse,
+use crate::{
+    errors::{ExecError, Result},
+    extension_codec::GlareDBExtensionCodec,
+    metastore::catalog::SessionCatalog,
+};
+use datafusion::{common::OwnedTableReference, logical_expr::LogicalPlan};
+use datafusion_proto::{logical_plan::AsLogicalPlan, protobuf::LogicalPlanNode};
+use protogen::{
+    gen::rpcsrv::service::{self, execution_service_client::ExecutionServiceClient},
+    rpcsrv::types::service::{
+        CloseSessionRequest, CreatePhysicalPlanRequest, DispatchAccessRequest,
+        InitializeSessionRequest, InitializeSessionResponse, PhysicalPlanExecuteRequest,
+        PhysicalPlanResponse, TableProviderResponse,
+    },
 };
 use proxyutil::metadata_constants::{
     COMPUTE_ENGINE_KEY, DB_NAME_KEY, ORG_KEY, PASSWORD_KEY, USER_KEY,
@@ -10,9 +20,12 @@ use std::sync::Arc;
 use tonic::{
     metadata::MetadataMap,
     transport::{Channel, Endpoint},
-    IntoRequest, Response, Status, Streaming,
+    IntoRequest, Streaming,
 };
 use url::Url;
+use uuid::Uuid;
+
+use super::{exec::RemoteExecutionPlan, table::RemoteTableProvider};
 
 const DEFAULT_RPC_PROXY_PORT: u16 = 6443;
 
@@ -33,26 +46,28 @@ pub struct ProxyAuthParams {
 
 /// Auth params and destination to use when connecting the client.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProxyAuthParamsAndDst {
+pub struct ProxyDestination {
     pub params: ProxyAuthParams,
     pub dst: Url,
 }
 
-impl ProxyAuthParamsAndDst {
+impl TryFrom<Url> for ProxyDestination {
+    type Error = ExecError;
+
     /// Try to parse authentication parameters and destinaton from a url.
-    pub fn try_from_url(url: Url) -> Result<Self> {
-        if url.scheme() != "glaredb" {
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        if value.scheme() != "glaredb" {
             return Err(ExecError::InvalidRemoteExecUrl(
                 "URL must start with 'glaredb://'".to_string(),
             ));
         }
 
-        let user = url.username();
-        let password = url
+        let user = value.username();
+        let password = value
             .password()
             .ok_or_else(|| ExecError::InvalidRemoteExecUrl("Missing password".to_string()))?;
 
-        let host = url
+        let host = value
             .host_str()
             .ok_or_else(|| ExecError::InvalidRemoteExecUrl("URL is missing a host".to_string()))?;
 
@@ -62,7 +77,7 @@ impl ProxyAuthParamsAndDst {
             .ok_or_else(|| ExecError::InvalidRemoteExecUrl("Invalid host".to_string()))?;
 
         // Remove leading slash from path, use that as database name.
-        let db_name = url.path().trim_start_matches('/');
+        let db_name = value.path().trim_start_matches('/');
         if db_name.is_empty() {
             return Err(ExecError::InvalidRemoteExecUrl(
                 "Missing db name".to_string(),
@@ -81,7 +96,7 @@ impl ProxyAuthParamsAndDst {
         // Rebuild url that we should actually connect to.
         let dst = Url::parse(&format!(
             "http://{host}:{}",
-            url.port().unwrap_or(DEFAULT_RPC_PROXY_PORT)
+            value.port().unwrap_or(DEFAULT_RPC_PROXY_PORT)
         ))
         .map_err(|e| {
             ExecError::Internal(format!("fail to parse reconstructed host and port: {e}"))
@@ -95,14 +110,14 @@ impl ProxyAuthParamsAndDst {
             compute_engine: compute_engine.map(String::from),
         };
 
-        Ok(ProxyAuthParamsAndDst { params, dst })
+        Ok(ProxyDestination { params, dst })
     }
 }
 
 /// An execution service client that has additonal metadata attached to each
 /// request for authentication through the proxy.
 #[derive(Debug, Clone)]
-pub struct AuthenticatedExecutionServiceClient {
+pub struct RemoteClient {
     /// The inner client.
     client: ExecutionServiceClient<Channel>,
 
@@ -110,23 +125,26 @@ pub struct AuthenticatedExecutionServiceClient {
     auth_metadata: Arc<MetadataMap>,
 }
 
-impl AuthenticatedExecutionServiceClient {
+impl RemoteClient {
     /// Connect to destination without any additional authentication metadata.
     ///
     /// This can be used for testing (and possibly for inter-node
     /// communication?).
-    pub async fn connect(
-        dst: impl TryInto<Endpoint, Error = tonic::transport::Error>,
-    ) -> Result<Self> {
-        let client = ExecutionServiceClient::connect(dst).await?;
-        Ok(AuthenticatedExecutionServiceClient {
+    pub async fn connect(dst: Url) -> Result<Self> {
+        let client = ExecutionServiceClient::connect(dst.to_string()).await?;
+        Ok(RemoteClient {
             client,
             auth_metadata: Arc::new(MetadataMap::new()),
         })
     }
 
+    /// Connect to a proxy destination.
+    pub async fn connect_with_proxy_destination(dst: ProxyDestination) -> Result<Self> {
+        Self::connect_with_proxy_auth_params(dst.dst.to_string(), dst.params).await
+    }
+
     /// Connect to a destination with the provided authentication params.
-    pub async fn connect_with_proxy_auth_params<'a>(
+    async fn connect_with_proxy_auth_params<'a>(
         dst: impl TryInto<Endpoint, Error = tonic::transport::Error>,
         params: ProxyAuthParams,
     ) -> Result<Self> {
@@ -141,7 +159,7 @@ impl AuthenticatedExecutionServiceClient {
 
         let client = ExecutionServiceClient::connect(dst).await?;
 
-        Ok(AuthenticatedExecutionServiceClient {
+        Ok(RemoteClient {
             client,
             auth_metadata: Arc::new(metadata),
         })
@@ -149,29 +167,25 @@ impl AuthenticatedExecutionServiceClient {
 
     pub async fn initialize_session(
         &mut self,
-        request: impl IntoRequest<InitializeSessionRequest>,
-    ) -> Result<Response<InitializeSessionResponse>, Status> {
-        let mut request = request.into_request();
+        request: InitializeSessionRequest,
+    ) -> Result<(RemoteSessionClient, SessionCatalog)> {
+        let mut request = service::InitializeSessionRequest::from(request).into_request();
         self.append_auth_metadata(request.metadata_mut());
-        self.client.initialize_session(request).await
-    }
 
-    pub async fn execute(
-        &mut self,
-        request: impl IntoRequest<ExecuteRequest>,
-    ) -> Result<Response<Streaming<ExecuteResponse>>, Status> {
-        let mut request = request.into_request();
-        self.append_auth_metadata(request.metadata_mut());
-        self.client.execute(request).await
-    }
+        let resp = self.client.initialize_session(request).await.map_err(|e| {
+            ExecError::RemoteSession(format!("failed to initialize remote session: {e}"))
+        })?;
+        let resp: InitializeSessionResponse = resp.into_inner().try_into()?;
 
-    pub async fn close_session(
-        &mut self,
-        request: impl IntoRequest<CloseSessionRequest>,
-    ) -> Result<Response<CloseSessionResponse>, Status> {
-        let mut request = request.into_request();
-        self.append_auth_metadata(request.metadata_mut());
-        self.client.close_session(request).await
+        let remote_sess_client = RemoteSessionClient {
+            session_id: resp.session_id,
+            inner: self.clone(),
+        };
+
+        Ok((
+            remote_sess_client,
+            SessionCatalog::new(Arc::new(resp.catalog)),
+        ))
     }
 
     fn append_auth_metadata(&self, metadata: &mut MetadataMap) {
@@ -188,18 +202,147 @@ impl AuthenticatedExecutionServiceClient {
     }
 }
 
+/// A client to interact with the current active remote session.
+#[derive(Debug, Clone)]
+pub struct RemoteSessionClient {
+    inner: RemoteClient,
+    session_id: Uuid,
+}
+
+impl RemoteSessionClient {
+    /// Returns the current session ID.
+    pub fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    pub async fn create_physical_plan(
+        &mut self,
+        logical_plan: &LogicalPlan,
+    ) -> Result<RemoteExecutionPlan> {
+        let logical_plan = {
+            let node = LogicalPlanNode::try_from_logical_plan(
+                logical_plan,
+                &GlareDBExtensionCodec::new_encoder(),
+            )?;
+            let mut buf = Vec::new();
+            node.try_encode(&mut buf)?;
+            buf
+        };
+
+        let mut request = service::CreatePhysicalPlanRequest::from(CreatePhysicalPlanRequest {
+            session_id: self.session_id(),
+            logical_plan,
+        })
+        .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let resp: PhysicalPlanResponse = self
+            .inner
+            .client
+            .create_physical_plan(request)
+            .await
+            .map_err(|e| {
+                ExecError::RemoteSession(format!(
+                    "cannot create physical plan from logical plan: {e}"
+                ))
+            })?
+            .into_inner()
+            .try_into()?;
+
+        Ok(RemoteExecutionPlan::new(
+            self.clone(),
+            resp.id,
+            Arc::new(resp.schema),
+        ))
+    }
+
+    pub async fn dispatch_access(
+        &mut self,
+        table_ref: OwnedTableReference,
+    ) -> Result<RemoteTableProvider> {
+        let mut request = service::DispatchAccessRequest::from(DispatchAccessRequest {
+            session_id: self.session_id(),
+            table_ref,
+        })
+        .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let resp: TableProviderResponse = self
+            .inner
+            .client
+            .dispatch_access(request)
+            .await
+            .map_err(|e| ExecError::RemoteSession(format!("unable to dispatch table access: {e}")))?
+            .into_inner()
+            .try_into()?;
+
+        Ok(RemoteTableProvider::new(
+            self.clone(),
+            resp.id,
+            Arc::new(resp.schema),
+        ))
+    }
+
+    pub async fn physical_plan_execute(
+        &mut self,
+        exec_id: Uuid,
+    ) -> Result<Streaming<service::RecordBatchResponse>> {
+        let mut request = service::PhysicalPlanExecuteRequest::from(PhysicalPlanExecuteRequest {
+            session_id: self.session_id(),
+            exec_id,
+        })
+        .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let resp = self
+            .inner
+            .client
+            .physical_plan_execute(request)
+            .await
+            .map_err(|e| {
+                ExecError::RemoteSession(format!("error while executing physical plan: {e}"))
+            })?
+            .into_inner();
+        Ok(resp)
+    }
+
+    pub async fn close_session(&mut self) -> Result<()> {
+        let mut request = service::CloseSessionRequest::from(CloseSessionRequest {
+            session_id: self.session_id(),
+        })
+        .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let _resp = self
+            .inner
+            .client
+            .close_session(request)
+            .await
+            .map_err(|e| {
+                ExecError::RemoteSession(format!(
+                    "unable to close session {}: {}",
+                    self.session_id(),
+                    e
+                ))
+            })?
+            .into_inner();
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn params_from_url_valid_default_port() {
-        let out = ProxyAuthParamsAndDst::try_from_url(
+        let out = ProxyDestination::try_from(
             Url::parse("glaredb://user:password@org.remote.glaredb.com/db").unwrap(),
         )
         .unwrap();
 
-        let expected = ProxyAuthParamsAndDst {
+        let expected = ProxyDestination {
             params: ProxyAuthParams {
                 user: "user".to_string(),
                 password: "password".to_string(),
@@ -215,12 +358,12 @@ mod tests {
 
     #[test]
     fn params_from_url_valid_port_and_engine() {
-        let out = ProxyAuthParamsAndDst::try_from_url(
+        let out = ProxyDestination::try_from(
             Url::parse("glaredb://user:password@org.remote.glaredb.com:4444/engine.db").unwrap(),
         )
         .unwrap();
 
-        let expected = ProxyAuthParamsAndDst {
+        let expected = ProxyDestination {
             params: ProxyAuthParams {
                 user: "user".to_string(),
                 password: "password".to_string(),
@@ -237,19 +380,19 @@ mod tests {
     #[test]
     fn params_from_url_invalid() {
         // Invalid scheme
-        ProxyAuthParamsAndDst::try_from_url(
+        ProxyDestination::try_from(
             Url::parse("http://user:password@org.remote.glaredb.com:4444/engine.db").unwrap(),
         )
         .unwrap_err();
 
         // Missing password
-        ProxyAuthParamsAndDst::try_from_url(
+        ProxyDestination::try_from(
             Url::parse("glaredb://user@org.remote.glaredb.com:4444/engine.db").unwrap(),
         )
         .unwrap_err();
 
         // Missing db name
-        ProxyAuthParamsAndDst::try_from_url(
+        ProxyDestination::try_from(
             Url::parse("glaredb://user:password@org.remote.glaredb.com:4444/").unwrap(),
         )
         .unwrap_err();

--- a/crates/sqlexec/src/remote/mod.rs
+++ b/crates/sqlexec/src/remote/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 pub mod exec;
 pub mod planner;
+pub mod table;

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -3,23 +3,21 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::context::{QueryPlanner, SessionState};
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
-use std::sync::Arc;
-use uuid::Uuid;
 
-use super::client::AuthenticatedExecutionServiceClient;
-use super::exec::RemoteLogicalExec;
+use std::sync::Arc;
+
+use super::client::RemoteSessionClient;
 
 /// A planner that executes everything on a remote service.
 #[derive(Debug, Clone)]
 pub struct RemotePlanner {
-    session_id: Uuid,
     /// Client to remote services.
-    client: AuthenticatedExecutionServiceClient,
+    client: RemoteSessionClient,
 }
 
 impl RemotePlanner {
-    pub fn new(session_id: Uuid, client: AuthenticatedExecutionServiceClient) -> RemotePlanner {
-        RemotePlanner { session_id, client }
+    pub fn new(client: RemoteSessionClient) -> RemotePlanner {
+        RemotePlanner { client }
     }
 }
 
@@ -30,10 +28,11 @@ impl QueryPlanner for RemotePlanner {
         logical_plan: &DfLogicalPlan,
         _session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        Ok(Arc::new(RemoteLogicalExec::new(
-            self.session_id,
-            self.client.clone(),
-            logical_plan.clone(),
-        )))
+        let mut client = self.client.clone();
+        let physical_plan = client
+            .create_physical_plan(logical_plan)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(Arc::new(physical_plan))
     }
 }

--- a/crates/sqlexec/src/remote/table.rs
+++ b/crates/sqlexec/src/remote/table.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::{
+    arrow::datatypes::{Schema, SchemaRef},
+    datasource::TableProvider,
+    error::{DataFusionError, Result as DfResult},
+    execution::context::SessionState,
+    logical_expr::TableType,
+    physical_plan::ExecutionPlan,
+    prelude::Expr,
+};
+use uuid::Uuid;
+
+use crate::errors::{ExecError, Result};
+
+use super::{client::RemoteSessionClient, exec::RemoteExecutionPlan};
+
+#[derive(Debug)]
+pub struct RemoteTableProvider {
+    /// ID for this table provider.
+    provider_id: Uuid,
+    /// Schema for the table provider.
+    schema: Arc<Schema>,
+    /// Client for remote services.
+    _client: RemoteSessionClient,
+}
+
+impl RemoteTableProvider {
+    pub fn new(client: RemoteSessionClient, provider_id: Uuid, schema: SchemaRef) -> Self {
+        Self {
+            provider_id,
+            schema,
+            _client: client,
+        }
+    }
+
+    pub fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        buf.extend_from_slice(self.provider_id.as_bytes());
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TableProvider for RemoteTableProvider {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::External(Box::new(
+            ExecError::UnsupportedFeature("Table scan over RPC"),
+        )))
+    }
+
+    async fn insert_into(
+        &self,
+        _state: &SessionState,
+        input: Arc<dyn ExecutionPlan>,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        let _input = input
+            .as_any()
+            .downcast_ref::<RemoteExecutionPlan>()
+            .ok_or_else(|| {
+                DataFusionError::External(Box::new(ExecError::Internal(
+                    "`ExecutionPlan` not a `RemoteExecutionPlan` for remote `insert_into`"
+                        .to_string(),
+                )))
+            })?;
+
+        Err(DataFusionError::External(Box::new(
+            ExecError::UnsupportedFeature("INSERT INTO on RPC"),
+        )))
+    }
+}

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -206,6 +206,7 @@ impl Session {
     ///
     /// All system schemas (including `information_schema`) should already be in
     /// the provided catalog.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vars: SessionVars,
         catalog: SessionCatalog,

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -2,8 +2,12 @@ use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::extension_codec::GlareDBExtensionCodec;
 use crate::metastore::catalog::SessionCatalog;
-use crate::remote::client::AuthenticatedExecutionServiceClient;
+use crate::planner::context_builder::PartialContextProvider;
+use crate::remote::client::RemoteSessionClient;
+use datafusion::common::OwnedTableReference;
+use datafusion::datasource::TableProvider;
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::insert::DataSink;
@@ -209,7 +213,8 @@ impl Session {
         tracker: Arc<Tracker>,
         spill_path: Option<PathBuf>,
         background_jobs: JobRunner,
-        exec_client: Option<AuthenticatedExecutionServiceClient>,
+        exec_client: Option<RemoteSessionClient>,
+        remote_ctx: bool,
     ) -> Result<Session> {
         let metrics = SessionMetrics::new(
             *vars.user_id.value(),
@@ -226,6 +231,7 @@ impl Session {
             spill_path,
             background_jobs,
             exec_client,
+            remote_ctx,
         )?;
 
         Ok(Session { ctx })
@@ -270,14 +276,48 @@ impl Session {
         Ok(stream)
     }
 
+    /// Get a table provider from session.
+    pub fn get_table_provider(&self, provider_id: &uuid::Uuid) -> Result<Arc<dyn TableProvider>> {
+        self.ctx.get_table_provider(provider_id)
+    }
+
+    /// Add a table provider to the session. Returns the ID of the provider.
+    pub fn add_table_provider(&mut self, provider: Arc<dyn TableProvider>) -> Result<uuid::Uuid> {
+        self.ctx.add_table_provider(provider)
+    }
+
+    /// Get a physical plan from session.
+    pub fn get_physical_plan(&self, exec_id: &uuid::Uuid) -> Result<Arc<dyn ExecutionPlan>> {
+        self.ctx.get_physical_plan(exec_id)
+    }
+
+    /// Add a physical plan to the session. Returns the ID of the plan.
+    pub fn add_physical_plan(&mut self, plan: Arc<dyn ExecutionPlan>) -> Result<uuid::Uuid> {
+        self.ctx.add_physical_plan(plan)
+    }
+
+    /// Returns the extension codec used for serializing and deserializing data
+    /// over RPCs.
+    pub fn extension_codec(&self) -> Result<GlareDBExtensionCodec<'_>> {
+        self.ctx.extension_codec()
+    }
+
+    /// Get the session dispatcher.
+    pub async fn dispatch_access(
+        &self,
+        table_ref: OwnedTableReference,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let state = self.ctx.init_exec();
+        let mut ctx_provider = PartialContextProvider::new(&self.ctx, &state)?;
+        Ok(ctx_provider.table_provider(table_ref).await?)
+    }
+
     pub(crate) async fn create_table(
         &mut self,
         plan: CreateTable,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = plan.schema.as_ref().clone();
-
         self.ctx.create_table(plan).await?;
-
         Ok(Arc::new(EmptyExec::new(false, schema.into())))
     }
 

--- a/crates/testing/src/slt/cli.rs
+++ b/crates/testing/src/slt/cli.rs
@@ -208,7 +208,7 @@ impl Cli {
                     None,
                     None,
                     /* integration_testing = */ true,
-                    /* ignore_auth = */ false,
+                    /* disable_rpc_auth = */ false,
                 )
                 .await?;
                 tokio::spawn(server.serve(server_conf));

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -101,7 +101,11 @@ fn connect(
             .map_err(PyGlareDbError::from)?;
 
         let mut session = engine
-            .new_session(SessionVars::default(), SessionStorageConfig::default())
+            .new_session(
+                SessionVars::default(),
+                SessionStorageConfig::default(),
+                /* remote_ctx = */ false,
+            )
             .await
             .map_err(PyGlareDbError::from)?;
 


### PR DESCRIPTION
Basically everything happens on remote (except creating the logical plan). Table providers and Physical plans are created on remote and executed on remote server. All the calls are RPC. Everything is stored in session context against a unique ID which the client uses to call on the server.

**Internal changes:**

* Renamed the server's `--ignore-auth` to `--ignore-pg-auth`.
* Use `--disable-rpc-auth` to start server for calling rpc directly without proxy.
* Use `--ignore-rpc-auth` with local to call the rpc server directly when `--disable-rpc-auth` is set.

Fixes: #1502