### PR TITLE
chore: Enable pretty logging

### DIFF
--- a/crates/logutil/src/lib.rs
+++ b/crates/logutil/src/lib.rs
@@ -101,7 +101,7 @@ pub fn init(verbosity: impl Into<Verbosity>, json: bool) {
         let subscriber = with_env_filter(builder.finish());
         subscriber::set_global_default(subscriber).unwrap();
     } else {
-        let builder = default_fmt_builder(level);
+        let builder = default_fmt_builder(level).pretty();
         let subscriber = with_env_filter(builder.finish());
         subscriber::set_global_default(subscriber).unwrap();
     }


### PR DESCRIPTION
```
  2023-08-27T22:50:49.908031Z DEBUG tower::buffer::worker: service.ready: true, processing request
    at /Users/sean/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tower-0.4.13/src/buffer/worker.rs:197 on server-thread-1 ThreadId(3)
    in sqlexec::metastore::client::fetch_interval with db_id: 00000000-0000-0000-0000-000000000000

  2023-08-27T22:50:49.911039Z DEBUG sqlexec::engine: new session opened, session_count: 1
    at crates/sqlexec/src/engine.rs:161 on server-thread-7 ThreadId(9)
    in glaredb::server::glaredb_connection with conn_id: f33becfd-4d60-4c65-a35d-2c4bc1301757

  2023-08-27T22:50:49.964877Z DEBUG metastore::srv: fetch catalog, req: FetchCatalogRequest { db_id: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
    at crates/metastore/src/srv.rs:76 on server-thread-6 ThreadId(8)

  2023-08-27T22:50:49.968590Z  INFO sqlexec::metastore::client: worker fetch interval, sess_count: 1, db_id: 00000000-0000-0000-0000-000000000000
    at crates/sqlexec/src/metastore/client.rs:533 on server-thread-6 ThreadId(8)

  2023-08-27T22:51:08.465302Z DEBUG sqlexec::planner::session_planner: planning sql statement, statement: SELECT 1
    at crates/sqlexec/src/planner/session_planner.rs:77 on server-thread-1 ThreadId(3)
    in pgsrv::handler::pg_protocol_message with name: "query"
    in glaredb::server::glaredb_connection with conn_id: f33becfd-4d60-4c65-a35d-2c4bc1301757
```

Has colors and bold too.