### PR TITLE
refactor: async catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,8 +1570,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddbcb2dda5b5033537457992ebde78938014390b2b19f9f4282e3be0e18b0c3"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "ahash 0.8.2",
  "apache-avro 0.14.0",
@@ -1621,8 +1620,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fbb7b4da925031311743ab96662d55f0f7342d3692744f184f99b2257ef435"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "apache-avro 0.14.0",
  "arrow",
@@ -1638,8 +1636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb3617466d894eb0ad11d06bab1e6e89c571c0a27d660685d327d0c6e1e1ccd"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1656,8 +1653,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd8220a0dfcdfddcc785cd7e71770ef1ce54fbe1e08984e5adf537027ecb6de"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1671,8 +1667,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d685a100c66952aaadd0cbe766df46d1887d58fc8bcf3589e6387787f18492b"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1689,8 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2c635da9b05b4b4c6c8d935f46fd99f9b6225f834091cf4e3c8a045b68beab"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1739,8 +1733,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ef8abf4dd84d3f20c910822b52779c035ab7f4f2d5e7125ede3bae618e9de8"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#24def3e6d36c4a8223266b2b27bb8b89896c2cc6"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3571,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -6600,7 +6593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,18 @@ url = "2.4.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.104"
+dashmap = "5.5.0"
 
 [workspace.dependencies.deltalake]
 git = "https://github.com/delta-io/delta-rs.git"
 branch = "main"
 features = ["s3", "gcs", "azure", "datafusion", "arrow", "parquet"]
+
+[patch.crates-io]
+datafusion = { git = "https://github.com/universalmind303/arrow-datafusion", features = ["avro"], branch = "28-patch" }
+datafusion-common = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-execution = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-expr = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-physical-expr = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-optimizer = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-sql = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }

--- a/crates/datafusion_ext/src/functions.rs
+++ b/crates/datafusion_ext/src/functions.rs
@@ -45,8 +45,8 @@ pub trait TableFunc: Sync + Send {
     }
 }
 pub trait TableFuncContextProvider: Sync + Send {
-    fn get_database_entry(&self, name: &str) -> Option<&DatabaseEntry>;
-    fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry>;
+    fn get_database_entry(&self, name: &str) -> Option<DatabaseEntry>;
+    fn get_credentials_entry(&self, name: &str) -> Option<CredentialsEntry>;
     fn get_session_vars(&self) -> SessionVars;
     fn get_session_state(&self) -> &SessionState;
 }

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1"
 uuid = "1.4.1"
 url.workspace = true
 webpki-roots = "0.25.1"
-dashmap = "5.5.0"
+dashmap = { workspace = true }
 
 # SSH tunnels
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]

--- a/crates/metastore/Cargo.toml
+++ b/crates/metastore/Cargo.toml
@@ -27,7 +27,7 @@ proptest = "1.2"
 proptest-derive = "0.3"
 tower = "0.4"
 futures = "0.3.28"
-dashmap = "5.5.0"
+dashmap = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/crates/rpcsrv/Cargo.toml
+++ b/crates/rpcsrv/Cargo.toml
@@ -25,4 +25,4 @@ prost-types = "0.11"
 tonic = { version = "0.9", features = ["transport", "tls", "tls-roots"] }
 bytes = "1.4"
 futures = "0.3.28"
-dashmap = "5.5.0"
+dashmap = { workspace = true }

--- a/crates/sqlbuiltins/src/functions/delta.rs
+++ b/crates/sqlbuiltins/src/functions/delta.rs
@@ -59,9 +59,11 @@ impl TableFunc for DeltaScan {
                     .map_err(|e| ExtensionError::Access(Box::new(e)))?;
 
                 let creds: IdentValue = args.next().unwrap().param_into()?;
-                let creds = ctx.get_credentials_entry(creds.as_str()).cloned().ok_or(
-                    ExtensionError::String(format!("missing credentials object: {creds}")),
-                )?;
+                let creds =
+                    ctx.get_credentials_entry(creds.as_str())
+                        .ok_or(ExtensionError::String(format!(
+                            "missing credentials object: {creds}"
+                        )))?;
 
                 match source_url.datasource_url_type() {
                     DatasourceUrlType::Gcs => match creds.options {

--- a/crates/sqlbuiltins/src/functions/iceberg.rs
+++ b/crates/sqlbuiltins/src/functions/iceberg.rs
@@ -217,9 +217,11 @@ fn iceberg_location_and_opts(
             let url: DatasourceUrl = first.param_into()?;
             let creds: IdentValue = args.next().unwrap().param_into()?;
 
-            let creds = ctx.get_credentials_entry(creds.as_str()).cloned().ok_or(
-                ExtensionError::String("missing credentials object".to_string()),
-            )?;
+            let creds = ctx
+                .get_credentials_entry(creds.as_str())
+                .ok_or(ExtensionError::String(
+                    "missing credentials object".to_string(),
+                ))?;
 
             match url.datasource_url_type() {
                 DatasourceUrlType::Gcs => {

--- a/crates/sqlexec/src/context/mod.rs
+++ b/crates/sqlexec/src/context/mod.rs
@@ -80,6 +80,7 @@ pub(crate) fn new_datafusion_session_config_opts(vars: SessionVars) -> ConfigOpt
     // NOTE: We handle catalog/schema defaults and information schemas
     // ourselves.
     let mut catalog_opts = CatalogOptions::default();
+
     catalog_opts.create_default_catalog_and_schema = false;
     catalog_opts.information_schema = false;
     let mut optimizer_opts = OptimizerOptions::default();

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -29,7 +29,7 @@ use protogen::metastore::types::options::{
 };
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
 
-use crate::metastore::catalog::{AsyncSessionCatalog, SessionCatalog};
+use crate::metastore::catalog::AsyncSessionCatalog;
 
 use super::{DispatchError, Result};
 

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -288,11 +288,11 @@ pub struct TableFnCtxProvider<'a> {
 }
 
 impl<'a> TableFuncContextProvider for TableFnCtxProvider<'a> {
-    fn get_database_entry(&self, name: &str) -> Option<&DatabaseEntry> {
+    fn get_database_entry(&self, name: &str) -> Option<DatabaseEntry> {
         self.ctx.get_session_catalog().resolve_database(name)
     }
 
-    fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry> {
+    fn get_credentials_entry(&self, name: &str) -> Option<CredentialsEntry> {
         self.ctx.get_session_catalog().resolve_credentials(name)
     }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::metastore::catalog::{CatalogMutator, SessionCatalog};
+use crate::metastore::catalog::{AsyncSessionCatalog, CatalogMutator, SessionCatalog};
 use crate::planner::context_builder::PartialContextProvider;
 use crate::planner::extension::{ExtensionNode, ExtensionType};
 use crate::remote::client::RemoteClient;
@@ -251,7 +251,7 @@ impl Session {
         self.ctx.close().await
     }
 
-    pub fn get_session_catalog(&self) -> &SessionCatalog {
+    pub fn get_session_catalog(&self) -> Arc<AsyncSessionCatalog> {
         self.ctx.get_session_catalog()
     }
 


### PR DESCRIPTION
so some of the new code actually broke our interaction with datafusion.

specifically within the `attach_remote_session` function. this mutably sets the catalog to a new catalog from the remote session. 

datafusion exposes no possible way to mutate the extensions after the state is initialized. This seemed kinda strange to me considering their numerous extension points. _i guess you could completely rebuild the state, but that seems like massive overkill_

this approach patches datafusion with a new function to register an extension on an existing state. (i'll open up a PR with datafusion if this is an acceptable approach. 

see for changes to datafusion. 
https://github.com/apache/arrow-datafusion/compare/28.0.0...universalmind303:arrow-datafusion:28-patch?expand=1
