### PR TITLE
feat: Allow reconstructing postgres table provider and execs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "datafusion",
  "decimal",
  "env_logger",
+ "futures",
  "once_cell",
  "paste",
  "protogen",

--- a/crates/datafusion_ext/Cargo.toml
+++ b/crates/datafusion_ext/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1"
 thiserror.workspace = true
 decimal = { path = "../decimal" }
 protogen = { path = "../protogen" }
+futures = "0.3.28"
 
 [dev-dependencies]
 ctor = "0.2.4"


### PR DESCRIPTION
Small refactor on the postgres stuff which allow reconstructing a postgres table provider and/or the binary copy exec with serializable values.

Started this because the broadcast/exchange stuff will be a lot easier when working with physical plans, and so I want to try to get the physical plan serialization done quickly. Other data sources should be able to follow this pattern of if we have the client, use that, otherwise create one.