### PR TITLE
fix: Serialize `ValuesExec` for RPC.

### DIFF
--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -279,10 +279,18 @@ pub struct CopyToExec {
 }
 
 #[derive(Clone, PartialEq, Message)]
+pub struct ValuesExec {
+    #[prost(message, tag = "1")]
+    pub schema: Option<Schema>,
+    #[prost(bytes, tag = "2")]
+    pub data: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
 pub struct ExecutionPlanExtension {
     #[prost(
         oneof = "ExecutionPlanExtensionType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
     )]
     pub inner: Option<ExecutionPlanExtensionType>,
 }
@@ -343,4 +351,7 @@ pub enum ExecutionPlanExtensionType {
     DeleteExec(DeleteExec),
     #[prost(message, tag = "25")]
     CopyToExec(CopyToExec),
+    // Other
+    #[prost(message, tag = "26")]
+    ValuesExec(ValuesExec),
 }

--- a/crates/sqlexec/src/planner/physical_plan/mod.rs
+++ b/crates/sqlexec/src/planner/physical_plan/mod.rs
@@ -26,6 +26,7 @@ pub mod send_recv;
 pub mod set_var;
 pub mod show_var;
 pub mod update;
+pub mod values;
 
 use crate::planner::extension::PhysicalExtensionNode;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};

--- a/crates/sqlexec/src/planner/physical_plan/values.rs
+++ b/crates/sqlexec/src/planner/physical_plan/values.rs
@@ -1,0 +1,79 @@
+use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::common::compute_record_batch_statistics;
+use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+    Statistics,
+};
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct ExtValuesExec {
+    pub schema: Schema,
+    pub data: Vec<RecordBatch>,
+}
+
+impl ExecutionPlan for ExtValuesExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> Arc<Schema> {
+        Arc::new(self.schema.clone())
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::Plan(
+            "Cannot change children for ValuesExec".to_string(),
+        ))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(
+                "ValuesExec only supports 1 partition".to_string(),
+            ));
+        }
+
+        Ok(Box::pin(MemoryStream::try_new(
+            self.data.clone(),
+            self.schema(),
+            None,
+        )?))
+    }
+
+    fn statistics(&self) -> Statistics {
+        compute_record_batch_statistics(&[self.data.clone()], &self.schema, None)
+    }
+}
+
+impl DisplayAs for ExtValuesExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ValuesExec")
+    }
+}

--- a/testdata/sqllogictests/rpc.slt
+++ b/testdata/sqllogictests/rpc.slt
@@ -89,3 +89,27 @@ query III
 select * from t1661;
 ----
 1 2 3
+
+# Test if "values" clause works.
+# https://github.com/GlareDB/glaredb/pull/1673
+
+query I
+values (1), (2), (3);
+----
+1
+2
+3
+
+statement ok
+create table t1665 (a int, b text);
+
+statement ok
+insert into t1665 values
+  (1, 'a-thing'),
+  (2, 'b-thing');
+
+query TI
+select b, a from t1665;
+----
+a-thing  1
+b-thing  2


### PR DESCRIPTION
```
Connected to Cloud deployment: unknown
GlareDB (v0.4.0)
Type \help for help.
Using in-memory catalog
>
> values (1), (2), (3);
┌─────────┐
│ column1 │
│ ──      │
│ Int64   │
╞═════════╡
│ 1       │
│ 2       │
│ 3       │
└─────────┘
>
> create table abc (a int, b text);
Table created
>
> insert into abc
::: values (1, 'something'), (2, 'another thing');
Inserted 2 rows
>
> select * from abc;
┌───────┬───────────────┐
│ a     │ b             │
│ ──    │ ──            │
│ Int32 │ Utf8          │
╞═══════╪═══════════════╡
│ 1     │ something     │
│ 2     │ another thing │
└───────┴───────────────┘
```

Fixes: #1665