### PR TITLE
fix: Dispatch views locally

### DIFF
--- a/testdata/sqllogictests/rpc.slt
+++ b/testdata/sqllogictests/rpc.slt
@@ -58,14 +58,13 @@ create schema hello_world;
 statement ok
 drop schema hello_world;
 
-# Views don't seem to be working yet.
-# statement ok
-# create view my_view as select 1;
-#
-# query I
-# select * from my_view;
-# ----
-# 1
+statement ok
+create view my_view as select 1;
+
+query I
+select * from my_view;
+----
+1
 
 statement ok
 create table test (a int);


### PR DESCRIPTION
This is not optimal, but it gets views working.

```
GlareDB (v0.4.0)
Type \help for help.
Using in-memory catalog
> \open http://localhost:6542
Connected to Cloud deployment: unknown
> create view hello as select 1;
View created
> select * from hello;
┌──────────┐
│ Int64(1) │
│ ──       │
│ Int64    │
╞══════════╡
│ 1        │
└──────────┘
```