### PR TITLE
fix: optimize lp before creating physical plan

### DIFF
--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -257,6 +257,7 @@ impl Session {
         plan: DfLogicalPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let state = self.ctx.df_ctx().state();
+        let plan = state.optimize(&plan)?;
         if let Some(client) = self.ctx.exec_client() {
             let planner = RemotePhysicalPlanner {
                 remote_client: client,


### PR DESCRIPTION
the default `state.create_physical_plan` optimizes the lp before creating it. We should as well. It was causing some issues with `Explain` 