### PR TITLE
fix: Return better error when querying pg table that doesn't exist

### DIFF
--- a/crates/datasources/src/postgres/errors.rs
+++ b/crates/datasources/src/postgres/errors.rs
@@ -1,5 +1,8 @@
 #[derive(Debug, thiserror::Error)]
 pub enum PostgresError {
+    #[error("Failed to query Postgres: {0}")]
+    QueryError(String),
+
     #[error("Unsupported Postgres type: {0}")]
     UnsupportedPostgresType(String),
 

--- a/testdata/sqllogictests_postgres/external_database.slt
+++ b/testdata/sqllogictests_postgres/external_database.slt
@@ -48,5 +48,10 @@ SELECT table_name
 ----
 bikeshare_stations
 
+# Try to query non-existent table.
+statement error failed to find table: 'public.doesnotexist'
+SELECT * FROM external_db.public.doesnotexist
+
 statement ok
 DROP DATABASE external_db;
+


### PR DESCRIPTION
Before:

> ERROR: Error during planning: Unable to fetch table provider for 'external_db.public.doesnotexist': Failed to dispatch to table: Failed to connect to Postgres instance: query returned an unexpected number of rows

After:

> ERROR: Error during planning: Unable to fetch table provider for 'external_db.public.doesnotexist': Failed to dispatch to table: Failed to query Postgres: failed to find table: 'public.doesnotexist'