### PR TITLE
feat(cli): multiline history support

### DIFF
--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -2,12 +2,22 @@ use std::io::{self};
 
 use nu_ansi_term::{Color, Style};
 
-use reedline::{Highlighter, StyledText};
+use reedline::{Highlighter, StyledText, Validator};
 use sqlexec::export::sqlparser::dialect::GenericDialect;
 use sqlexec::export::sqlparser::keywords::Keyword;
 use sqlexec::export::sqlparser::tokenizer::{Token, Tokenizer};
 
-pub(crate) struct SQLHighlighter {}
+pub(crate) struct SQLHighlighter;
+pub(crate) struct SQLValidator;
+impl Validator for SQLValidator {
+    fn validate(&self, line: &str) -> reedline::ValidationResult {
+        if line.trim_end().ends_with(';') {
+            reedline::ValidationResult::Complete
+        } else {
+            reedline::ValidationResult::Incomplete
+        }
+    }
+}
 
 fn colorize_sql(query: &str, st: &mut StyledText) -> std::io::Result<()> {
     let dialect = GenericDialect;

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -1,4 +1,4 @@
-use crate::highlighter::SQLHighlighter;
+use crate::highlighter::{SQLHighlighter, SQLValidator};
 use crate::prompt::SQLPrompt;
 use crate::util::MetastoreClientMode;
 use anyhow::{anyhow, Result};
@@ -202,8 +202,9 @@ impl LocalSession {
 
         let mut line_editor = Reedline::create().with_history(history);
 
-        let sql_highlighter = SQLHighlighter {};
-        line_editor = line_editor.with_highlighter(Box::new(sql_highlighter));
+        line_editor = line_editor
+            .with_highlighter(Box::new(SQLHighlighter))
+            .with_validator(Box::new(SQLValidator));
 
         println!("GlareDB (v{})", env!("CARGO_PKG_VERSION"));
         println!("Type \\help for help.");


### PR DESCRIPTION
this has been bothering me for a while, if you put in a multiline sql command, you were not able to use the history to re do your previous statement, as the history was stored line by line. 

now the history is stored per statement as it should


https://github.com/GlareDB/glaredb/assets/21327470/364e28ee-d9a8-41e7-b40b-f4fe0051e0a9

