### PR TITLE
feat: Update catalog with rpc

### DIFF
--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -86,10 +86,14 @@ message InitializeSessionResponse {
   metastore.catalog.CatalogState catalog = 2;
 }
 
+message FetchCatalogRequest { bytes session_id = 1; }
+
+message FetchCatalogResponse { metastore.catalog.CatalogState catalog = 1; }
+
 // Dispatch the table access on remote server.
 message DispatchAccessRequest {
   bytes session_id = 1;
-  TableReference table_ref = 2;
+  ResolvedTableReference table_ref = 2;
 }
 
 // Execute a physical plan and get the stream.
@@ -109,10 +113,24 @@ message RecordBatchResponse {
   bytes arrow_ipc = 1;
 }
 
-message TableReference {
-  optional string catalog = 1;
-  optional string schema = 2;
-  string table = 3;
+message InternalTableReference {
+  // OID of the table in the catalog.
+  uint32 table_oid = 1;
+}
+
+message ExternalTableReference {
+  string database = 1;
+  string schema = 2;
+  string name = 3;
+}
+
+message ResolvedTableReference {
+  oneof reference {
+    // Table exists in our catalog.
+    InternalTableReference internal = 1;
+    // Table exists in an external system that we need to contact.
+    ExternalTableReference external = 2;
+  }
 }
 
 message BroadcastExchangeRequest {
@@ -146,6 +164,8 @@ service ExecutionService {
   // Initializes a remote session.
   rpc InitializeSession(InitializeSessionRequest)
       returns (InitializeSessionResponse);
+
+  rpc FetchCatalog(FetchCatalogRequest) returns (FetchCatalogResponse);
 
   // Dispatch and create a table provider on the remote server.
   rpc DispatchAccess(DispatchAccessRequest) returns (TableProviderResponse);

--- a/crates/rpcsrv/src/proxy.rs
+++ b/crates/rpcsrv/src/proxy.rs
@@ -178,6 +178,15 @@ impl<A: ProxyAuthenticator + 'static> service::execution_service_server::Executi
         Ok(Response::new(resp.try_into()?))
     }
 
+    async fn fetch_catalog(
+        &self,
+        request: Request<service::FetchCatalogRequest>,
+    ) -> Result<Response<service::FetchCatalogResponse>, Status> {
+        info!("fetching catalog (proxy)");
+        let (_, mut client) = self.connect(request.metadata()).await?;
+        client.fetch_catalog(request).await
+    }
+
     async fn dispatch_access(
         &self,
         request: Request<service::DispatchAccessRequest>,

--- a/crates/sqlexec/src/context/remote.rs
+++ b/crates/sqlexec/src/context/remote.rs
@@ -7,12 +7,15 @@ use datafusion::{
 };
 use datafusion_ext::vars::SessionVars;
 use datasources::native::access::NativeTableStorage;
+use protogen::{
+    metastore::types::catalog::CatalogEntry, rpcsrv::types::service::ResolvedTableReference,
+};
 use uuid::Uuid;
 
 use crate::{
     background_jobs::JobRunner,
     dispatch::external::ExternalDispatcher,
-    errors::Result,
+    errors::{ExecError, Result},
     extension_codec::GlareDBExtensionCodec,
     metastore::catalog::{CatalogMutator, SessionCatalog, TempCatalog},
     remote::{provider_cache::ProviderCache, staged_stream::StagedClientStreams},
@@ -80,6 +83,13 @@ impl RemoteSessionContext {
         &self.catalog
     }
 
+    pub async fn refresh_catalog(&mut self) -> Result<()> {
+        self.catalog
+            .maybe_refresh_state(self.catalog_mutator().get_metastore_client(), false)
+            .await?;
+        Ok(())
+    }
+
     /// Returns the extension codec used for serializing and deserializing data
     /// over RPCs.
     pub fn extension_codec(&self) -> GlareDBExtensionCodec<'_> {
@@ -122,23 +132,41 @@ impl RemoteSessionContext {
     // getting the correct entries from the catalog.
     pub async fn load_and_cache_table(
         &mut self,
-        database: &str,
-        schema: &str,
-        name: &str,
+        table_ref: ResolvedTableReference,
     ) -> Result<(Uuid, Arc<dyn TableProvider>)> {
         self.catalog
             .maybe_refresh_state(self.catalog_mutator().get_metastore_client(), false)
             .await?;
 
-        let prov: Arc<dyn TableProvider> =
-            if let Some(tbl) = self.catalog.resolve_table(database, schema, name) {
-                self.tables.load_table(tbl).await?.into_table_provider()
-            } else {
+        let prov: Arc<dyn TableProvider> = match table_ref {
+            ResolvedTableReference::Internal { table_oid } => {
+                match self.catalog.get_by_oid(table_oid) {
+                    Some(CatalogEntry::Table(tbl)) => {
+                        self.tables.load_table(tbl).await?.into_table_provider()
+                    }
+                    Some(_) => {
+                        return Err(ExecError::Internal(format!("oid not a table: {table_oid}")))
+                    }
+                    None => {
+                        return Err(ExecError::Internal(format!(
+                            "missing entry for oid: {table_oid}"
+                        )))
+                    }
+                }
+            }
+            ResolvedTableReference::External {
+                database,
+                schema,
+                name,
+            } => {
                 // Since this is operating on a remote node, always disable local fs
                 // access.
                 let dispatcher = ExternalDispatcher::new(&self.catalog, &self.df_ctx, true);
-                dispatcher.dispatch_external(database, schema, name).await?
-            };
+                dispatcher
+                    .dispatch_external(&database, &schema, &name)
+                    .await?
+            }
+        };
 
         let id = Uuid::new_v4();
         self.provider_cache.put(id, prov.clone());

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -153,6 +153,9 @@ pub enum ExecError {
 
     #[error(transparent)]
     InvalidMetadataValue(#[from] tonic::metadata::errors::InvalidMetadataValue),
+
+    #[error("{0}")]
+    String(String),
 }
 
 pub type Result<T, E = ExecError> = std::result::Result<T, E>;

--- a/crates/sqlexec/src/metastore/catalog.rs
+++ b/crates/sqlexec/src/metastore/catalog.rs
@@ -330,8 +330,8 @@ impl SessionCatalog {
         // Note that when we have transactions, we should move this to only
         // swapping states between transactions.
         if client.version_hint() != self.version() {
-            debug!(version = %self.version(), "swapping catalog state for session");
             let new_state = client.get_cached_state().await?;
+            debug!(old_version = %self.version(), new_version = %new_state.version, "swapping catalog state for session");
             self.swap_state(new_state);
         }
 
@@ -339,7 +339,12 @@ impl SessionCatalog {
     }
 
     /// Swap the underlying state of the catalog.
-    fn swap_state(&mut self, new_state: Arc<CatalogState>) {
+    ///
+    /// NOTE: This does not check if the new state is actually from a new
+    /// catalog.
+    pub fn swap_state(&mut self, new_state: Arc<CatalogState>) {
+        debug!(old_version = %self.state.version, new_version = %new_state.version, "swapping session catalog");
+
         self.state = new_state;
         self.rebuild_name_maps();
     }

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -19,8 +19,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::LogicalPlan as DfLogicalPlan;
 use datafusion::physical_plan::{
-    execute_stream, EmptyRecordBatchStream, ExecutionPlan, RecordBatchStream,
-    SendableRecordBatchStream,
+    execute_stream, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
 };
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::scalar::ScalarValue;
@@ -29,7 +28,6 @@ use datasources::native::access::NativeTableStorage;
 use futures::{Stream, StreamExt};
 use pgrepr::format::Format;
 use telemetry::Tracker;
-use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::background_jobs::JobRunner;
@@ -40,112 +38,18 @@ use crate::metrics::{BatchStreamWithMetricSender, ExecutionStatus, QueryMetrics,
 use crate::parser::StatementWithExtensions;
 use crate::planner::logical_plan::*;
 
-/// The results of execution.
-pub struct ExecutionStream {
-    /// Inner results stream from execution.
-    inner: SendableRecordBatchStream,
-    /// Execution plan used to create the stream. Used for collecting metrics
-    /// for query execution.
-    // TODO: Remote Option once everything is executed through an execution
-    // plan.
-    plan: Option<Arc<dyn ExecutionPlan>>,
-}
-
-impl ExecutionStream {
-    pub fn empty() -> ExecutionStream {
-        ExecutionStream {
-            inner: Box::pin(EmptyRecordBatchStream::new(Arc::new(Schema::empty()))),
-            plan: None,
-        }
-    }
-
-    /// Inspect the stream to provide additional details.
-    pub async fn inspect_result(&mut self) -> ExecutionResult {
-        let schema = self.inner.schema();
-        // If we don't match either of these schemas, just assume these results
-        // are from a normal SELECT query.
-        if !(schema.eq(&GENERIC_OPERATION_PHYSICAL_SCHEMA)
-            || schema.eq(&GENERIC_OPERATION_AND_COUNT_PHYSICAL_SCHEMA))
-        {
-            return ExecutionResult::Query;
-        }
-
-        let batch = match self.inner.next().await {
-            Some(Ok(batch)) => batch,
-            Some(Err(e)) => return ExecutionResult::Error(e),
-            None => return ExecutionResult::EmptyQuery,
-        };
-
-        // Our special batches contain only a single row. If we have more,
-        // assume that this is a user query (which would be weird since it
-        // matches our special schemas).
-        if batch.num_rows() != 1 {
-            self.swap_with_stream_and_first_result(Ok(batch));
-            return ExecutionResult::Query;
-        }
-
-        // Try to get the execution result type from the batch. Default to
-        // `Query` if we don't know how to translate it into a result.
-        let op = get_operation_from_batch(&batch).unwrap_or_default();
-        let count = get_count_from_batch(&batch);
-        let result =
-            ExecutionResult::from_str_and_count(&op, count).unwrap_or(ExecutionResult::Query);
-
-        // Put the batch we inspected back on the stream.
-        self.swap_with_stream_and_first_result(Ok(batch));
-
-        result
-    }
-
-    /// Helper for swapping out the stream with one that prepends `result`.
-    fn swap_with_stream_and_first_result(&mut self, result: DataFusionResult<RecordBatch>) {
-        let mut placeholder: SendableRecordBatchStream =
-            Box::pin(EmptyRecordBatchStream::new(Arc::new(Schema::empty())));
-        std::mem::swap(&mut self.inner, &mut placeholder);
-        self.inner = Box::pin(StreamAndFirstResult {
-            stream: placeholder,
-            first_result: Some(result),
-        });
-    }
-
-    /// Swap out the stream with one that will record metrics on query completion.
-    // TODO: This could be a bit better integrated.
-    fn swap_with_metrics_stream(
-        &mut self,
-        pending: QueryMetrics,
-        sender: mpsc::Sender<QueryMetrics>,
-    ) {
-        let mut placeholder: SendableRecordBatchStream =
-            Box::pin(EmptyRecordBatchStream::new(Arc::new(Schema::empty())));
-        std::mem::swap(&mut self.inner, &mut placeholder);
-
-        let metrics_stream =
-            BatchStreamWithMetricSender::new(placeholder, self.plan.clone(), pending, sender);
-
-        self.inner = Box::pin(metrics_stream)
-    }
-}
-
-impl Stream for ExecutionStream {
-    type Item = DataFusionResult<RecordBatch>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.inner.poll_next_unpin(cx)
-    }
-}
-
-impl RecordBatchStream for ExecutionStream {
-    fn schema(&self) -> Arc<Schema> {
-        self.inner.schema()
-    }
-}
-
 /// Results from a sql statement execution.
 pub enum ExecutionResult {
+    /// The stream for the output of a query.
+    Query {
+        /// Inner results stream from execution.
+        stream: SendableRecordBatchStream,
+        /// Execution plan used to create the stream. Used for collecting metrics
+        /// for query execution.
+        plan: Arc<dyn ExecutionPlan>,
+    },
     /// Execution errored.
     Error(DataFusionError),
-    /// The stream for the output of a query.
-    Query,
     /// No batches returned.
     EmptyQuery,
     /// Transaction started.
@@ -197,6 +101,58 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
+    /// Create a result from a stream and a physical plan.
+    ///
+    /// This will look at the first batch in the stream to determine which
+    /// result it is.
+    pub async fn from_stream_and_plan(
+        mut stream: SendableRecordBatchStream,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> ExecutionResult {
+        let schema = stream.schema();
+        // If we don't match either of these schemas, just assume these results
+        // are from a normal SELECT query.
+        if !(schema.eq(&GENERIC_OPERATION_PHYSICAL_SCHEMA)
+            || schema.eq(&GENERIC_OPERATION_AND_COUNT_PHYSICAL_SCHEMA))
+        {
+            return ExecutionResult::Query { stream, plan };
+        }
+
+        let (batch, stream) = match stream.next().await {
+            Some(Ok(batch)) => (
+                batch.clone(),
+                StreamAndFirstResult {
+                    stream,
+                    first_result: Some(Ok(batch)),
+                },
+            ),
+            Some(Err(e)) => {
+                return ExecutionResult::Error(e);
+            }
+            None => return ExecutionResult::EmptyQuery,
+        };
+
+        // Our special batches contain only a single row. If we have more,
+        // assume that this is a user query (which would be weird since it
+        // matches our special schemas).
+        if batch.num_rows() != 1 {
+            return ExecutionResult::Query {
+                stream: Box::pin(stream),
+                plan,
+            };
+        }
+
+        // Try to get the execution result type from the batch. Default to
+        // `Query` if we don't know how to translate it into a result.
+        let op = get_operation_from_batch(&batch).unwrap_or_default();
+        let count = get_count_from_batch(&batch);
+
+        ExecutionResult::from_str_and_count(&op, count).unwrap_or(ExecutionResult::Query {
+            stream: Box::pin(stream),
+            plan,
+        })
+    }
+
     const fn result_type_str(&self) -> &'static str {
         match self {
             ExecutionResult::Error(_) => "error",
@@ -226,6 +182,27 @@ impl ExecutionResult {
             ExecutionResult::DropTunnel => "drop_tunnel",
             ExecutionResult::DropCredentials => "drop_credentials",
         }
+    }
+
+    const fn is_ddl(&self) -> bool {
+        matches!(
+            self,
+            ExecutionResult::CreateTable
+                | ExecutionResult::CreateDatabase
+                | ExecutionResult::CreateTunnel
+                | ExecutionResult::CreateCredentials
+                | ExecutionResult::CreateSchema
+                | ExecutionResult::CreateView
+                | ExecutionResult::AlterTableRename
+                | ExecutionResult::AlterDatabaseRename
+                | ExecutionResult::AlterTunnelRotateKeys
+                | ExecutionResult::DropTables
+                | ExecutionResult::DropViews
+                | ExecutionResult::DropSchemas
+                | ExecutionResult::DropDatabase
+                | ExecutionResult::DropTunnel
+                | ExecutionResult::DropCredentials
+        )
     }
 
     fn from_str_and_count(s: &str, count: Option<u64>) -> Option<ExecutionResult> {
@@ -270,7 +247,7 @@ impl fmt::Display for ExecutionResult {
             ExecutionResult::Error(e) => {
                 write!(f, "Execution error: {e}")
             }
-            ExecutionResult::Query => {
+            ExecutionResult::Query { .. } => {
                 write!(f, "Query")
             }
             ExecutionResult::EmptyQuery => write!(f, "No results"),
@@ -509,21 +486,42 @@ impl Session {
             .bind_statement(portal_name, stmt_name, params, result_formats)
     }
 
-    pub async fn execute_inner(&mut self, plan: LogicalPlan) -> Result<ExecutionStream> {
+    pub async fn execute_inner(&mut self, plan: LogicalPlan) -> Result<ExecutionResult> {
         // Note that transaction support is fake, in that we don't currently do
         // anything and do not provide any transactional semantics.
         //
         // We stub out transaction commands since many tools (even BI ones) will
         // try to open a transaction for some queries.
         match plan {
-            LogicalPlan::Transaction(_plan) => Ok(ExecutionStream::empty()),
+            LogicalPlan::Transaction(_plan) => Ok(ExecutionResult::EmptyQuery),
             LogicalPlan::Datafusion(plan) => {
                 let physical = self.create_physical_plan(plan).await?;
                 let stream = self.execute_physical(physical.clone())?;
-                Ok(ExecutionStream {
-                    inner: stream,
-                    plan: Some(physical),
-                })
+
+                let stream = ExecutionResult::from_stream_and_plan(stream, physical).await;
+
+                // If we're attached to a remote node, and the result indicates
+                // the operation was a DDL operation, then fetch the newer
+                // catalog from the remote node.
+                if let Some(mut client) = self.ctx.exec_client() {
+                    // TODO: It might make to check the error too, since it's
+                    // possible that erroring might've been from using an out of
+                    // date catalog.
+                    if stream.is_ddl() {
+                        // TODO: Instead of swapping here, I'd like to if we
+                        // could go towards collecting a "diff" of a session
+                        // (including new catalog states, variable changes, etc)
+                        // and applying at the start of a new query. This would
+                        // make "rolling back" in the case of an error pretty
+                        // easy -- just drop the diff.
+                        let state = client.fetch_catalog().await?;
+                        self.ctx
+                            .get_session_catalog_mut()
+                            .swap_state(Arc::new(state));
+                    }
+                }
+
+                Ok(stream)
             }
         }
     }
@@ -536,35 +534,49 @@ impl Session {
         &mut self,
         portal_name: &str,
         _max_rows: i32,
-    ) -> Result<ExecutionStream> {
+    ) -> Result<ExecutionResult> {
         // Flush any completed metrics.
         self.ctx.get_metrics_mut().flush_completed();
 
         let portal = self.ctx.get_portal(portal_name)?;
         let plan = match &portal.stmt.plan {
             Some(plan) => plan.clone(),
-            None => return Ok(ExecutionStream::empty()),
+            None => return Ok(ExecutionResult::EmptyQuery),
         };
 
         // Create "base" metrics.
         let mut metrics = QueryMetrics::new_for_portal(portal);
 
-        let mut stream = match self.execute_inner(plan).await {
-            Ok(mut stream) => {
-                let result = stream.inspect_result().await;
-                match result {
-                    ExecutionResult::Error(e) => {
-                        metrics.execution_status = ExecutionStatus::Fail;
-                        metrics.error_message = Some(e.to_string());
-                        return Err(e.into());
-                    }
-                    result => {
-                        metrics.execution_status = ExecutionStatus::Success;
-                        metrics.result_type = result.result_type_str();
-                        stream
+        let stream = match self.execute_inner(plan).await {
+            Ok(stream) => match stream {
+                ExecutionResult::Error(e) => {
+                    metrics.execution_status = ExecutionStatus::Fail;
+                    metrics.error_message = Some(e.to_string());
+                    return Err(e.into());
+                }
+                stream => {
+                    metrics.execution_status = ExecutionStatus::Success;
+                    metrics.result_type = stream.result_type_str();
+
+                    match stream {
+                        ExecutionResult::Query { stream, plan } => {
+                            // Swap out the batch stream with one that will send
+                            // metrics at the completions of the stream.
+                            let sender = self.ctx.get_metrics().get_sender();
+                            ExecutionResult::Query {
+                                stream: Box::pin(BatchStreamWithMetricSender::new(
+                                    stream,
+                                    plan.clone(),
+                                    metrics,
+                                    sender,
+                                )),
+                                plan,
+                            }
+                        }
+                        other => other,
                     }
                 }
-            }
+            },
             Err(e) => {
                 metrics.execution_status = ExecutionStatus::Fail;
                 metrics.error_message = Some(e.to_string());
@@ -576,11 +588,6 @@ impl Session {
                 return Err(e);
             }
         };
-
-        // Swap out the batch stream with one that will send metrics at the
-        // completions of the stream.
-        let sender = self.ctx.get_metrics().get_sender();
-        stream.swap_with_metrics_stream(metrics, sender);
 
         Ok(stream)
     }

--- a/crates/testing/src/slt/test.rs
+++ b/crates/testing/src/slt/test.rs
@@ -305,44 +305,48 @@ impl AsyncDB for TestClient {
                         Vec::new(),
                         vec![Format::Text; num_fields],
                     )?;
-                    let mut stream = session.execute_portal(&UNNAMED, 0).await?;
-                    let result = stream.inspect_result().await;
+                    let stream = session.execute_portal(&UNNAMED, 0).await?;
 
-                    if let ExecutionResult::Query = result {
-                        let batches = stream
-                            .collect::<Vec<_>>()
-                            .await
-                            .into_iter()
-                            .collect::<Result<Vec<_>, _>>()?;
+                    match stream {
+                        ExecutionResult::Query { stream, .. } => {
+                            let batches = stream
+                                .collect::<Vec<_>>()
+                                .await
+                                .into_iter()
+                                .collect::<Result<Vec<_>, _>>()?;
 
-                        for batch in batches {
-                            if num_columns == 0 {
-                                num_columns = batch.num_columns();
-                            }
-                            for row_idx in 0..batch.num_rows() {
-                                let mut row_output = Vec::with_capacity(num_columns);
-                                for col in batch.columns() {
-                                    let pg_type = arrow_to_pg_type(col.data_type(), None);
-                                    let scalar = Scalar::try_from_array(col, row_idx, &pg_type)?;
-                                    if scalar.is_null() {
-                                        row_output.push("NULL".to_string());
-                                    }
-                                    let mut buf = BytesMut::new();
-                                    scalar.encode_with_format(Format::Text, &mut buf)?;
-                                    if buf.is_empty() {
-                                        row_output.push("(empty)".to_string())
-                                    } else {
-                                        let scalar = String::from_utf8(buf.to_vec()).map_err(|e| {
+                            for batch in batches {
+                                if num_columns == 0 {
+                                    num_columns = batch.num_columns();
+                                }
+                                for row_idx in 0..batch.num_rows() {
+                                    let mut row_output = Vec::with_capacity(num_columns);
+                                    for col in batch.columns() {
+                                        let pg_type = arrow_to_pg_type(col.data_type(), None);
+                                        let scalar =
+                                            Scalar::try_from_array(col, row_idx, &pg_type)?;
+                                        if scalar.is_null() {
+                                            row_output.push("NULL".to_string());
+                                        }
+                                        let mut buf = BytesMut::new();
+                                        scalar.encode_with_format(Format::Text, &mut buf)?;
+                                        if buf.is_empty() {
+                                            row_output.push("(empty)".to_string())
+                                        } else {
+                                            let scalar = String::from_utf8(buf.to_vec()).map_err(|e| {
                                                 ExecError::Internal(format!(
                                                     "invalid text formatted result from pg encoder: {e}"
                                                 ))
                                             })?;
-                                        row_output.push(scalar);
+                                            row_output.push(scalar);
+                                        }
                                     }
+                                    output.push(row_output);
                                 }
-                                output.push(row_output);
                             }
                         }
+                        ExecutionResult::Error(e) => return Err(e.into()),
+                        _ => (),
                     }
                 }
             }

--- a/py-glaredb/src/session.rs
+++ b/py-glaredb/src/session.rs
@@ -1,13 +1,13 @@
 use crate::util::pyprint;
 use anyhow::Result;
 use arrow_util::pretty::pretty_format_batches;
+use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::ToPyArrow;
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::lock::Mutex;
 use futures::StreamExt;
 use pgrepr::format::Format;
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyTuple};
-use sqlexec::session::ExecutionStream;
 use sqlexec::{
     engine::{Engine, TrackedSession},
     parser,
@@ -26,10 +26,7 @@ pub struct LocalSession {
 }
 
 #[pyclass]
-pub struct PyExecutionStream {
-    pub inner: ExecutionStream,
-    pub result: ExecutionResult,
-}
+pub struct PyExecutionResult(pub ExecutionResult);
 
 #[pymethods]
 impl LocalSession {
@@ -45,7 +42,7 @@ impl LocalSession {
         })
     }
 
-    fn execute(&mut self, py: Python<'_>, query: &str) -> PyResult<PyExecutionStream> {
+    fn execute(&mut self, py: Python<'_>, query: &str) -> PyResult<PyExecutionResult> {
         const UNNAMED: String = String::new();
 
         let mut statements = parser::parse_sql(query).map_err(PyGlareDbError::from)?;
@@ -73,17 +70,12 @@ impl LocalSession {
                         vec![Format::Text; num_fields],
                     )
                     .map_err(PyGlareDbError::from)?;
-                    let mut stream = sess
+                    let stream = sess
                         .execute_portal(&UNNAMED, 0)
                         .await
                         .map_err(PyGlareDbError::from)?;
 
-                    let result = stream.inspect_result().await;
-
-                    Ok(PyExecutionStream {
-                        inner: stream,
-                        result,
-                    })
+                    Ok(PyExecutionResult(stream))
                 }
                 _ => {
                     todo!()
@@ -103,56 +95,72 @@ impl LocalSession {
 }
 
 fn to_arrow_batches_and_schema(
-    stream: &mut ExecutionStream,
+    result: &mut ExecutionResult,
     py: Python<'_>,
 ) -> PyResult<(PyObject, PyObject)> {
-    let batches: Result<Vec<RecordBatch>> = wait_for_future(py, async move {
-        Ok(stream
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?)
-    });
+    match result {
+        ExecutionResult::Query { stream, .. } => {
+            let batches: Result<Vec<RecordBatch>> = wait_for_future(py, async move {
+                Ok(stream
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?)
+            });
 
-    let batches =
-        batches.map_err(|e| PyRuntimeError::new_err(format!("unhandled exception: {:?}", &e)))?;
-    let schema = batches[0].schema().to_pyarrow(py)?;
+            let batches = batches
+                .map_err(|e| PyRuntimeError::new_err(format!("unhandled exception: {:?}", &e)))?;
+            let schema = batches[0].schema().to_pyarrow(py)?;
 
-    // TODO: currently we are iterating twice due to the GIL lock
-    // we can't use `to_pyarrow` within an async block.
-    let batches = batches
-        .into_iter()
-        .map(|batch| batch.to_pyarrow(py))
-        .collect::<Result<Vec<_>, _>>()?
-        .to_object(py);
+            // TODO: currently we are iterating twice due to the GIL lock
+            // we can't use `to_pyarrow` within an async block.
+            let batches = batches
+                .into_iter()
+                .map(|batch| batch.to_pyarrow(py))
+                .collect::<Result<Vec<_>, _>>()?
+                .to_object(py);
 
-    Ok((batches, schema))
+            Ok((batches, schema))
+        }
+        _ => {
+            // TODO: Figure out the schema we actually want to use.
+            let schema = Arc::new(Schema::empty());
+            let batches = vec![RecordBatch::new_empty(schema.clone()).to_pyarrow(py)]
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()?
+                .to_object(py);
+            Ok((batches, schema.to_pyarrow(py)?))
+        }
+    }
 }
 
-fn print_batch(stream: &mut ExecutionStream, py: Python<'_>) -> PyResult<()> {
-    let batches = wait_for_future(py, async move {
-        stream
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .collect::<Result<Vec<RecordBatch>, _>>()
-    })?;
+fn print_batch(result: &mut ExecutionResult, py: Python<'_>) -> PyResult<()> {
+    match result {
+        ExecutionResult::Query { stream, .. } => {
+            let batches = wait_for_future(py, async move {
+                stream
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<RecordBatch>, _>>()
+            })?;
 
-    let disp = pretty_format_batches(&batches, None, None, None)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            let disp = pretty_format_batches(&batches, None, None, None)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
-    pyprint(disp, py)?;
-
-    Ok(())
+            pyprint(disp, py)
+        }
+        _ => Err(PyRuntimeError::new_err("Not able to show executed result")),
+    }
 }
 
 #[pymethods]
-impl PyExecutionStream {
+impl PyExecutionResult {
     /// Convert to Arrow Table
     /// Collect the batches and pass to Arrow Table
     #[allow(clippy::wrong_self_convention)] // this is consistent with other python API's
     pub fn to_arrow(&mut self, py: Python) -> PyResult<PyObject> {
-        let (batches, schema) = to_arrow_batches_and_schema(&mut self.inner, py)?;
+        let (batches, schema) = to_arrow_batches_and_schema(&mut self.0, py)?;
 
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object and use its from_batches method
@@ -165,7 +173,7 @@ impl PyExecutionStream {
 
     #[allow(clippy::wrong_self_convention)] // this is consistent with other python API's
     pub fn to_polars(&mut self, py: Python) -> PyResult<PyObject> {
-        let (batches, schema) = to_arrow_batches_and_schema(&mut self.inner, py)?;
+        let (batches, schema) = to_arrow_batches_and_schema(&mut self.0, py)?;
 
         Python::with_gil(|py| {
             let table_class = py.import("pyarrow")?.getattr("Table")?;
@@ -181,7 +189,7 @@ impl PyExecutionStream {
 
     #[allow(clippy::wrong_self_convention)] // this is consistent with other python API's
     pub fn to_pandas(&mut self, py: Python) -> PyResult<PyObject> {
-        let (batches, schema) = to_arrow_batches_and_schema(&mut self.inner, py)?;
+        let (batches, schema) = to_arrow_batches_and_schema(&mut self.0, py)?;
 
         Python::with_gil(|py| {
             let table_class = py.import("pyarrow")?.getattr("Table")?;
@@ -194,7 +202,7 @@ impl PyExecutionStream {
     }
 
     pub fn show(&mut self, py: Python) -> PyResult<()> {
-        print_batch(&mut self.inner, py)?;
+        print_batch(&mut self.0, py)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This change makes it so that the local session will pull the catalog after it detects the query was a DDL query.

```
GlareDB (v0.4.0)
Type \help for help.
Using in-memory catalog
> \open http:localhost:6542
Connected to Cloud deployment: unknown
> create table hello7 (a int);
Table created
> insert into hello7 select 1 as a;
Inserted 1 row
> insert into hello7 select 2 as a;
Inserted 1 row
> select * from hello7;
┌────────────┐
│ $operation │
│ ──         │
│ Utf8       │
╞════════════╡
│ 1          │
│ 2          │
└────────────┘
```

Other changes:

- Reverts some of the execution stream/result stuff. It made working with the results pretty clumsy.
- Adds a quick-fix around querying system tables by wrapping it in a local hint. This was useful for debugging.
- Reinits the datafusion context on client attach. This was done to create a catalog mutator that didn't have a metastore client. Without this change, the catalog would inadvertently revert back to the local session's catalog since the session will attempt to update the catalog from the local cache with the client.

Bugs:

- The above example, the column name is incorrect. I'm not sure why yet, but plan on looking into it in a follow up.
- The memory store not working is very inconvenient for testing. The above example was done by specifying a data dir.