### PR TITLE
refactor: move catalog into a datafusion extension

### DIFF
--- a/crates/datafusion_ext/src/functions.rs
+++ b/crates/datafusion_ext/src/functions.rs
@@ -44,9 +44,10 @@ pub trait TableFunc: Sync + Send {
         Ok(plan)
     }
 }
+#[async_trait]
 pub trait TableFuncContextProvider: Sync + Send {
-    fn get_database_entry(&self, name: &str) -> Option<&DatabaseEntry>;
-    fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry>;
+    async fn get_database_entry(&self, name: &str) -> Option<DatabaseEntry>;
+    async fn get_credentials_entry(&self, name: &str) -> Option<CredentialsEntry>;
     fn get_session_vars(&self) -> SessionVars;
     fn get_session_state(&self) -> &SessionState;
 }

--- a/crates/datafusion_ext/src/planner/mod.rs
+++ b/crates/datafusion_ext/src/planner/mod.rs
@@ -74,7 +74,7 @@ pub trait AsyncContextProvider: Send + Sync {
     ///
     /// Note that this accepts a table reference since these functions are
     /// namespaced similiarly to tables.
-    fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>>;
+    async fn get_table_func(&self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>>;
 
     /// Get the table func context provider.
     fn table_fn_ctx_provider(&self) -> Self::TableFuncContextProvider;

--- a/crates/datafusion_ext/src/planner/relation/mod.rs
+++ b/crates/datafusion_ext/src/planner/relation/mod.rs
@@ -63,6 +63,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                         let func = self
                             .schema_provider
                             .get_table_func(table_ref.clone())
+                            .await
                             .ok_or_else(|| {
                                 DataFusionError::Plan(format!(
                                     "Missing table function: '{table_ref}'"

--- a/crates/datafusion_ext/src/vars/constants.rs
+++ b/crates/datafusion_ext/src/vars/constants.rs
@@ -200,3 +200,4 @@ pub const POSTGRES_SCHEMA: &str = "pg_catalog";
 
 /// Schema to store temporary objects (only valid for current session).
 pub const CURRENT_SESSION_SCHEMA: &str = "current_session";
+pub const DEFAULT_CATALOG: &str = "default";

--- a/crates/rpcsrv/src/session.rs
+++ b/crates/rpcsrv/src/session.rs
@@ -33,7 +33,13 @@ impl RemoteSession {
     /// session.
     pub async fn get_catalog_state(&self) -> CatalogState {
         let session = self.session.lock().await;
-        session.get_session_catalog().get_state().as_ref().clone()
+        session
+            .get_session_catalog()
+            .read()
+            .await
+            .get_state()
+            .as_ref()
+            .clone()
     }
 
     pub async fn create_physical_plan(

--- a/crates/sqlbuiltins/src/functions/delta.rs
+++ b/crates/sqlbuiltins/src/functions/delta.rs
@@ -58,7 +58,7 @@ impl TableFunc for DeltaScan {
                     .map_err(|e| ExtensionError::Access(Box::new(e)))?;
 
                 let creds: IdentValue = args.next().unwrap().param_into()?;
-                let creds = ctx.get_credentials_entry(creds.as_str()).cloned().ok_or(
+                let creds = ctx.get_credentials_entry(creds.as_str()).await.ok_or(
                     ExtensionError::String(format!("missing credentials object: {creds}")),
                 )?;
 

--- a/crates/sqlbuiltins/src/functions/iceberg.rs
+++ b/crates/sqlbuiltins/src/functions/iceberg.rs
@@ -30,7 +30,7 @@ impl TableFunc for IcebergScan {
         mut opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         // TODO: Reduce duplication
-        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts)?;
+        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts).await?;
 
         let store = opts.into_object_store(&loc).map_err(box_err)?;
         let table = IcebergTable::open(loc, store).await.map_err(box_err)?;
@@ -57,7 +57,7 @@ impl TableFunc for IcebergSnapshots {
         args: Vec<FuncParamValue>,
         mut opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
-        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts)?;
+        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts).await?;
 
         let store = opts.into_object_store(&loc).map_err(box_err)?;
         let table = IcebergTable::open(loc, store).await.map_err(box_err)?;
@@ -116,7 +116,7 @@ impl TableFunc for IcebergDataFiles {
         args: Vec<FuncParamValue>,
         mut opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
-        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts)?;
+        let (loc, opts) = iceberg_location_and_opts(ctx, args, &mut opts).await?;
 
         let store = opts.into_object_store(&loc).map_err(box_err)?;
         let table = IcebergTable::open(loc, store).await.map_err(box_err)?;
@@ -184,7 +184,7 @@ impl TableFunc for IcebergDataFiles {
 }
 
 /// Get the datasoruce url and options for an iceberg table.
-fn iceberg_location_and_opts(
+async fn iceberg_location_and_opts(
     ctx: &dyn TableFuncContextProvider,
     args: Vec<FuncParamValue>,
     opts: &mut HashMap<String, FuncParamValue>,
@@ -211,7 +211,7 @@ fn iceberg_location_and_opts(
             let url: DatasourceUrl = first.param_into()?;
             let creds: IdentValue = args.next().unwrap().param_into()?;
 
-            let creds = ctx.get_credentials_entry(creds.as_str()).cloned().ok_or(
+            let creds = ctx.get_credentials_entry(creds.as_str()).await.ok_or(
                 ExtensionError::String("missing credentials object".to_string()),
             )?;
 

--- a/crates/sqlbuiltins/src/functions/virtual_listing.rs
+++ b/crates/sqlbuiltins/src/functions/virtual_listing.rs
@@ -111,6 +111,7 @@ async fn get_db_lister(
 ) -> Result<Box<dyn VirtualLister>> {
     let db = ctx
         .get_database_entry(&dbname)
+        .await
         .ok_or(ExtensionError::MissingObject {
             obj_typ: "database",
             name: dbname,

--- a/crates/sqlexec/src/planner/dispatch.rs
+++ b/crates/sqlexec/src/planner/dispatch.rs
@@ -1,6 +1,6 @@
 //! Adapter types for dispatching to table sources.
 use crate::context::SessionContext;
-use crate::metastore::catalog::{AsyncSessionCatalog, SessionCatalog};
+use crate::metastore::catalog::AsyncSessionCatalog;
 use datafusion::arrow::array::{
     BooleanBuilder, ListBuilder, StringBuilder, UInt32Builder, UInt64Builder,
 };
@@ -183,7 +183,9 @@ impl<'a> SessionDispatcher<'a> {
             CatalogEntry::View(view) => self.dispatch_view(view).await,
             // Dispatch to builtin tables.
             CatalogEntry::Table(tbl) if tbl.meta.builtin => {
-                SystemTableDispatcher::new(self.ctx).dispatch(schema, name).await
+                SystemTableDispatcher::new(self.ctx)
+                    .dispatch(schema, name)
+                    .await
             }
             // Dispatch to external tables.
             CatalogEntry::Table(tbl) if tbl.meta.external => {

--- a/crates/sqlexec/src/planner/extension_planner.rs
+++ b/crates/sqlexec/src/planner/extension_planner.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use datafusion::{
+    execution::{context::SessionState, TaskContext},
+    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
+    physical_plan::ExecutionPlan,
+    physical_planner::{ExtensionPlanner, PhysicalPlanner},
+};
+use datafusion_ext::vars::SessionVars;
+
+use crate::metastore::catalog::AsyncSessionCatalog;
+
+use super::{extension::ExtensionType, physical_plan::create_table_exec::CreateTableExecPlanner};
+
+pub struct GlareExtensionPlanner;
+
+pub trait DatafusionExtensionProvider {
+    fn get_session_catalog(&self) -> Arc<AsyncSessionCatalog>;
+    fn get_session_vars(&self) -> SessionVars;
+}
+
+impl DatafusionExtensionProvider for &SessionState {
+    fn get_session_catalog(&self) -> Arc<AsyncSessionCatalog> {
+        self.config()
+            .get_extension::<AsyncSessionCatalog>()
+            .unwrap()
+    }
+
+    fn get_session_vars(&self) -> SessionVars {
+        let vars = self
+            .config_options()
+            .extensions
+            .get::<SessionVars>()
+            .unwrap();
+        vars.clone()
+    }
+}
+
+impl DatafusionExtensionProvider for TaskContext {
+    fn get_session_catalog(&self) -> Arc<AsyncSessionCatalog> {
+        self.session_config()
+            .get_extension::<AsyncSessionCatalog>()
+            .unwrap()
+    }
+
+    fn get_session_vars(&self) -> SessionVars {
+        self.session_config()
+            .options()
+            .extensions
+            .get::<SessionVars>()
+            .unwrap()
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ExtensionPlanner for GlareExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
+        session_state: &SessionState,
+    ) -> datafusion::error::Result<Option<Arc<dyn ExecutionPlan>>> {
+        let ext_type = node.name().parse::<ExtensionType>().unwrap();
+        match ext_type {
+            ExtensionType::CreateTable => {
+                CreateTableExecPlanner
+                    .plan_extension(
+                        planner,
+                        node,
+                        logical_inputs,
+                        physical_inputs,
+                        session_state,
+                    )
+                    .await
+            }
+            _ => todo!(),
+        }
+    }
+}

--- a/crates/sqlexec/src/planner/mod.rs
+++ b/crates/sqlexec/src/planner/mod.rs
@@ -4,6 +4,7 @@ pub mod extension;
 pub mod logical_plan;
 pub mod physical_plan;
 pub mod session_planner;
+pub mod extension_planner;
 
 pub(crate) mod context_builder;
 

--- a/crates/sqlexec/src/planner/physical_plan/create_table_exec.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_table_exec.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    common::{DFSchema, DFSchemaRef},
+    execution::context::SessionState,
+    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
+    physical_plan::{DisplayAs, ExecutionPlan},
+    physical_planner::{ExtensionPlanner, PhysicalPlanner},
+};
+
+use crate::planner::{extension_planner::DatafusionExtensionProvider, logical_plan::CreateTable};
+
+#[derive(Debug, Clone)]
+pub struct CreateTableExec {
+    pub schema: String,
+    pub table: String,
+    pub if_not_exists: bool,
+    pub arrow_schema: DFSchemaRef,
+    pub source: Option<Arc<dyn ExecutionPlan>>,
+}
+pub struct CreateTableExecPlanner;
+
+#[async_trait::async_trait]
+impl ExtensionPlanner for CreateTableExecPlanner {
+    async fn plan_extension(
+        &self,
+        planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        _physical_inputs: &[Arc<dyn ExecutionPlan>],
+        session_state: &SessionState,
+    ) -> datafusion::error::Result<Option<Arc<dyn ExecutionPlan>>> {
+        let create_table_lp = match node.as_any().downcast_ref::<CreateTable>() {
+            Some(s) => s,
+            None => todo!(),
+        };
+
+        let source = if let Some(source) = &create_table_lp.source {
+            planner
+                .create_physical_plan(source, session_state)
+                .await
+                .ok()
+        } else {
+            None
+        };
+        let (_, schema, table) = session_state
+            .get_session_vars()
+            .resolve_table_ref(&create_table_lp.table_name)
+            .unwrap();
+
+        let exec = CreateTableExec {
+            schema,
+            table,
+            if_not_exists: create_table_lp.if_not_exists,
+            arrow_schema: create_table_lp.schema.clone(),
+            source,
+        };
+        Ok(Some(Arc::new(exec)))
+    }
+}
+
+impl DisplayAs for CreateTableExec {
+    fn fmt_as(
+        &self,
+        t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            datafusion::physical_plan::DisplayFormatType::Default => {
+                write!(
+                    f,
+                    "CreateTableExec: schema={}, table={}, if_not_exists={}",
+                    self.schema, self.table, self.if_not_exists
+                )
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+impl ExecutionPlan for CreateTableExec {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        let arrow_schema: &DFSchema = self.arrow_schema.as_ref();
+
+        Arc::new(arrow_schema.into())
+    }
+
+    fn output_partitioning(&self) -> datafusion::physical_plan::Partitioning {
+        datafusion::physical_plan::Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[datafusion::physical_expr::PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        match &self.source {
+            Some(source) => vec![source.clone()],
+            None => vec![],
+        }
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if children.len() > 1 {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "CreateTableExec::with_new_children: children.len() > 1".to_string(),
+            ));
+        }
+        Ok(Arc::new(CreateTableExec {
+            source: children.into_iter().next(),
+            ..self.as_ref().clone()
+        }))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::error::Result<datafusion::physical_plan::SendableRecordBatchStream> {
+        let _catalog = context.get_session_catalog();
+        let vars = context.get_session_vars();
+        println!("CreateTableExec::execute: vars={:?}", vars);
+        todo!()
+    }
+
+    fn statistics(&self) -> datafusion::physical_plan::Statistics {
+        datafusion::physical_plan::Statistics::default()
+    }
+}

--- a/crates/sqlexec/src/planner/physical_plan/mod.rs
+++ b/crates/sqlexec/src/planner/physical_plan/mod.rs
@@ -1,2 +1,3 @@
 pub mod client_recv;
 pub mod client_send;
+pub mod create_table_exec;

--- a/crates/sqlexec/src/planner/preprocess.rs
+++ b/crates/sqlexec/src/planner/preprocess.rs
@@ -37,10 +37,11 @@ impl<'a> ast::VisitorMut for CastRegclassReplacer<'a> {
             let catalog = ctx.get_session_catalog();
             for schema in ctx.implicit_search_paths() {
                 // TODO
-                if let Some(ent) = catalog.resolve_entry(DEFAULT_CATALOG, &schema, rel) {
-                    // Table found.
-                    return Some(ent.get_meta().id);
-                }
+                todo!("wip")
+                // if let Some(ent) = catalog.resolve_entry(DEFAULT_CATALOG, &schema, rel).await {
+                //     // Table found.
+                //     return Some(ent.get_meta().id);
+                // }
             }
             None
         }

--- a/crates/sqlexec/src/planner/preprocess.rs
+++ b/crates/sqlexec/src/planner/preprocess.rs
@@ -1,7 +1,6 @@
 //! AST visitors for preprocessing queries before planning.
 use crate::context::SessionContext;
 use datafusion::sql::sqlparser::ast::{self, VisitMut, VisitorMut};
-use sqlbuiltins::builtins::DEFAULT_CATALOG;
 use std::ops::ControlFlow;
 
 #[derive(Debug, thiserror::Error)]
@@ -33,11 +32,11 @@ impl<'a> ast::VisitorMut for CastRegclassReplacer<'a> {
     type Break = PreprocessError;
 
     fn post_visit_expr(&mut self, expr: &mut ast::Expr) -> ControlFlow<Self::Break> {
-        fn find_oid(ctx: &SessionContext, rel: &str) -> Option<u32> {
-            let catalog = ctx.get_session_catalog();
-            for schema in ctx.implicit_search_paths() {
+        fn find_oid(ctx: &SessionContext, _rel: &str) -> Option<u32> {
+            let _catalog = ctx.get_session_catalog();
+            for _schema in ctx.implicit_search_paths() {
                 // TODO
-                todo!("wip")
+                todo!("IS IT POSSIBLE TO DO THIS WITHOUT THE CATALOG?")
                 // if let Some(ent) = catalog.resolve_entry(DEFAULT_CATALOG, &schema, rel).await {
                 //     // Table found.
                 //     return Some(ent.get_meta().id);

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -3,9 +3,9 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::common::DFSchema;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::{QueryPlanner, SessionState};
-use datafusion::logical_expr::{LogicalPlan as DfLogicalPlan, UserDefinedLogicalNode};
+use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
-use datafusion::physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner};
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::prelude::Expr;
 
 use std::sync::Arc;
@@ -85,19 +85,5 @@ impl PhysicalPlanner for RemotePhysicalPlanner {
             input_schema,
             session_state,
         )
-    }
-}
-
-#[async_trait]
-impl ExtensionPlanner for RemotePhysicalPlanner {
-    async fn plan_extension(
-        &self,
-        _planner: &dyn PhysicalPlanner,
-        _node: &dyn UserDefinedLogicalNode,
-        _logical_inputs: &[&DfLogicalPlan],
-        _physical_inputs: &[Arc<dyn ExecutionPlan>],
-        _session_state: &SessionState,
-    ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
-        Ok(None)
     }
 }

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -7,6 +7,7 @@ use crate::metastore::catalog::{AsyncSessionCatalog, SessionCatalog};
 use crate::planner::context_builder::PartialContextProvider;
 use crate::planner::extension::{ExtensionNode, ExtensionType};
 use crate::remote::client::RemoteSessionClient;
+
 use crate::remote::staged_stream::StagedClientStreams;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::common::OwnedTableReference;
@@ -269,6 +270,19 @@ impl Session {
 
         // TODO!: these should be pushed down to physical execs,
         // currently we need to early exit on extension nodes as we don't have a physical exec for them.
+        
+        //---
+        // just swap out the default planner with an extension aware physical planner.
+        // use crate::planner::extension_planner::GlareExtensionPlanner;
+        // use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+        // let planner =
+        //     DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(GlareExtensionPlanner)]);
+        // planner
+        //     .create_physical_plan(&plan, &state)
+        //     .await
+        //     .map_err(|e| e.into())
+        // ---
+
         match plan {
             DfLogicalPlan::Extension(ref extension) if self.is_main_instance() => {
                 let _exec_res = self.execute_extension(extension).await?;

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::extension_codec::GlareDBExtensionCodec;
-use crate::metastore::catalog::SessionCatalog;
+use crate::metastore::catalog::{AsyncSessionCatalog, SessionCatalog};
 use crate::planner::context_builder::PartialContextProvider;
 use crate::planner::extension::{ExtensionNode, ExtensionType};
 use crate::remote::client::RemoteSessionClient;
@@ -246,7 +246,7 @@ impl Session {
         self.ctx.close().await
     }
 
-    pub fn get_session_catalog(&self) -> &SessionCatalog {
+    pub fn get_session_catalog(&self) -> Arc<AsyncSessionCatalog> {
         self.ctx.get_session_catalog()
     }
 


### PR DESCRIPTION
So this ended up being a bit trickier than the session vars. 

The context is used within async/await a lot more than the vars were & caused the `parking_lot::RwLock` to not work. I had to swap it out with the `tokio::sync::RwLock` which unfortunately causes all read/write actions to be async. This caused qquite a ripple effect as all dependent function calls in the stack also had to be converted to async/await. 


I also added a small example exec `CreateTableExec`, it's not fully wired up yet, but it does show that we can mutably access the catalog & session vars from the exec now!

you can test it out by swapping out the planner in `sqlexec/src/session.rs:create_physical_plan` for the extension aware planner. 

There's a few small todo's & unwraps left in here, but I think the bulk of the work is ready for review. 

 