### PR TITLE
rpc variable execs

### DIFF
--- a/crates/protogen/src/sqlexec/logical_plan.rs
+++ b/crates/protogen/src/sqlexec/logical_plan.rs
@@ -125,12 +125,20 @@ pub struct AlterTableRename {
     pub new_name: Option<OwnedTableReference>,
 }
 
+#[derive(Clone, PartialEq, Message)]
+pub struct SetVariable {
+    #[prost(string, tag = "1")]
+    pub variable: String,
+    #[prost(string, tag = "2")]
+    pub values: String,
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, Message)]
 pub struct LogicalPlanExtension {
     #[prost(
         oneof = "LogicalPlanExtensionType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18"
     )]
     pub inner: Option<LogicalPlanExtensionType>,
 }
@@ -172,6 +180,8 @@ pub enum LogicalPlanExtensionType {
     DropTunnel(DropTunnel),
     #[prost(message, tag = "17")]
     DropViews(DropViews),
+    #[prost(message, tag = "18")]
+    SetVariable(SetVariable),
 }
 
 // -----

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -150,6 +150,7 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
 
                 drop_credentials.into_extension()
             }
+<<<<<<< HEAD
             PlanType::DropDatabase(drop_database) => {
                 let drop_database: plan::DropDatabase = drop_database
                     .try_into()
@@ -178,6 +179,8 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
 
                 drop_views.into_extension()
             }
+=======
+>>>>>>> 6dc89c6 (wip)
         })
     }
 

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -150,7 +150,6 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
 
                 drop_credentials.into_extension()
             }
-<<<<<<< HEAD
             PlanType::DropDatabase(drop_database) => {
                 let drop_database: plan::DropDatabase = drop_database
                     .try_into()
@@ -179,8 +178,6 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
 
                 drop_views.into_extension()
             }
-=======
->>>>>>> 6dc89c6 (wip)
         })
     }
 

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -178,6 +178,13 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
 
                 drop_views.into_extension()
             }
+            PlanType::SetVariable(set_variable) => {
+                let set_variable: plan::SetVariable = set_variable
+                    .try_into()
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+                set_variable.into_extension()
+            }
         })
     }
 
@@ -232,6 +239,7 @@ impl<'a> LogicalExtensionCodec for GlareDBExtensionCodec<'a> {
             ExtensionType::DropSchemas => plan::DropSchemas::try_encode_extension(node, buf, self),
             ExtensionType::DropTunnel => plan::DropTunnel::try_encode_extension(node, buf, self),
             ExtensionType::DropViews => plan::DropViews::try_encode_extension(node, buf, self),
+            ExtensionType::SetVariable => plan::SetVariable::try_encode_extension(node, buf, self),
         }
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
         Ok(())

--- a/crates/sqlexec/src/planner/extension.rs
+++ b/crates/sqlexec/src/planner/extension.rs
@@ -12,7 +12,7 @@ use super::logical_plan::{
     AlterDatabaseRename, AlterTableRename, AlterTunnelRotateKeys, CreateCredentials,
     CreateExternalDatabase, CreateExternalTable, CreateSchema, CreateTable, CreateTempTable,
     CreateTunnel, CreateView, DropCredentials, DropDatabase, DropSchemas, DropTables, DropTunnel,
-    DropViews,
+    DropViews, SetVariable,
 };
 
 /// This tracks all of our extensions so that we can ensure an exhaustive match on anywhere that uses the extension
@@ -36,6 +36,7 @@ pub enum ExtensionType {
     DropSchemas,
     DropTunnel,
     DropViews,
+    SetVariable,
 }
 
 impl FromStr for ExtensionType {
@@ -59,6 +60,7 @@ impl FromStr for ExtensionType {
             DropSchemas::EXTENSION_NAME => Self::DropSchemas,
             DropTunnel::EXTENSION_NAME => Self::DropTunnel,
             DropViews::EXTENSION_NAME => Self::DropViews,
+            SetVariable::EXTENSION_NAME => Self::SetVariable,
             _ => return Err(internal!("unknown extension type: {}", s)),
         })
     }

--- a/crates/sqlexec/src/planner/logical_plan.rs
+++ b/crates/sqlexec/src/planner/logical_plan.rs
@@ -15,6 +15,8 @@ mod drop_schemas;
 mod drop_tables;
 mod drop_tunnel;
 mod drop_views;
+mod set_variable;
+mod show_variable;
 
 use crate::errors::{internal, Result};
 use crate::planner::extension::ExtensionNode;
@@ -55,6 +57,8 @@ pub use drop_schemas::*;
 pub use drop_tables::*;
 pub use drop_tunnel::*;
 pub use drop_views::*;
+pub use set_variable::*;
+pub use show_variable::*;
 
 static EMPTY_SCHEMA: Lazy<Arc<DFSchema>> = Lazy::new(|| Arc::new(DFSchema::empty()));
 
@@ -248,39 +252,4 @@ impl From<VariablePlan> for LogicalPlan {
     fn from(plan: VariablePlan) -> Self {
         LogicalPlan::Variable(plan)
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct SetVariable {
-    pub variable: String,
-    pub values: Vec<ast::Expr>,
-}
-
-impl SetVariable {
-    /// Try to convert the value into a string.
-    pub fn try_value_into_string(&self) -> Result<String> {
-        let expr_to_string = |expr: &ast::Expr| {
-            Ok(match expr {
-                ast::Expr::Identifier(_) | ast::Expr::CompoundIdentifier(_) => expr.to_string(),
-                ast::Expr::Value(ast::Value::SingleQuotedString(s)) => s.clone(),
-                ast::Expr::Value(ast::Value::DoubleQuotedString(s)) => format!("\"{}\"", s),
-                ast::Expr::Value(ast::Value::UnQuotedString(s)) => s.clone(),
-                ast::Expr::Value(ast::Value::Number(s, _)) => s.clone(),
-                ast::Expr::Value(v) => v.to_string(),
-                other => return Err(internal!("invalid expression for SET var: {:}", other)),
-            })
-        };
-
-        Ok(self
-            .values
-            .iter()
-            .map(expr_to_string)
-            .collect::<Result<Vec<_>>>()?
-            .join(","))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ShowVariable {
-    pub variable: String,
 }

--- a/crates/sqlexec/src/planner/logical_plan/set_variable.rs
+++ b/crates/sqlexec/src/planner/logical_plan/set_variable.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SetVariable {
+    pub variable: String,
+    pub values: String,
+}
+
+impl SetVariable {
+    pub fn try_new(variable: impl Into<String>, values: Vec<ast::Expr>) -> Result<Self> {
+        let expr_to_string = |expr: &ast::Expr| {
+            Ok(match expr {
+                ast::Expr::Identifier(_) | ast::Expr::CompoundIdentifier(_) => expr.to_string(),
+                ast::Expr::Value(ast::Value::SingleQuotedString(s)) => s.clone(),
+                ast::Expr::Value(ast::Value::DoubleQuotedString(s)) => format!("\"{}\"", s),
+                ast::Expr::Value(ast::Value::UnQuotedString(s)) => s.clone(),
+                ast::Expr::Value(ast::Value::Number(s, _)) => s.clone(),
+                ast::Expr::Value(v) => v.to_string(),
+                other => return Err(internal!("invalid expression for SET var: {:}", other)),
+            })
+        };
+        let values = values
+            .iter()
+            .map(expr_to_string)
+            .collect::<Result<Vec<_>>>()?
+            .join(",");
+
+        Ok(Self {
+            variable: variable.into(),
+            values,
+        })
+    }
+}
+
+impl TryFrom<protogen::sqlexec::logical_plan::SetVariable> for SetVariable {
+    type Error = ProtoConvError;
+
+    fn try_from(
+        value: protogen::sqlexec::logical_plan::SetVariable,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            variable: value.variable,
+            values: value.values,
+        })
+    }
+}
+
+impl UserDefinedLogicalNodeCore for SetVariable {
+    fn name(&self) -> &str {
+        Self::EXTENSION_NAME
+    }
+
+    fn inputs(&self) -> Vec<&DfLogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &datafusion::common::DFSchemaRef {
+        &EMPTY_SCHEMA
+    }
+
+    fn expressions(&self) -> Vec<datafusion::prelude::Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "SetVariable")
+    }
+
+    fn from_template(
+        &self,
+        _exprs: &[datafusion::prelude::Expr],
+        _inputs: &[DfLogicalPlan],
+    ) -> Self {
+        self.clone()
+    }
+}
+
+impl ExtensionNode for SetVariable {
+    const EXTENSION_NAME: &'static str = "SetVariable";
+    fn try_decode_extension(extension: &LogicalPlanExtension) -> Result<Self> {
+        match extension.node.as_any().downcast_ref::<Self>() {
+            Some(s) => Ok(s.clone()),
+            None => Err(internal!("SetVariable::try_decode_extension failed",)),
+        }
+    }
+
+    fn try_encode(&self, buf: &mut Vec<u8>, _codec: &dyn LogicalExtensionCodec) -> Result<()> {
+        use protogen::sqlexec::logical_plan as protogen;
+
+        let proto = protogen::SetVariable {
+            variable: self.variable.clone(),
+            values: self.values.clone(),
+        };
+        let plan_type = protogen::LogicalPlanExtensionType::SetVariable(proto);
+
+        let lp_extension = protogen::LogicalPlanExtension {
+            inner: Some(plan_type),
+        };
+
+        lp_extension
+            .encode(buf)
+            .map_err(|e| internal!("{}", e.to_string()))?;
+
+        Ok(())
+    }
+}

--- a/crates/sqlexec/src/planner/logical_plan/show_variable.rs
+++ b/crates/sqlexec/src/planner/logical_plan/show_variable.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Debug)]
+pub struct ShowVariable {
+    pub variable: String,
+}

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -945,7 +945,7 @@ impl<'a> SessionPlanner<'a> {
 
             // "SHOW ..."
             //
-            // Show the value of a variable.  i
+            // Show the value of a variable.
             ast::Statement::ShowVariable { variable } => {
                 // Normalize variables
                 let mut variable: Vec<_> = variable.into_iter().map(normalize_ident).collect();

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -928,15 +928,24 @@ impl<'a> SessionPlanner<'a> {
                 variable,
                 value,
                 ..
-            } => Ok(VariablePlan::SetVariable(SetVariable {
-                variable: variable.to_string(),
-                values: value,
-            })
-            .into()),
+            } => {
+                let plan = SetVariable::try_new(variable.to_string(), value)?;
+                Ok(plan.into_logical_plan())
+            }
+            ast::Statement::SetVariable {
+                local: true,
+                hivevar: false,
+                variable,
+                value,
+                ..
+            } => Ok(
+                VariablePlan::SetVariable(SetVariable::try_new(variable.to_string(), value)?)
+                    .into(),
+            ),
 
             // "SHOW ..."
             //
-            // Show the value of a variable.
+            // Show the value of a variable.  i
             ast::Statement::ShowVariable { variable } => {
                 // Normalize variables
                 let mut variable: Vec<_> = variable.into_iter().map(normalize_ident).collect();

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -365,6 +365,11 @@ impl Session {
                 self.drop_views(drop_views).await?;
                 Ok(ExecutionResult::DropViews)
             }
+            ExtensionType::DropCredentials => {
+                let drop_credentials = DropCredentials::try_decode_extension(extension)?;
+                self.drop_credentials(drop_credentials).await?;
+                Ok(Arc::new(EmptyExec::new(false, Schema::empty().into())))
+            }
         }
     }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -368,7 +368,27 @@ impl Session {
             ExtensionType::DropCredentials => {
                 let drop_credentials = DropCredentials::try_decode_extension(extension)?;
                 self.drop_credentials(drop_credentials).await?;
-                Ok(Arc::new(EmptyExec::new(false, Schema::empty().into())))
+                Ok(ExecutionResult::DropCredentials)
+            }
+            ExtensionType::DropDatabase => {
+                let drop_database = DropDatabase::try_decode_extension(extension)?;
+                self.drop_database(drop_database).await?;
+                Ok(ExecutionResult::DropDatabase)
+            }
+            ExtensionType::DropSchemas => {
+                let drop_schemas = DropSchemas::try_decode_extension(extension)?;
+                self.drop_schemas(drop_schemas).await?;
+                Ok(ExecutionResult::DropSchemas)
+            }
+            ExtensionType::DropTunnel => {
+                let drop_tunnel = DropTunnel::try_decode_extension(extension)?;
+                self.drop_tunnel(drop_tunnel).await?;
+                Ok(ExecutionResult::DropTunnel)
+            }
+            ExtensionType::DropViews => {
+                let drop_views = DropViews::try_decode_extension(extension)?;
+                self.drop_views(drop_views).await?;
+                Ok(ExecutionResult::DropViews)
             }
         }
     }
@@ -691,7 +711,6 @@ impl Session {
                 TransactionPlan::Commit => ExecutionResult::Commit,
                 TransactionPlan::Abort => ExecutionResult::Rollback,
             },
-
             LogicalPlan::Write(WritePlan::Insert(plan)) => {
                 self.insert_into(plan).await?;
                 ExecutionResult::WriteSuccess

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -365,31 +365,6 @@ impl Session {
                 self.drop_views(drop_views).await?;
                 Ok(ExecutionResult::DropViews)
             }
-            ExtensionType::DropCredentials => {
-                let drop_credentials = DropCredentials::try_decode_extension(extension)?;
-                self.drop_credentials(drop_credentials).await?;
-                Ok(ExecutionResult::DropCredentials)
-            }
-            ExtensionType::DropDatabase => {
-                let drop_database = DropDatabase::try_decode_extension(extension)?;
-                self.drop_database(drop_database).await?;
-                Ok(ExecutionResult::DropDatabase)
-            }
-            ExtensionType::DropSchemas => {
-                let drop_schemas = DropSchemas::try_decode_extension(extension)?;
-                self.drop_schemas(drop_schemas).await?;
-                Ok(ExecutionResult::DropSchemas)
-            }
-            ExtensionType::DropTunnel => {
-                let drop_tunnel = DropTunnel::try_decode_extension(extension)?;
-                self.drop_tunnel(drop_tunnel).await?;
-                Ok(ExecutionResult::DropTunnel)
-            }
-            ExtensionType::DropViews => {
-                let drop_views = DropViews::try_decode_extension(extension)?;
-                self.drop_views(drop_views).await?;
-                Ok(ExecutionResult::DropViews)
-            }
             ExtensionType::SetVariable => {
                 let set_variable = SetVariable::try_decode_extension(extension)?;
                 self.set_variable(set_variable)?;

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -390,6 +390,11 @@ impl Session {
                 self.drop_views(drop_views).await?;
                 Ok(ExecutionResult::DropViews)
             }
+            ExtensionType::SetVariable => {
+                let set_variable = SetVariable::try_decode_extension(extension)?;
+                self.set_variable(set_variable)?;
+                Ok(ExecutionResult::SetLocal)
+            }
         }
     }
 
@@ -532,11 +537,9 @@ impl Session {
     }
 
     pub(crate) fn set_variable(&mut self, plan: SetVariable) -> Result<()> {
-        self.ctx.get_session_vars_mut().set(
-            &plan.variable,
-            plan.try_value_into_string()?.as_str(),
-            VarSetter::User,
-        )?;
+        self.ctx
+            .get_session_vars_mut()
+            .set(&plan.variable, &plan.values, VarSetter::User)?;
         Ok(())
     }
 


### PR DESCRIPTION
closes #1567 

can set variables on remote via `SET <variable>` and locally via `SET LOCAL <variable>`. 

when running on a single instance, both ops behave the same. 