### PR TITLE
fix: Fix projection/partition related bugs with remote planner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,11 @@ jobs:
           just sql-logic-tests -v --exclude '*/tunnels/ssh'
           just sql-logic-tests -v '*/tunnels/ssh'
 
+      - name: SQL Logic Tests (RPC)
+        run: |
+          just sql-logic-tests -v 'sqllogictests/rpc' \
+                                  'sqllogictests/time'
+
       - name: Protocol Tests
         run: ./scripts/protocol-test.sh
 

--- a/crates/sqlexec/src/planner/physical_plan/client_recv.rs
+++ b/crates/sqlexec/src/planner/physical_plan/client_recv.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::remote::staged_stream::{ResolveClientStreamFut, StagedClientStreams};
@@ -62,6 +63,7 @@ impl ExecutionPlan for ClientExchangeRecvExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
+        debug!(%partition, %self.broadcast_id, "executing client exchange recv exec");
         if partition != 0 {
             return Err(DataFusionError::Execution(
                 "ClientExchangeRecvExec only supports 1 partition".to_string(),
@@ -91,7 +93,11 @@ impl ExecutionPlan for ClientExchangeRecvExec {
 
 impl DisplayAs for ClientExchangeRecvExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ClientExchangeRecvExec")
+        write!(
+            f,
+            "ClientExchangeRecvExec: broadcast_id={}",
+            self.broadcast_id
+        )
     }
 }
 

--- a/crates/sqlexec/src/planner/physical_plan/client_send.rs
+++ b/crates/sqlexec/src/planner/physical_plan/client_send.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tracing::debug;
 use uuid::Uuid;
 
 /// Execution plan for sending batches to a remote node.
@@ -74,11 +75,12 @@ impl ExecutionPlan for ClientExchangeSendExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
+        debug!(%partition, %self.broadcast_id, "executing client exchange send exec");
         // Supporting multiple partitions in the future should be easy enough,
         // just make more streams.
         if partition != 0 {
             return Err(DataFusionError::Execution(
-                "ClientExchangeInputSendExec only supports 1 partition".to_string(),
+                "ClientExchangeSendExec only supports 1 partition".to_string(),
             ));
         }
 
@@ -102,7 +104,11 @@ impl ExecutionPlan for ClientExchangeSendExec {
 
 impl DisplayAs for ClientExchangeSendExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ClientExchangeInputSendExec")
+        write!(
+            f,
+            "ClientExchangeInputSendExec: broadcast_id={}",
+            self.broadcast_id
+        )
     }
 }
 

--- a/crates/sqlexec/src/planner/physical_plan/send_recv.rs
+++ b/crates/sqlexec/src/planner/physical_plan/send_recv.rs
@@ -92,6 +92,12 @@ impl ExecutionPlan for SendRecvJoinExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(
+                "SendRecvJoinExec only supports 1 partition".to_string(),
+            ));
+        }
+
         // Set up send exec tokio tasks.
         //
         // Will be empty if this isn't the first call to execute, which is fine

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -223,6 +223,10 @@ impl RemoteSessionClient {
         self.session_id
     }
 
+    pub fn get_deployment_name(&self) -> &str {
+        self.inner.get_deployment_name()
+    }
+
     pub async fn dispatch_access(
         &mut self,
         table_ref: OwnedTableReference,

--- a/testdata/sqllogictests/functions/parquet_scan.slt
+++ b/testdata/sqllogictests/functions/parquet_scan.slt
@@ -38,3 +38,18 @@ select count(*) from parquet_scan([
 ]);
 ----
 2000
+
+# Ambiguous name.
+# query I
+# select count(*)
+#   from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+#   inner join (values ('Sweden')) as c(country) on p.country = c.country
+# ----
+# 1000
+
+# query I
+# select count(*)
+#   from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+#   inner join (select 'Sweden') as c(country) on p.country = c.country
+# ----
+# 1000

--- a/testdata/sqllogictests/rpc.slt
+++ b/testdata/sqllogictests/rpc.slt
@@ -1,0 +1,51 @@
+# Test cases specific to RPC regressions.
+#
+# Since we're still developing RPC, it's easiest to just put regression cases
+# in a single file. We can split this up later.
+
+# This triggered a few different errors during testing, mostly around our execs
+# not supporting partitioning (while also not ensuring there's only 1
+# partition).
+statement ok
+select *
+  from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+  inner join (select 'Sweden') c(country2) on p.country = country2
+
+query I
+select count(*)
+  from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+  inner join (select 'Sweden') c(country2) on p.country = country2
+----
+25
+
+# Ensure projection works (#1597 and #1602)
+query T
+select first_name
+  from parquet_scan('../../testdata/parquet/userdata1.parquet')
+  order by id
+  limit 3
+----
+Amanda
+Albert
+Evelyn
+
+query T
+select p.first_name
+  from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+  order by p.id
+  limit 3
+----
+Amanda
+Albert
+Evelyn
+
+query TT
+select p.first_name, country2
+  from parquet_scan('../../testdata/parquet/userdata1.parquet') p
+  inner join (select 'Sweden') c(country2) on p.country = country2
+  order by p.id
+  limit 3;
+----
+John     Sweden
+Aaron    Sweden
+Kathryn  Sweden


### PR DESCRIPTION
- Current execs assume a single partition, so added a coalesce exec to ensure that is the case.
- Was sending the wrong schema in the recv exec causing projection issues.
- Added some SLTs that I was using for testing this.
- Add section in github workflow for running SLTs with rpc. We can enable more tests as we go along.

Closes #1597 
Closes #1602 