### PR TITLE
refactor: catalog mutator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,8 +1570,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddbcb2dda5b5033537457992ebde78938014390b2b19f9f4282e3be0e18b0c3"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "ahash 0.8.2",
  "apache-avro 0.14.0",
@@ -1621,8 +1620,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fbb7b4da925031311743ab96662d55f0f7342d3692744f184f99b2257ef435"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "apache-avro 0.14.0",
  "arrow",
@@ -1638,8 +1636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb3617466d894eb0ad11d06bab1e6e89c571c0a27d660685d327d0c6e1e1ccd"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1656,8 +1653,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd8220a0dfcdfddcc785cd7e71770ef1ce54fbe1e08984e5adf537027ecb6de"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1671,8 +1667,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d685a100c66952aaadd0cbe766df46d1887d58fc8bcf3589e6387787f18492b"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1689,8 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2c635da9b05b4b4c6c8d935f46fd99f9b6225f834091cf4e3c8a045b68beab"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -1739,8 +1733,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ef8abf4dd84d3f20c910822b52779c035ab7f4f2d5e7125ede3bae618e9de8"
+source = "git+https://github.com/universalmind303/arrow-datafusion?branch=28-patch#cf2c81f1342125e87087fddb070768460d5ca1ba"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,12 @@ serde_json = "1.0.104"
 git = "https://github.com/delta-io/delta-rs.git"
 branch = "main"
 features = ["s3", "gcs", "azure", "datafusion", "arrow", "parquet"]
+
+[patch.crates-io]
+datafusion = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-common = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-execution = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-expr = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-physical-expr = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-optimizer = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }
+datafusion-sql = { git = "https://github.com/universalmind303/arrow-datafusion", branch = "28-patch" }

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -126,7 +126,6 @@ impl LocalSessionContext {
             .unwrap();
         self.exec_client = Some(client.clone());
 
-
         self.catalog = catalog;
 
         // Replace datafusion context with the remote aware planner.

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -53,7 +53,6 @@ pub struct LocalSessionContext {
     exec_client: Option<RemoteSessionClient>,
     /// Database catalog.
     catalog: SessionCatalog,
-    catalog_mutator: CatalogMutator,
     /// Temporary objects dropped at the end of a session.
     temp_objects: TempObjects,
     /// Native tables.
@@ -86,7 +85,8 @@ impl LocalSessionContext {
     ) -> Result<LocalSessionContext> {
         let runtime = new_datafusion_runtime_env(&vars, &catalog, spill_path)?;
         let opts = new_datafusion_session_config_opts(vars);
-        let conf: SessionConfig = opts.into();
+        let mut conf: SessionConfig = opts.into();
+        conf = conf.with_extension(Arc::new(catalog_mutator));
         let state = SessionState::with_config_rt(conf, Arc::new(runtime));
 
         let df_ctx = DfSessionContext::with_state(state);
@@ -94,7 +94,7 @@ impl LocalSessionContext {
         Ok(LocalSessionContext {
             exec_client: None,
             catalog,
-            catalog_mutator,
+
             temp_objects: TempObjects::default(),
             tables: native_tables,
             prepared: HashMap::new(),
@@ -125,14 +125,20 @@ impl LocalSessionContext {
             .set_raw(Some(client.session_id()), VarType::System)
             .unwrap();
         self.exec_client = Some(client.clone());
-        // TODO: We _could_ do something fancy where we keep the local catalog
-        // around, but that's for another time.
-        self.catalog_mutator.client = None;
+
+
         self.catalog = catalog;
 
         // Replace datafusion context with the remote aware planner.
         let planner = RemoteQueryPlanner::new(client);
-        let state = self.df_ctx.state().with_query_planner(Arc::new(planner));
+        let state = self
+            .df_ctx
+            .state()
+            .with_query_planner(Arc::new(planner))
+            // TODO: We _could_ do something fancy where we keep the local catalog
+            // around, but that's for another time.
+            .with_config_extension(Arc::new(CatalogMutator::empty()));
+
         self.df_ctx = DfSessionContext::with_state(state);
 
         Ok(())
@@ -181,6 +187,14 @@ impl LocalSessionContext {
         self.exec_client.clone()
     }
 
+    fn catalog_mutator(&self) -> Arc<CatalogMutator> {
+        self.df_ctx
+            .state()
+            .config()
+            .get_extension::<CatalogMutator>()
+            .unwrap()
+    }
+
     /// Create a temp table.
     pub async fn create_temp_table(&mut self, plan: CreateTempTable) -> Result<()> {
         if self
@@ -219,7 +233,7 @@ impl LocalSessionContext {
 
         // Insert into catalog.
         let state = self
-            .catalog_mutator
+            .catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateTable(service::CreateTable {
@@ -280,7 +294,7 @@ impl LocalSessionContext {
         }
 
         // Add the storage tracker job once data is inserted.
-        if let Some(client) = &self.catalog_mutator.client {
+        if let Some(client) = &self.catalog_mutator().client {
             let tracker = BackgroundJobStorageTracker::new(self.tables.clone(), client.clone());
             self.background_jobs.add(tracker)?;
         }
@@ -322,7 +336,7 @@ impl LocalSessionContext {
         let (_, schema, name) = self.resolve_table_ref(plan.table_name)?;
         // TODO: Check if catalog is valid
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateExternalTable(
@@ -342,7 +356,7 @@ impl LocalSessionContext {
     /// Create a schema.
     pub async fn create_schema(&mut self, plan: CreateSchema) -> Result<()> {
         let (_, name) = Self::resolve_schema_ref(plan.schema_name);
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateSchema(service::CreateSchema {
@@ -355,7 +369,7 @@ impl LocalSessionContext {
     }
 
     pub async fn create_external_database(&mut self, plan: CreateExternalDatabase) -> Result<()> {
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateExternalDatabase(
@@ -372,7 +386,7 @@ impl LocalSessionContext {
     }
 
     pub async fn create_tunnel(&mut self, plan: CreateTunnel) -> Result<()> {
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateTunnel(service::CreateTunnel {
@@ -386,7 +400,7 @@ impl LocalSessionContext {
     }
 
     pub async fn create_credentials(&mut self, plan: CreateCredentials) -> Result<()> {
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateCredentials(service::CreateCredentials {
@@ -401,7 +415,7 @@ impl LocalSessionContext {
 
     pub async fn create_view(&mut self, plan: CreateView) -> Result<()> {
         let (_, schema, name) = self.resolve_table_ref(plan.view_name)?;
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::CreateView(service::CreateView {
@@ -421,7 +435,7 @@ impl LocalSessionContext {
         let (_, schema, name) = self.resolve_table_ref(plan.name)?;
         let (_, _, new_name) = self.resolve_table_ref(plan.new_name)?;
         // TODO: Check that the schema and catalog names are same.
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::AlterTableRename(service::AlterTableRename {
@@ -436,7 +450,7 @@ impl LocalSessionContext {
     }
 
     pub async fn alter_database_rename(&mut self, plan: AlterDatabaseRename) -> Result<()> {
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::AlterDatabaseRename(
@@ -452,7 +466,7 @@ impl LocalSessionContext {
     }
 
     pub async fn alter_tunnel_rotate_keys(&mut self, plan: AlterTunnelRotateKeys) -> Result<()> {
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(
                 self.catalog.version(),
                 [Mutation::AlterTunnelRotateKeys(
@@ -496,7 +510,7 @@ impl LocalSessionContext {
                 if_exists: plan.if_exists,
             }));
         }
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -528,7 +542,7 @@ impl LocalSessionContext {
             }));
         }
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -550,7 +564,7 @@ impl LocalSessionContext {
             })
             .collect();
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -570,7 +584,7 @@ impl LocalSessionContext {
             })
             .collect();
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -590,7 +604,7 @@ impl LocalSessionContext {
             })
             .collect();
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -610,7 +624,7 @@ impl LocalSessionContext {
             })
             .collect();
 
-        self.catalog_mutator
+        self.catalog_mutator()
             .mutate(self.catalog.version(), drops)
             .await?;
 
@@ -639,11 +653,11 @@ impl LocalSessionContext {
         _params: Vec<i32>, // TODO: We can use these for providing types for parameters.
     ) -> Result<()> {
         // Refresh the cached catalog state if necessary
+        let mutator = self.catalog_mutator();
+        let client = mutator.get_metastore_client();
+
         self.catalog
-            .maybe_refresh_state(
-                self.catalog_mutator.get_metastore_client(),
-                self.get_session_vars().force_catalog_refresh(),
-            )
+            .maybe_refresh_state(client, self.get_session_vars().force_catalog_refresh())
             .await?;
 
         // Unnamed (empty string) prepared statements can be overwritten

--- a/crates/sqlexec/src/metastore/catalog.rs
+++ b/crates/sqlexec/src/metastore/catalog.rs
@@ -30,6 +30,9 @@ pub struct CatalogMutator {
 }
 
 impl CatalogMutator {
+    pub fn empty() -> Self {
+        CatalogMutator { client: None }
+    }
     pub fn new(client: Option<MetastoreClientHandle>) -> Self {
         CatalogMutator { client }
     }
@@ -45,7 +48,7 @@ impl CatalogMutator {
     /// This will retry mutations if we were working with an out of date
     /// catalog.
     pub async fn mutate(
-        &mut self,
+        &self,
         catalog_version: u64,
         mutations: impl IntoIterator<Item = Mutation>,
     ) -> Result<Arc<CatalogState>> {


### PR DESCRIPTION
moves the catalog mutator into the session context. 

the mutator already had internal mutability, so no need to create a wrapper like i did with sessionvars. 

the patch to datafusion is still needed as mentioned in #1607 