### PR TITLE
feat: Display deployment name when connecting with local

### DIFF
--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -166,7 +166,15 @@ impl LocalSession {
             let mut sess = engine
                 .new_local_session_context(SessionVars::default(), SessionStorageConfig::default())
                 .await?;
-            sess.attach_remote_session(exec_client, None).await?;
+            sess.attach_remote_session(exec_client.clone(), None)
+                .await?;
+
+            let info = format!(
+                "Connected to Cloud deployment: {}",
+                exec_client.get_deployment_name()
+            );
+            println!("{}", info.bold());
+
             sess
         } else {
             engine

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -137,6 +137,15 @@ impl RemoteClient {
         })
     }
 
+    /// Get the deployment name that we're connected to from the stored metadata
+    /// map.
+    pub fn get_deployment_name(&self) -> &str {
+        self.auth_metadata
+            .get(DB_NAME_KEY)
+            .map(|m| m.to_str().unwrap_or_default())
+            .unwrap_or("unknown")
+    }
+
     /// Connect to a proxy destination.
     pub async fn connect_with_proxy_destination(dst: ProxyDestination) -> Result<Self> {
         Self::connect_with_proxy_auth_params(dst.dst.to_string(), dst.params).await


### PR DESCRIPTION
<img width="1977" alt="Screenshot 2023-08-20 at 6 27 10 PM" src="https://github.com/GlareDB/glaredb/assets/4040560/9290bb77-2f3f-42e8-a0e7-74d883b83d55">
