### PR TITLE
chore: Remove init catalog endpoint for metastore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "dashmap",
  "datafusion",
  "futures",
  "logutil",

--- a/crates/metastore/Cargo.toml
+++ b/crates/metastore/Cargo.toml
@@ -27,6 +27,7 @@ proptest = "1.2"
 proptest-derive = "0.3"
 tower = "0.4"
 futures = "0.3.28"
+dashmap = "5.5.0"
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -39,6 +39,14 @@ const MAX_DATABASE_OBJECTS: usize = 2048;
 static BUILTIN_CATALOG: Lazy<BuiltinCatalog> = Lazy::new(|| BuiltinCatalog::new().unwrap());
 
 /// Catalog for a single database.
+///
+/// This struct may be concurrently accessed via its public methods.
+/// Synchronization happens at two levels:
+///
+/// 1. The in-memory catalog state is wrapped in a mutex.
+/// 2. Persistence is managed via leases in object storage.
+///
+/// The source of truth for a database catalog is always what's in object store.
 pub struct DatabaseCatalog {
     db_id: Uuid,
 

--- a/crates/metastore/src/errors.rs
+++ b/crates/metastore/src/errors.rs
@@ -23,9 +23,6 @@ pub enum MetastoreError {
     #[error("Builtin object persisted when it shouldn't have been: {0:?}")]
     BuiltinObjectPersisted(protogen::metastore::types::catalog::EntryMeta),
 
-    #[error("Missing database catalog: {0}")]
-    MissingCatalog(uuid::Uuid),
-
     #[error("Missing database: {0}")]
     MissingDatabase(String),
 

--- a/crates/protogen/proto/metastore/service.proto
+++ b/crates/protogen/proto/metastore/service.proto
@@ -7,23 +7,6 @@ package metastore.service;
 import "metastore/catalog.proto";
 import "metastore/options.proto";
 
-message InitializeCatalogRequest {
-  // ID of the catalog to initialize.
-  bytes db_id = 1;
-}
-
-message InitializeCatalogResponse {
-  enum Status {
-    UNKNOWN = 0;
-    // Catalog initialized.
-    INITIALIZED = 1;
-    // Catalog already loaded.
-    ALREADY_LOADED = 2;
-  }
-
-  Status status = 1;
-}
-
 message FetchCatalogRequest {
   // ID of the database catalog to fetch.
   bytes db_id = 1;
@@ -190,17 +173,12 @@ message MutateResponse {
 }
 
 service MetastoreService {
-  // Initialize a database catalog.
-  //
-  // Idempotent, safe to call multiple times.
-  rpc InitializeCatalog(InitializeCatalogRequest)
-      returns (InitializeCatalogResponse);
-
   // Fetch the catalog for some database.
   //
   // The returned catalog will be the latest catalog that this metastore node
   // knows about.
-  // TODO: Could be streaming.
+  // TODO: Could be streaming for returning updated catalogs as they get
+  // mutated.
   rpc FetchCatalog(FetchCatalogRequest) returns (FetchCatalogResponse);
 
   // Mutate a database's catalog.

--- a/crates/sqlexec/src/metastore/client.rs
+++ b/crates/sqlexec/src/metastore/client.rs
@@ -50,9 +50,7 @@
 //! to any limitations in metastore itself.
 
 use protogen::gen::metastore::service::metastore_service_client::MetastoreServiceClient;
-use protogen::gen::metastore::service::{
-    FetchCatalogRequest, InitializeCatalogRequest, MutateRequest,
-};
+use protogen::gen::metastore::service::{FetchCatalogRequest, MutateRequest};
 use protogen::metastore::strategy::ResolveErrorStrategy;
 use protogen::metastore::types::{catalog::CatalogState, service::Mutation};
 use std::collections::HashMap;
@@ -479,12 +477,6 @@ impl StatefulWorker {
         db_id: Uuid,
         mut client: MetastoreServiceClient<Channel>,
     ) -> Result<(StatefulWorker, mpsc::Sender<ClientRequest>)> {
-        let _ = client
-            .initialize_catalog(tonic::Request::new(InitializeCatalogRequest {
-                db_id: db_id.into_bytes().to_vec(),
-            }))
-            .await?;
-
         let resp = client
             .fetch_catalog(tonic::Request::new(FetchCatalogRequest {
                 db_id: db_id.into_bytes().to_vec(),


### PR DESCRIPTION
Removes needing to "init" a catalog before fetching or mutating it. Since we create catalogs lazily, the only thing "init" was doing was loading it into memory. This change makes it so that that other two endpoints just do that automatically if the catalog isn't found.

These errors should no longer happen:

```
Missing database catalog: cbdfc895-3d01-4771-92b6-9ab1c43a3bb9
```

(because I deleted it)