### PR TITLE
fix(rpc): Use correct schema when serialize create table execs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,8 +131,8 @@ jobs:
 
       - name: SQL Logic Tests (RPC)
         run: |
-          just sql-logic-tests -v 'sqllogictests/rpc' \
-                                  'sqllogictests/time'
+          just sql-logic-tests -v --rpc-test 'sqllogictests/rpc' \
+                                             'sqllogictests/time'
 
       - name: Protocol Tests
         run: ./scripts/protocol-test.sh

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -724,13 +724,13 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                 catalog_version: exec.catalog_version,
                 tbl_reference: Some(exec.tbl_reference.clone().into()),
                 if_not_exists: exec.if_not_exists,
-                arrow_schema: Some(exec.schema().try_into()?),
+                arrow_schema: Some(exec.arrow_schema.clone().try_into()?),
             })
         } else if let Some(exec) = node.as_any().downcast_ref::<CreateTempTableExec>() {
             proto::ExecutionPlanExtensionType::CreateTempTableExec(proto::CreateTempTableExec {
                 tbl_reference: Some(exec.tbl_reference.clone().into()),
                 if_not_exists: exec.if_not_exists,
-                arrow_schema: Some(exec.schema().try_into()?),
+                arrow_schema: Some(exec.arrow_schema.clone().try_into()?),
             })
         } else if let Some(exec) = node.as_any().downcast_ref::<AlterDatabaseRenameExec>() {
             proto::ExecutionPlanExtensionType::AlterDatabaseRenameExec(

--- a/testdata/sqllogictests/rpc.slt
+++ b/testdata/sqllogictests/rpc.slt
@@ -52,15 +52,16 @@ Kathryn  Sweden
 
 # One off tests for #1599
 
-# statement ok
-# create schema hello_world;
+statement ok
+create schema hello_world;
 
-# statement ok
-# drop schema hello_world;
+statement ok
+drop schema hello_world;
 
+# Views don't seem to be working yet.
 # statement ok
 # create view my_view as select 1;
-
+#
 # query I
 # select * from my_view;
 # ----
@@ -77,3 +78,14 @@ select * from test2;
 ----
 1
 
+# Test for #1661
+statement ok
+create table t1661 (a int, b int, c int);
+
+statement ok
+insert into t1661 select 1, 2, 3;
+
+query III
+select * from t1661;
+----
+1 2 3


### PR DESCRIPTION
Closes #1661 

Was using the schema of the _output_ of the create table execs, and the schema for the table itself.

```
> \open http://localhost:6542
Connected to Cloud deployment: unknown
> create table hello (a int, b int, c int);
Table created
> insert into hello select 1, 2, 3;
Inserted 1 row
> select * from hello;
┌───────┬───────┬───────┐
│ a     │ b     │ c     │
│ ──    │ ──    │ ──    │
│ Int32 │ Int32 │ Int32 │
╞═══════╪═══════╪═══════╡
│ 1     │ 2     │ 3     │
└───────┴───────┴───────┘
```