### PR TITLE
fix: Use named arguments for file compression

### DIFF
--- a/crates/datasources/src/common/url.rs
+++ b/crates/datasources/src/common/url.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, fmt::Display, path::PathBuf};
 
-use datafusion::{datasource::file_format::file_type::FileCompressionType, scalar::ScalarValue};
+use datafusion::scalar::ScalarValue;
 use datafusion_ext::{
     errors::ExtensionError,
     functions::{FromFuncParamValue, FuncParamValue},
@@ -149,21 +149,6 @@ impl DatasourceUrl {
             _ => Err(DatasourceCommonError::InvalidUrl(
                 "cannot convert datasource URL to a generic URL".to_string(),
             )),
-        }
-    }
-
-    pub fn get_file_compression(&self) -> FileCompressionType {
-        match self {
-            DatasourceUrl::File(f) => f
-                .extension()
-                .and_then(|s| s.to_str())
-                .and_then(|ext| ext.parse().ok())
-                .unwrap_or(FileCompressionType::UNCOMPRESSED),
-            DatasourceUrl::Url(u) => u
-                .path()
-                .rsplit_once('.')
-                .and_then(|(_, ext)| ext.parse().ok())
-                .unwrap_or(FileCompressionType::UNCOMPRESSED),
         }
     }
 }

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -13,7 +13,7 @@ pub(crate) struct SQLHighlighter;
 pub(crate) struct SQLValidator;
 impl Validator for SQLValidator {
     fn validate(&self, line: &str) -> reedline::ValidationResult {
-        if line.trim_end().ends_with(';') || is_client_cmd(line) {
+        if line.trim().is_empty() || line.trim_end().ends_with(';') || is_client_cmd(line) {
             reedline::ValidationResult::Complete
         } else {
             reedline::ValidationResult::Incomplete

--- a/crates/protogen/proto/metastore/options.proto
+++ b/crates/protogen/proto/metastore/options.proto
@@ -135,6 +135,7 @@ message TableOptionsMysql {
 message TableOptionsLocal {
   string location = 1;
   string file_type = 2;
+  optional string compression = 3;
 }
 
 message TableOptionsGcs {
@@ -142,6 +143,7 @@ message TableOptionsGcs {
   string bucket = 2;
   string location = 3;
   string file_type = 4;
+  optional string compression = 5;
 }
 
 message TableOptionsS3 {
@@ -151,6 +153,7 @@ message TableOptionsS3 {
   string bucket = 4;
   string location = 5;
   string file_type = 6;
+  optional string compression = 7;
 }
 
 message TableOptionsMongo {

--- a/crates/protogen/src/metastore/types/options.rs
+++ b/crates/protogen/src/metastore/types/options.rs
@@ -689,6 +689,7 @@ impl From<TableOptionsMysql> for options::TableOptionsMysql {
 pub struct TableOptionsLocal {
     pub location: String,
     pub file_type: String,
+    pub compression: Option<String>,
 }
 
 impl TryFrom<options::TableOptionsLocal> for TableOptionsLocal {
@@ -697,6 +698,7 @@ impl TryFrom<options::TableOptionsLocal> for TableOptionsLocal {
         Ok(TableOptionsLocal {
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         })
     }
 }
@@ -706,6 +708,7 @@ impl From<TableOptionsLocal> for options::TableOptionsLocal {
         options::TableOptionsLocal {
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         }
     }
 }
@@ -716,6 +719,7 @@ pub struct TableOptionsGcs {
     pub bucket: String,
     pub location: String,
     pub file_type: String,
+    pub compression: Option<String>,
 }
 
 impl TryFrom<options::TableOptionsGcs> for TableOptionsGcs {
@@ -726,6 +730,7 @@ impl TryFrom<options::TableOptionsGcs> for TableOptionsGcs {
             bucket: value.bucket,
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         })
     }
 }
@@ -737,6 +742,7 @@ impl From<TableOptionsGcs> for options::TableOptionsGcs {
             bucket: value.bucket,
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         }
     }
 }
@@ -749,6 +755,7 @@ pub struct TableOptionsS3 {
     pub bucket: String,
     pub location: String,
     pub file_type: String,
+    pub compression: Option<String>,
 }
 
 impl TryFrom<options::TableOptionsS3> for TableOptionsS3 {
@@ -761,6 +768,7 @@ impl TryFrom<options::TableOptionsS3> for TableOptionsS3 {
             bucket: value.bucket,
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         })
     }
 }
@@ -774,6 +782,7 @@ impl From<TableOptionsS3> for options::TableOptionsS3 {
             bucket: value.bucket,
             location: value.location,
             file_type: value.file_type,
+            compression: value.compression,
         }
     }
 }

--- a/crates/sqlexec/src/parser/options.rs
+++ b/crates/sqlexec/src/parser/options.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, fmt};
 
 use datafusion::{
-    datasource::file_format::file_type::FileType, sql::sqlparser::parser::ParserError,
+    common::parsers::CompressionTypeVariant, datasource::file_format::file_type::FileType,
+    sql::sqlparser::parser::ParserError,
 };
 use datasources::{debug::DebugTableType, mongodb::MongoProtocol};
 
@@ -167,6 +168,18 @@ impl ParseOptionValue<FileType> for OptionValue {
                 s.parse().map_err(|e| parser_err!("{e}"))?
             }
             o => return Err(unexpected_type_err!("file type", o)),
+        };
+        Ok(opt)
+    }
+}
+
+impl ParseOptionValue<CompressionTypeVariant> for OptionValue {
+    fn parse_opt(self) -> Result<CompressionTypeVariant, ParserError> {
+        let opt = match self {
+            Self::QuotedLiteral(s) | Self::UnquotedLiteral(s) => {
+                s.parse().map_err(|e| parser_err!("{e}"))?
+            }
+            o => return Err(unexpected_type_err!("file compression type", o)),
         };
         Ok(opt)
     }

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::{
     DataType, Field, Schema, TimeUnit, DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
 };
+use datafusion::common::parsers::CompressionTypeVariant;
 use datafusion::common::{OwnedSchemaReference, OwnedTableReference, ToDFSchema};
 use datafusion::datasource::file_format::file_type::FileType;
 use datafusion::logical_expr::{cast, col, LogicalPlanBuilder};
@@ -420,11 +421,13 @@ impl<'a> SessionPlanner<'a> {
                 let location: String = m.remove_required("location")?;
 
                 let access = Arc::new(LocalStoreAccess);
-                let file_type = validate_obj_and_get_file_type(access, &location, m).await?;
+                let (file_type, compression) =
+                    validate_and_get_file_type_and_compression(access, &location, m).await?;
 
                 TableOptions::Local(TableOptionsLocal {
                     location,
                     file_type: format!("{file_type:?}").to_lowercase(),
+                    compression: compression.map(|c| c.to_string()),
                 })
             }
             TableOptions::GCS => {
@@ -443,13 +446,15 @@ impl<'a> SessionPlanner<'a> {
                     bucket: bucket.clone(),
                     service_account_key: service_account_key.clone(),
                 });
-                let file_type = validate_obj_and_get_file_type(access, &location, m).await?;
+                let (file_type, compression) =
+                    validate_and_get_file_type_and_compression(access, &location, m).await?;
 
                 TableOptions::Gcs(TableOptionsGcs {
                     bucket,
                     service_account_key,
                     location,
                     file_type: format!("{file_type:?}").to_lowercase(),
+                    compression: compression.map(|c| c.to_string()),
                 })
             }
             TableOptions::S3_STORAGE => {
@@ -480,7 +485,8 @@ impl<'a> SessionPlanner<'a> {
                     access_key_id: access_key_id.clone(),
                     secret_access_key: secret_access_key.clone(),
                 });
-                let file_type = validate_obj_and_get_file_type(access, &location, m).await?;
+                let (file_type, compression) =
+                    validate_and_get_file_type_and_compression(access, &location, m).await?;
 
                 TableOptions::S3(TableOptionsS3 {
                     region,
@@ -489,6 +495,7 @@ impl<'a> SessionPlanner<'a> {
                     secret_access_key,
                     location,
                     file_type: format!("{file_type:?}").to_lowercase(),
+                    compression: compression.map(|c| c.to_string()),
                 })
             }
             TableOptions::DEBUG => {
@@ -1367,12 +1374,12 @@ impl<'a> SessionPlanner<'a> {
 
 /// Creates an accessor from object store external table and validates if the
 /// location returns any objects. If objects are returned, tries to get the
-/// file type of the object.
-async fn validate_obj_and_get_file_type(
+/// file type and compression of the object.
+async fn validate_and_get_file_type_and_compression(
     access: Arc<dyn ObjStoreAccess>,
     location: &str,
     m: &mut StmtOptions,
-) -> Result<FileType> {
+) -> Result<(FileType, Option<CompressionTypeVariant>)> {
     let accessor =
         ObjStoreAccessor::new(access.clone()).map_err(|e| PlanError::InvalidExternalTable {
             source: Box::new(e),
@@ -1392,22 +1399,37 @@ async fn validate_obj_and_get_file_type(
         });
     }
 
-    match m.remove_optional("file_type")? {
-        Some(file_type) => Ok(file_type),
+    let compression = match m.remove_optional::<CompressionTypeVariant>("compression")? {
+        Some(compression) => Some(compression),
+        None => objects
+            .first()
+            .ok_or_else(|| PlanError::InvalidExternalTable {
+                source: Box::new(internal!("object '{location} not found'")),
+            })?
+            .location
+            .extension()
+            .and_then(|ext| ext.parse().ok()),
+    };
+
+    let file_type = match m.remove_optional::<FileType>("file_type")? {
+        Some(file_type) => file_type,
         None => {
+            let mut ft = None;
             for obj in objects {
-                match file_type_from_path(&obj.location) {
+                ft = match file_type_from_path(&obj.location) {
                     Err(_) => continue,
-                    Ok(file_type) => return Ok(file_type),
-                }
+                    Ok(file_type) => Some(file_type),
+                };
             }
-            Err(PlanError::InvalidExternalTable {
+            ft.ok_or_else(|| PlanError::InvalidExternalTable {
                 source: Box::new(internal!(
                     "unable to resolve file type from the objects, try passing `file_type` option"
                 )),
-            })
+            })?
         }
-    }
+    };
+
+    Ok((file_type, compression))
 }
 
 /// Resolves an ident (unquoted -> lowercase else case sensitive).

--- a/testdata/sqllogictests/functions/csv_scan.slt
+++ b/testdata/sqllogictests/functions/csv_scan.slt
@@ -7,10 +7,29 @@ select count(*) from csv_scan('file://${PWD}/testdata/sqllogictests_datasources_
 102
 
 # Absolute path (compressed)
+
 query I
 select count(*) from csv_scan('file://${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz')
 ----
 102
+
+# Compressed (with function argument)
+
+query I
+select count(*) from csv_scan(
+  'file://${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
+  compression => 'gzip'
+);
+----
+102
+
+# To prove this actually picks up the compression from the argument, giving a
+# wrong compression type should fail.
+statement error stream/file format not recognized
+select count(*) from csv_scan(
+  'file://${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
+  compression => 'xz'
+);
 
 # Relative path
 query I

--- a/testdata/sqllogictests_object_store/local/external_table.slt
+++ b/testdata/sqllogictests_object_store/local/external_table.slt
@@ -53,3 +53,41 @@ select * from ext_table_2;
 ----
 5	6
 7	8
+
+# Check compressed files
+
+statement ok
+create external table ext_table_3 from local (
+	location '${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
+	file_type csv
+);
+
+query I
+select count(*) from ext_table_3;
+----
+102
+
+# Give compression as argument
+
+# Giving wrong compression should error
+statement ok
+create external table ext_table_4 from local (
+	location '${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
+	file_type csv,
+	compression xz
+);
+
+statement error stream/file format not recognized
+select * from ext_table_4;
+
+statement ok
+create external table ext_table_5 from local (
+	location '${PWD}/testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
+	file_type csv,
+	compression gz
+);
+
+query I
+select count(*) from ext_table_5;
+----
+102


### PR DESCRIPTION
Both for scan functions and external tables

```
> select count(*) from csv_scan(
::: 'testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
::: compression => 'gz'
::: );
┌─────────────────┐
│ COUNT(UInt8(1)) │
│ ──              │
│ Int64           │
╞═════════════════╡
│ 102             │
└─────────────────┘
> create external table abc from local (
::: location 'testdata/sqllogictests_datasources_common/data/bikeshare_stations.csv.gz',
::: file_type 'csv',
::: compression 'gz'
::: );
┌┐
└┘
> select count(*) from abc;
┌─────────────────┐
│ COUNT(UInt8(1)) │
│ ──              │
│ Int64           │
╞═════════════════╡
│ 102             │
└─────────────────┘
```

Fixes #1491