### PR TITLE
feat: Support remote table scans and inserts

### DIFF
--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -101,7 +101,7 @@ message TableProviderScanRequest {
   bytes session_id = 1;
   bytes provider_id = 2;
   // Scan parameters.
-  optional uint64 projection = 3;
+  repeated uint64 projection = 3;
   repeated bytes filters = 4;
   optional uint64 limit = 5; 
 }

--- a/crates/protogen/src/lib.rs
+++ b/crates/protogen/src/lib.rs
@@ -51,6 +51,9 @@ pub mod errors {
 
         #[error(transparent)]
         DfLogicalToProto(#[from] datafusion_proto::logical_plan::to_proto::Error),
+
+        #[error(transparent)]
+        DataFusionError(#[from] datafusion::common::DataFusionError),
     }
 
     impl From<ProtoConvError> for tonic::Status {

--- a/crates/rpcsrv/src/session.rs
+++ b/crates/rpcsrv/src/session.rs
@@ -2,11 +2,10 @@ use crate::errors::Result;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::common::OwnedTableReference;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use datafusion::prelude::SessionContext;
+use datafusion::prelude::{Expr, SessionContext};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use protogen::metastore::types::catalog::CatalogState;
-use protogen::rpcsrv::types::service::{PhysicalPlanResponse, TableProviderResponse};
 use sqlexec::engine::TrackedSession;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -39,7 +38,7 @@ impl RemoteSession {
     pub async fn create_physical_plan(
         &self,
         logical_plan: impl AsRef<[u8]>,
-    ) -> Result<PhysicalPlanResponse> {
+    ) -> Result<(Uuid, Schema)> {
         let mut session = self.session.lock().await;
 
         // TODO: Use a context that actually matters.
@@ -51,26 +50,50 @@ impl RemoteSession {
         let physical = session.create_physical_plan(plan).await?;
         let schema = physical.schema();
         let exec_id = session.add_physical_plan(physical)?;
-
-        Ok(PhysicalPlanResponse {
-            id: exec_id,
-            schema: Schema::clone(&schema),
-        })
+        Ok((exec_id, Schema::clone(&schema)))
     }
 
-    pub async fn dispatch_access(
-        &self,
-        table_ref: OwnedTableReference,
-    ) -> Result<TableProviderResponse> {
+    pub async fn dispatch_access(&self, table_ref: OwnedTableReference) -> Result<(Uuid, Schema)> {
         let mut session = self.session.lock().await;
         let provider = session.dispatch_access(table_ref).await?;
         let schema = provider.schema();
         let provider_id = session.add_table_provider(provider)?;
+        Ok((provider_id, Schema::clone(&schema)))
+    }
 
-        Ok(TableProviderResponse {
-            id: provider_id,
-            schema: Schema::clone(&schema),
-        })
+    pub async fn table_provider_scan(
+        &self,
+        provider_id: Uuid,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<(Uuid, Schema)> {
+        let mut session = self.session.lock().await;
+        let provider = session.get_table_provider(&provider_id)?;
+        // TODO: Use a context that actually matters.
+        let fake_ctx = SessionContext::new();
+        let physical = provider
+            .scan(&fake_ctx.state(), projection, filters, limit)
+            .await?;
+        let schema = physical.schema();
+        let exec_id = session.add_physical_plan(physical)?;
+        Ok((exec_id, Schema::clone(&schema)))
+    }
+
+    pub async fn table_provider_insert_into(
+        &self,
+        provider_id: Uuid,
+        input_exec_id: Uuid,
+    ) -> Result<(Uuid, Schema)> {
+        let mut session = self.session.lock().await;
+        let provider = session.get_table_provider(&provider_id)?;
+        let input = session.get_physical_plan(&input_exec_id)?;
+        // TODO: Use a context that actually matters.
+        let fake_ctx = SessionContext::new();
+        let physical = provider.insert_into(&fake_ctx.state(), input).await?;
+        let schema = physical.schema();
+        let exec_id = session.add_physical_plan(physical)?;
+        Ok((exec_id, Schema::clone(&schema)))
     }
 
     pub async fn physical_plan_execute(&self, exec_id: Uuid) -> Result<SendableRecordBatchStream> {

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -3,14 +3,15 @@ use crate::{
     extension_codec::GlareDBExtensionCodec,
     metastore::catalog::SessionCatalog,
 };
-use datafusion::{common::OwnedTableReference, logical_expr::LogicalPlan};
+use datafusion::{common::OwnedTableReference, logical_expr::LogicalPlan, prelude::Expr};
 use datafusion_proto::{logical_plan::AsLogicalPlan, protobuf::LogicalPlanNode};
 use protogen::{
     gen::rpcsrv::service::{self, execution_service_client::ExecutionServiceClient},
     rpcsrv::types::service::{
         CloseSessionRequest, CreatePhysicalPlanRequest, DispatchAccessRequest,
         InitializeSessionRequest, InitializeSessionResponse, PhysicalPlanExecuteRequest,
-        PhysicalPlanResponse, TableProviderResponse,
+        PhysicalPlanResponse, TableProviderInsertIntoRequest, TableProviderResponse,
+        TableProviderScanRequest,
     },
 };
 use proxyutil::metadata_constants::{
@@ -278,6 +279,71 @@ impl RemoteSessionClient {
             .try_into()?;
 
         Ok(RemoteTableProvider::new(
+            self.clone(),
+            resp.id,
+            Arc::new(resp.schema),
+        ))
+    }
+
+    pub async fn table_provider_scan(
+        &mut self,
+        provider_id: Uuid,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<RemoteExecutionPlan> {
+        let mut request = service::TableProviderScanRequest::try_from(TableProviderScanRequest {
+            session_id: self.session_id(),
+            provider_id,
+            projection: projection.cloned(),
+            filters: filters.to_vec(),
+            limit,
+        })?
+        .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let resp: PhysicalPlanResponse = self
+            .inner
+            .client
+            .table_provider_scan(request)
+            .await
+            .map_err(|e| ExecError::RemoteSession(format!("unable to scan table provider: {e}")))?
+            .into_inner()
+            .try_into()?;
+
+        Ok(RemoteExecutionPlan::new(
+            self.clone(),
+            resp.id,
+            Arc::new(resp.schema),
+        ))
+    }
+
+    pub async fn table_provider_insert_into(
+        &mut self,
+        provider_id: Uuid,
+        input_exec_id: Uuid,
+    ) -> Result<RemoteExecutionPlan> {
+        let mut request =
+            service::TableProviderInsertIntoRequest::from(TableProviderInsertIntoRequest {
+                session_id: self.session_id(),
+                provider_id,
+                input_exec_id,
+            })
+            .into_request();
+        self.inner.append_auth_metadata(request.metadata_mut());
+
+        let resp: PhysicalPlanResponse = self
+            .inner
+            .client
+            .table_provider_insert_into(request)
+            .await
+            .map_err(|e| {
+                ExecError::RemoteSession(format!("unable to insert into table provider: {e}"))
+            })?
+            .into_inner()
+            .try_into()?;
+
+        Ok(RemoteExecutionPlan::new(
             self.clone(),
             resp.id,
             Arc::new(resp.schema),

--- a/crates/sqlexec/src/remote/exec.rs
+++ b/crates/sqlexec/src/remote/exec.rs
@@ -41,6 +41,10 @@ impl RemoteExecutionPlan {
             schema,
         }
     }
+
+    pub fn id(&self) -> Uuid {
+        self.exec_id
+    }
 }
 
 impl ExecutionPlan for RemoteExecutionPlan {


### PR DESCRIPTION
```
> select * from abc;
┌───────┐
│ a     │
│ ──    │
│ Int32 │
╞═══════╡
│ 1     │
│ 2     │
│ 3     │
└───────┘
> insert into abc values (4), (5);
Write success
> select * from abc;
┌───────┐
│ a     │
│ ──    │
│ Int32 │
╞═══════╡
│ 1     │
│ 2     │
│ 3     │
│ 4     │
│ 5     │
└───────┘
```

**Logs:**

```
initializing remote session session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668
dispatching table access session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 table_ref=abc
creating physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668
executing physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 exec_id=e72dc636-faf9-4953-b3bb-0bd786a626e5
dispatching table access session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 table_ref=abc
creating physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668
insert into table provider session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 provider_id=21f8f6c2-51af-44bf-b3e3-57367363ca0c
executing physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 exec_id=9c2a7f9f-7449-408e-b667-357e10975801
dispatching table access session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 table_ref=abc
creating physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668
executing physical plan session_id=accc8ed7-d0e1-463a-834d-6f5ae2199668 exec_id=ea5525e1-38a4-45db-b90a-da9b499e5216
```