### PR TITLE
feat: remote execution of table funcs via dispatcher

### DIFF
--- a/crates/datafusion_ext/src/planner/mod.rs
+++ b/crates/datafusion_ext/src/planner/mod.rs
@@ -25,6 +25,7 @@ mod statement;
 pub mod utils;
 mod values;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::functions::*;
@@ -56,8 +57,6 @@ use crate::utils::make_decimal_type;
 /// functions referenced in SQL statements
 #[async_trait]
 pub trait AsyncContextProvider: Send + Sync {
-    type TableFuncContextProvider: TableFuncContextProvider;
-
     /// Getter for a datasource
     async fn get_table_provider(
         &mut self,
@@ -74,10 +73,12 @@ pub trait AsyncContextProvider: Send + Sync {
     ///
     /// Note that this accepts a table reference since these functions are
     /// namespaced similiarly to tables.
-    fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>>;
-
-    /// Get the table func context provider.
-    fn table_fn_ctx_provider(&self) -> Self::TableFuncContextProvider;
+    async fn get_table_func(
+        &mut self,
+        name: TableReference<'_>,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
+    ) -> Option<Arc<dyn TableSource>>;
 
     /// Get configuration options.
     fn options(&self) -> &ConfigOptions;

--- a/crates/datafusion_ext/src/planner/mod.rs
+++ b/crates/datafusion_ext/src/planner/mod.rs
@@ -78,7 +78,7 @@ pub trait AsyncContextProvider: Send + Sync {
         name: TableReference<'_>,
         args: Vec<FuncParamValue>,
         opts: HashMap<String, FuncParamValue>,
-    ) -> Option<Arc<dyn TableSource>>;
+    ) -> Result<Arc<dyn TableSource>>;
 
     /// Get configuration options.
     fn options(&self) -> &ConfigOptions;

--- a/crates/datafusion_ext/src/planner/relation/mod.rs
+++ b/crates/datafusion_ext/src/planner/relation/mod.rs
@@ -63,12 +63,7 @@ impl<'a, S: AsyncContextProvider> SqlQueryPlanner<'a, S> {
                         let provider = self
                             .schema_provider
                             .get_table_func(table_ref.clone(), unnamed_args, named_args)
-                            .await
-                            .ok_or_else(|| {
-                                DataFusionError::Plan(format!(
-                                    "Missing table function: '{table_ref}'"
-                                ))
-                            })?;
+                            .await?;
 
                         let plan_builder = LogicalPlanBuilder::scan(table_ref, provider, None)?;
 

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1188,6 +1188,7 @@ impl BuiltinCatalog {
                         is_temp: false,
                     },
                     func_type: FunctionType::TableReturning,
+                    runtime_preference: func.runtime_preference(),
                 }),
             );
             schema_objects

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -179,8 +179,14 @@ message FunctionEntry {
     TABLE_RETURNING = 3;
   }
 
+  enum RuntimePreference {
+    UNSPECIFIED = 0;
+    LOCAL = 1;
+    REMOTE = 2;
+  }
   EntryMeta meta = 1;
   FunctionType func_type = 2;
+  RuntimePreference runtime_preference = 3;
 }
 
 message CredentialsEntry {

--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -94,6 +94,10 @@ message FetchCatalogResponse { metastore.catalog.CatalogState catalog = 1; }
 message DispatchAccessRequest {
   bytes session_id = 1;
   ResolvedTableReference table_ref = 2;
+  repeated bytes args = 3;
+  // gRPC doesn't really provide a way for Option<Vec<T>> or Option<Map<K,V>>
+  // so we use a map and just check if it's empty or not in rust.
+  map < string, bytes > options = 4;
 }
 
 // Execute a physical plan and get the stream.

--- a/crates/protogen/src/rpcsrv/types/func_param_value.rs
+++ b/crates/protogen/src/rpcsrv/types/func_param_value.rs
@@ -1,0 +1,24 @@
+use datafusion_proto::protobuf::ScalarValue;
+use prost::{Message, Oneof};
+
+#[derive(Clone, PartialEq, Message)]
+pub struct FuncParamValue {
+    #[prost(oneof = "FuncParamValueEnum", tags = "1, 2, 3")]
+    pub func_param_value_enum: Option<FuncParamValueEnum>,
+}
+
+#[derive(Clone, PartialEq, Oneof)]
+pub enum FuncParamValueEnum {
+    #[prost(string, tag = "1")]
+    Ident(String),
+    #[prost(message, tag = "2")]
+    Scalar(ScalarValue),
+    #[prost(message, tag = "3")]
+    Array(FuncParamValueArrayVariant),
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct FuncParamValueArrayVariant {
+    #[prost(message, repeated, tag = "1")]
+    pub array: Vec<FuncParamValue>,
+}

--- a/crates/protogen/src/rpcsrv/types/mod.rs
+++ b/crates/protogen/src/rpcsrv/types/mod.rs
@@ -1,1 +1,2 @@
+pub mod func_param_value;
 pub mod service;

--- a/crates/rpcsrv/src/errors.rs
+++ b/crates/rpcsrv/src/errors.rs
@@ -28,6 +28,9 @@ pub enum RpcsrvError {
     ProtoConvError(#[from] protogen::errors::ProtoConvError),
 
     #[error(transparent)]
+    ExtensionError(#[from] datafusion_ext::errors::ExtensionError),
+
+    #[error(transparent)]
     ExecError(#[from] sqlexec::errors::ExecError),
 
     #[error("Failed to authenticate with GlareDB Cloud: {0}")]

--- a/crates/sqlbuiltins/src/functions/bigquery.rs
+++ b/crates/sqlbuiltins/src/functions/bigquery.rs
@@ -7,12 +7,16 @@ use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
 use datasources::bigquery::{BigQueryAccessor, BigQueryTableAccess};
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadBigQuery;
 
 #[async_trait]
 impl TableFunc for ReadBigQuery {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "read_bigquery"
     }

--- a/crates/sqlbuiltins/src/functions/delta.rs
+++ b/crates/sqlbuiltins/src/functions/delta.rs
@@ -9,6 +9,7 @@ use datafusion_ext::local_hint::LocalTableHint;
 use datasources::common::url::{DatasourceUrl, DatasourceUrlType};
 use datasources::lake::delta::access::load_table_direct;
 use datasources::lake::LakeStorageOptions;
+use protogen::metastore::types::catalog::RuntimePreference;
 use protogen::metastore::types::options::CredentialsOptions;
 
 /// Function for scanning delta tables.
@@ -24,6 +25,9 @@ pub struct DeltaScan;
 
 #[async_trait]
 impl TableFunc for DeltaScan {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "delta_scan"
     }

--- a/crates/sqlbuiltins/src/functions/generate_series.rs
+++ b/crates/sqlbuiltins/src/functions/generate_series.rs
@@ -40,7 +40,7 @@ impl TableFunc for GenerateSeries {
         &self,
         _: &dyn TableFuncContextProvider,
         args: Vec<FuncParamValue>,
-        _opts: HashMap<String, FuncParamValue>,
+        _: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
         match args.len() {
             2 => {

--- a/crates/sqlbuiltins/src/functions/generate_series.rs
+++ b/crates/sqlbuiltins/src/functions/generate_series.rs
@@ -22,12 +22,16 @@ use datafusion_ext::functions::{
 use decimal::Decimal128;
 use futures::Stream;
 use num_traits::Zero;
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct GenerateSeries;
 
 #[async_trait]
 impl TableFunc for GenerateSeries {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Local
+    }
     fn name(&self) -> &str {
         "generate_series"
     }

--- a/crates/sqlbuiltins/src/functions/iceberg.rs
+++ b/crates/sqlbuiltins/src/functions/iceberg.rs
@@ -12,6 +12,7 @@ use datafusion_ext::local_hint::LocalTableHint;
 use datasources::common::url::{DatasourceUrl, DatasourceUrlType};
 use datasources::lake::iceberg::table::IcebergTable;
 use datasources::lake::LakeStorageOptions;
+use protogen::metastore::types::catalog::RuntimePreference;
 use protogen::metastore::types::options::CredentialsOptions;
 
 /// Scan an iceberg table.
@@ -20,6 +21,9 @@ pub struct IcebergScan;
 
 #[async_trait]
 impl TableFunc for IcebergScan {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "iceberg_scan"
     }
@@ -53,6 +57,9 @@ pub struct IcebergSnapshots;
 
 #[async_trait]
 impl TableFunc for IcebergSnapshots {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "iceberg_snapshots"
     }
@@ -112,6 +119,9 @@ pub struct IcebergDataFiles;
 
 #[async_trait]
 impl TableFunc for IcebergDataFiles {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "iceberg_data_files"
     }

--- a/crates/sqlbuiltins/src/functions/mongo.rs
+++ b/crates/sqlbuiltins/src/functions/mongo.rs
@@ -6,12 +6,16 @@ use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
 use datasources::mongodb::{MongoAccessor, MongoTableAccessInfo};
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadMongoDb;
 
 #[async_trait]
 impl TableFunc for ReadMongoDb {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "read_mongodb"
     }

--- a/crates/sqlbuiltins/src/functions/mysql.rs
+++ b/crates/sqlbuiltins/src/functions/mysql.rs
@@ -6,12 +6,16 @@ use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
 use datasources::mysql::{MysqlAccessor, MysqlTableAccess};
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadMysql;
 
 #[async_trait]
 impl TableFunc for ReadMysql {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "read_mysql"
     }

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -20,7 +20,7 @@ use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{
     FromFuncParamValue, FuncParamValue, IdentValue, TableFunc, TableFuncContextProvider,
 };
-use datafusion_ext::local_hint::LocalTableHint;
+
 use datasources::common::url::{DatasourceUrl, DatasourceUrlType};
 use datasources::object_store::gcs::GcsStoreAccess;
 use datasources::object_store::http::HttpStoreAccess;
@@ -249,9 +249,7 @@ async fn get_table_provider(
         ObjStoreAccessor::new(access).map_err(|e| ExtensionError::Access(Box::new(e)))?;
 
     let mut objects = Vec::new();
-    let mut is_local = true; // Sets to false if any of the data sources aren't a file.
     for loc in locations {
-        is_local = loc.datasource_url_type() == DatasourceUrlType::File && is_local;
         let list = accessor
             .list_globbed(loc.path())
             .await
@@ -269,11 +267,7 @@ async fn get_table_provider(
         .await
         .map_err(|e| ExtensionError::Access(Box::new(e)))?;
 
-    if is_local {
-        Ok(Arc::new(LocalTableHint(provider)))
-    } else {
-        Ok(provider)
-    }
+    Ok(provider)
 }
 
 fn get_store_access(

--- a/crates/sqlbuiltins/src/functions/postgres.rs
+++ b/crates/sqlbuiltins/src/functions/postgres.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
-use datafusion_ext::functions::{
-    FuncParamValue, TableFunc, TableFuncContextProvider,
-};
+use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
 use datasources::postgres::{PostgresAccess, PostgresTableProvider, PostgresTableProviderConfig};
 use protogen::metastore::types::catalog::RuntimePreference;
 

--- a/crates/sqlbuiltins/src/functions/postgres.rs
+++ b/crates/sqlbuiltins/src/functions/postgres.rs
@@ -4,14 +4,20 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
-use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
+use datafusion_ext::functions::{
+    FuncParamValue, TableFunc, TableFuncContextProvider,
+};
 use datasources::postgres::{PostgresAccess, PostgresTableProvider, PostgresTableProviderConfig};
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadPostgres;
 
 #[async_trait]
 impl TableFunc for ReadPostgres {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "read_postgres"
     }

--- a/crates/sqlbuiltins/src/functions/snowflake.rs
+++ b/crates/sqlbuiltins/src/functions/snowflake.rs
@@ -6,12 +6,16 @@ use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
 use datasources::snowflake::{SnowflakeAccessor, SnowflakeDbConnection, SnowflakeTableAccess};
+use protogen::metastore::types::catalog::RuntimePreference;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadSnowflake;
 
 #[async_trait]
 impl TableFunc for ReadSnowflake {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
     fn name(&self) -> &str {
         "read_snowflake"
     }

--- a/crates/sqlbuiltins/src/functions/virtual_listing.rs
+++ b/crates/sqlbuiltins/src/functions/virtual_listing.rs
@@ -15,6 +15,7 @@ use datasources::mongodb::MongoAccessor;
 use datasources::mysql::MysqlAccessor;
 use datasources::postgres::PostgresAccess;
 use datasources::snowflake::{SnowflakeAccessor, SnowflakeDbConnection};
+use protogen::metastore::types::catalog::RuntimePreference;
 use protogen::metastore::types::options::{
     DatabaseOptions, DatabaseOptionsBigQuery, DatabaseOptionsMongo, DatabaseOptionsMysql,
     DatabaseOptionsPostgres, DatabaseOptionsSnowflake,
@@ -25,6 +26,9 @@ pub struct ListSchemas;
 
 #[async_trait]
 impl TableFunc for ListSchemas {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Unspecified
+    }
     fn name(&self) -> &str {
         "list_schemas"
     }
@@ -67,6 +71,9 @@ pub struct ListTables;
 
 #[async_trait]
 impl TableFunc for ListTables {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Unspecified
+    }
     fn name(&self) -> &str {
         "list_tables"
     }

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -268,8 +268,7 @@ impl<'a> Dispatcher<'a> {
         let prov = resolve_func
             .unwrap()
             .create_provider(self, args, opts)
-            .await
-            .map_err(|_| DispatchError::InvalidDispatch("failed to create provider"))?;
+            .await?;
         Ok(prov)
     }
 }

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -87,6 +87,9 @@ pub enum ExecError {
     #[error(transparent)]
     ProtoConvError(#[from] protogen::errors::ProtoConvError),
 
+    #[error(transparent)]
+    ExtensionError(#[from] datafusion_ext::errors::ExtensionError),
+
     #[error("Unable to retrieve ssh tunnel connection: {0}")]
     MissingSshTunnel(Box<crate::errors::ExecError>),
 

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -1,9 +1,11 @@
 use crate::context::local::LocalSessionContext;
+use crate::dispatch::DispatchError;
 use crate::dispatch::Dispatcher;
 use crate::errors::ExecError;
 use crate::functions::BuiltinScalarFunction;
 use crate::functions::PgFunctionBuilder;
 use crate::planner::errors::PlanError;
+use crate::remote::client::RemoteSessionClient;
 use crate::resolve::EntryResolver;
 use crate::resolve::ResolvedEntry;
 use async_trait::async_trait;
@@ -18,19 +20,19 @@ use datafusion::logical_expr::AggregateUDF;
 use datafusion::logical_expr::ScalarUDF;
 use datafusion::logical_expr::TableSource;
 use datafusion::sql::TableReference;
-use datafusion_ext::functions::TableFunc;
-use datafusion_ext::functions::TableFuncContextProvider;
+use datafusion_ext::functions::FuncParamValue;
 use datafusion_ext::local_hint::LocalTableHint;
 use datafusion_ext::planner::AsyncContextProvider;
-use datafusion_ext::vars::SessionVars;
-use protogen::metastore::types::catalog::{CatalogEntry, CredentialsEntry, DatabaseEntry};
+
+use protogen::metastore::types::catalog::CatalogEntry;
+use protogen::metastore::types::catalog::DatabaseEntry;
+use protogen::metastore::types::catalog::FunctionEntry;
+use protogen::metastore::types::catalog::RuntimePreference;
 use protogen::metastore::types::options::TableOptions;
 use protogen::rpcsrv::types::service::ResolvedTableReference;
-use sqlbuiltins::builtins::DEFAULT_CATALOG;
 use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::error;
 
 /// Partial context provider with table providers required to fulfill a single
 /// query.
@@ -61,6 +63,65 @@ impl<'a> PartialContextProvider<'a> {
         })
     }
 
+    fn new_dispatcher(&self) -> Dispatcher {
+        Dispatcher::new(
+            self.ctx.get_session_catalog(),
+            self.ctx.get_native_tables(),
+            self.ctx.get_metrics(),
+            &self.resolver.temp_objects,
+            self.ctx,
+            self.ctx.df_ctx(),
+            self.ctx.get_session_vars().is_cloud_instance(),
+        )
+    }
+
+    async fn dispatch_function_local(
+        &self,
+        func: &FunctionEntry,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
+    ) -> Result<Arc<dyn TableProvider>, DispatchError> {
+        self.new_dispatcher()
+            .dispatch_function(func, args, opts)
+            .await
+    }
+
+    async fn dispatch_function_remote(
+        &self,
+        func: &FunctionEntry,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
+        client: &mut RemoteSessionClient,
+    ) -> Result<Arc<dyn TableProvider>, ExecError> {
+        client
+            .dispatch_access(
+                ResolvedTableReference::Internal {
+                    table_oid: func.meta.id,
+                },
+                Some(args),
+                Some(opts),
+            )
+            .await
+    }
+
+    async fn dispatch_catalog_entry_local(
+        &self,
+        ent: &CatalogEntry,
+    ) -> Result<Arc<dyn TableProvider>, DispatchError> {
+        self.new_dispatcher().dispatch(ent.clone()).await
+    }
+
+    async fn dispatch_external_entry_local(
+        &self,
+        db_ent: &DatabaseEntry,
+        schema: &str,
+        name: &str,
+    ) -> Result<Arc<dyn TableProvider>, DispatchError> {
+        self.new_dispatcher()
+            .dispatch_external(db_ent, schema, name)
+            .await
+    }
+
     /// Get the table provider from the table reference.
     pub async fn table_provider(
         &mut self,
@@ -70,7 +131,7 @@ impl<'a> PartialContextProvider<'a> {
             Some(provider) => provider.clone(),
             None => {
                 let provider = self
-                    .table_for_reference(TableReference::from(&name))
+                    .resolve_reference(TableReference::from(&name), None, None)
                     .await?;
                 self.providers.insert(name, provider.clone());
                 provider
@@ -82,9 +143,11 @@ impl<'a> PartialContextProvider<'a> {
 
     /// Find a table provider the given reference, taking into account the
     /// session's search path.
-    async fn table_for_reference(
+    async fn resolve_reference(
         &mut self,
         reference: TableReference<'_>,
+        args: Option<Vec<FuncParamValue>>,
+        opts: Option<HashMap<String, FuncParamValue>>,
     ) -> Result<Arc<dyn TableProvider>, PlanError> {
         // Try to read from the environment first.
         //
@@ -106,165 +169,206 @@ impl<'a> PartialContextProvider<'a> {
         let ent = self
             .resolver
             .resolve_entry_from_reference(reference.clone())?;
+        use ResolvedEntry::*;
+        let provider = match (ent, self.ctx.exec_client()) {
+            // TODO: Views will likely need to be handled a bit
+            // differently in the future.
+            //
+            // Given the following view:
+            //
+            // `create view v1 as select local_table cross join remote_table`
+            //
+            // And the following query:
+            //
+            // `select * from v1`
+            //
+            // Will mean that the client will be streaming 2 sets of
+            // record batches, not just one, as would be optimal.
+            //
+            // 1. The client needs to upload the results of
+            // `local_table`.
+            // 2. The client will then receive the results of the
+            // cross join, but then needs upload that so that the
+            // rest of the query can continue to execute remotely.
+            (Entry(ent @ CatalogEntry::View(_)), _) => self.new_dispatcher().dispatch(ent).await?,
 
-        // If we have a remote session configured, do some selective dispatching
-        // remotely.
-        if let Some(mut client) = self.ctx.exec_client() {
-            match &ent {
-                // References to external databases should always resolve
-                // remotely.
-                ResolvedEntry::NeedsExternalResolution {
+            // --- LOCAL RESOLUTION ---
+            // (function , no remote client)
+            (Entry(CatalogEntry::Function(ref f)), None) => {
+                let args = args.unwrap_or_default();
+                let opts = opts.unwrap_or_default();
+
+                self.dispatch_function_local(f, args, opts).await?
+            }
+
+            // (native entry, no remote client)
+            (Entry(ent), None) => self.dispatch_catalog_entry_local(&ent).await?,
+            // (external entry, no remote client)
+            (
+                NeedsExternalResolution {
                     db_ent,
                     schema,
                     name,
-                } => {
-                    let prov = client
-                        .dispatch_access(ResolvedTableReference::External {
+                },
+                None,
+            ) => {
+                self.dispatch_external_entry_local(db_ent, &schema, &name)
+                    .await?
+            }
+
+            // --- REMOTE RESOLUTION ---
+            // (local entry, remote client)
+            (Entry(ref ent @ CatalogEntry::Table(ref t)), Some(client)) => {
+                self.handle_table_entry_dispatch(ent, t, client, args, opts)
+                    .await?
+            }
+
+            (Entry(CatalogEntry::Function(ref f)), Some(client)) => {
+                self.handle_function_dispatch(f, args, opts, client).await?
+            }
+
+            // (native entry, remote client)
+            (Entry(ent), Some(client)) => {
+                self.handle_catalog_entry_dispatch(ent, client, args, opts)
+                    .await?
+            }
+            // (external entry, remote client)
+            (
+                NeedsExternalResolution {
+                    db_ent,
+                    schema,
+                    name,
+                },
+                Some(mut client),
+            ) => {
+                client
+                    .dispatch_access(
+                        ResolvedTableReference::External {
                             database: db_ent.meta.name.clone(),
                             schema: schema.clone().into_owned(),
                             name: name.clone().into_owned(),
-                        })
-                        .await?;
-                    return Ok(Arc::new(prov));
-                }
-
-                // Only resolve native and external tables remotely.
-                //
-                // Temp and system tables should be handled locally.
-                ResolvedEntry::Entry(ent) => {
-                    // Anything that should be resolved locally should not go
-                    // to server for resolution.
-                    let should_resolve_local = match &ent {
-                        CatalogEntry::Table(t) => {
-                            matches!(&t.options, TableOptions::Debug(_) | TableOptions::Local(_))
-                        }
-                        // TODO: Views will likely need to be handled a bit
-                        // differently in the future.
-                        //
-                        // Given the following view:
-                        //
-                        // `create view v1 as select local_table cross join remote_table`
-                        //
-                        // And the following query:
-                        //
-                        // `select * from v1`
-                        //
-                        // Will mean that the client will be streaming 2 sets of
-                        // record batches, not just one, as would be optimal.
-                        //
-                        // 1. The client needs to upload the results of
-                        // `local_table`.
-                        // 2. The client will then receive the results of the
-                        // cross join, but then needs upload that so that the
-                        // rest of the query can continue to execute remotely.
-                        CatalogEntry::View(_) => true,
-                        _ => false,
-                    };
-                    let meta = ent.get_meta();
-                    let should_resolve_local = meta.is_temp || meta.builtin || should_resolve_local;
-                    if !should_resolve_local {
-                        let prov = client
-                            .dispatch_access(ResolvedTableReference::Internal {
-                                table_oid: meta.id,
-                            })
-                            .await?;
-                        return Ok(Arc::new(prov));
-                    }
-                }
+                        },
+                        args,
+                        opts,
+                    )
+                    .await?
             }
-        }
-
-        let dispatcher = Dispatcher::new(
-            self.ctx.get_session_catalog(),
-            self.ctx.get_native_tables(),
-            self.ctx.get_metrics(),
-            &self.resolver.temp_objects,
-            self.ctx,
-            self.ctx.df_ctx(),
-            self.ctx.get_session_vars().is_cloud_instance(),
-        );
-
-        let provider = match ent {
-            ResolvedEntry::Entry(ent) => dispatcher.dispatch(ent).await?,
-            ResolvedEntry::NeedsExternalResolution {
-                db_ent,
-                schema,
-                name,
-            } => dispatcher.dispatch_external(db_ent, &schema, &name).await?,
-        };
-
-        // TODO: See <https://github.com/GlareDB/glaredb/issues/1657#issuecomment-1696219544>
-        let provider = if self.ctx.exec_client().is_some() {
-            Arc::new(LocalTableHint(provider))
-        } else {
-            provider
         };
 
         Ok(provider)
     }
 
-    /// Find a table function with the given reference, taking into account the
-    /// session's search path.
-    fn table_function_for_reference(
-        &self,
-        reference: TableReference<'_>,
-    ) -> Option<Arc<dyn TableFunc>> {
-        // TODO: Refactor this to resolve properly.
+    async fn handle_catalog_entry_dispatch(
+        &mut self,
+        ent: CatalogEntry,
+        mut client: RemoteSessionClient,
+        args: Option<Vec<FuncParamValue>>,
+        opts: Option<HashMap<String, FuncParamValue>>,
+    ) -> Result<Arc<dyn TableProvider>, PlanError> {
+        let meta = ent.get_meta();
+        let should_resolve_local = meta.is_temp || meta.builtin;
+        Ok(if should_resolve_local {
+            self.dispatch_catalog_entry_local(&ent).await?
+        } else {
+            client
+                .dispatch_access(
+                    ResolvedTableReference::Internal { table_oid: meta.id },
+                    args,
+                    opts,
+                )
+                .await?
+        })
+    }
 
-        let catalog = self.ctx.get_session_catalog();
-
-        let resolve_func = |schema: String, name| {
-            match catalog.resolve_entry(DEFAULT_CATALOG, &schema, name) {
-                Some(CatalogEntry::Function(func)) => {
-                    if func.meta.builtin {
-                        if let Some(func_impl) = BUILTIN_TABLE_FUNCS.find_function(&func.meta.name)
-                        {
-                            Some(func_impl)
-                        } else {
-                            // This can happen if we're in the middle of
-                            // a deploy and builtin functions were
-                            // added/removed.
-                            error!(name = %func.meta.name, "missing builtin function impl");
-                            None
-                        }
-                    } else {
-                        // We only have builtin functions right now.
-                        None
-                    }
-                }
-                _ => None,
-            }
-        };
-
-        match &reference {
-            TableReference::Bare { table } => {
-                for schema in self.ctx.implicit_search_paths() {
-                    if let Some(func_impl) = resolve_func(schema, table) {
-                        return Some(func_impl);
-                    }
-                }
-                None
-            }
-            TableReference::Partial { schema, table } => resolve_func(schema.to_string(), table),
-            TableReference::Full {
-                catalog,
-                schema,
-                table,
-            } => {
-                if catalog == DEFAULT_CATALOG {
-                    resolve_func(schema.to_string(), table)
-                } else {
-                    None
-                }
-            }
+    async fn handle_function_dispatch(
+        &mut self,
+        func: &protogen::metastore::types::catalog::FunctionEntry,
+        args: Option<Vec<FuncParamValue>>,
+        opts: Option<HashMap<String, FuncParamValue>>,
+        mut client: RemoteSessionClient,
+    ) -> Result<Arc<dyn TableProvider>, PlanError> {
+        if args.is_none() && opts.is_none() {
+            return Err(PlanError::Internal(
+                "function should have args or opts at this point".to_string(),
+            ));
         }
+        let args = args.unwrap_or_default();
+        let opts = opts.unwrap_or_default();
+
+        Ok(match func.runtime_preference {
+            RuntimePreference::Local => self.dispatch_function_local(func, args, opts).await?,
+            RuntimePreference::Remote => {
+                self.dispatch_function_remote(func, args, opts, &mut client)
+                    .await?
+            }
+            RuntimePreference::Unspecified => {
+                let resolve_func = if func.meta.builtin {
+                    BUILTIN_TABLE_FUNCS
+                        .find_function(&func.meta.name)
+                        .expect("function should always exist for builtins")
+                } else {
+                    return Err(PlanError::Internal(
+                        "only builtin functions supported at this timef".to_string(),
+                    ));
+                };
+
+                let actual_runtime = resolve_func
+                    .detect_runtime(&args)
+                    .map_err(DispatchError::ExtensionError)?;
+
+                match actual_runtime {
+                    RuntimePreference::Local => {
+                        self.new_dispatcher()
+                            .dispatch_function(func, args, opts)
+                            .await?
+                    }
+                    RuntimePreference::Remote => {
+                        client
+                            .dispatch_access(
+                                ResolvedTableReference::Internal {
+                                    table_oid: func.meta.id,
+                                },
+                                Some(args),
+                                Some(opts),
+                            )
+                            .await?
+                    }
+                    RuntimePreference::Unspecified => panic!(
+                        "function should have a specified runtime at this point. This is a bug."
+                    ),
+                }
+            }
+        })
+    }
+
+    async fn handle_table_entry_dispatch(
+        &mut self,
+        ent: &CatalogEntry,
+        t: &protogen::metastore::types::catalog::TableEntry,
+        mut client: RemoteSessionClient,
+        args: Option<Vec<FuncParamValue>>,
+        opts: Option<HashMap<String, FuncParamValue>>,
+    ) -> Result<Arc<dyn TableProvider>, PlanError> {
+        let meta = ent.get_meta();
+        let should_resolve_local = meta.is_temp
+            || meta.builtin
+            || matches!(&t.options, TableOptions::Debug(_) | TableOptions::Local(_));
+        Ok(if !should_resolve_local {
+            client
+                .dispatch_access(
+                    ResolvedTableReference::Internal { table_oid: meta.id },
+                    args,
+                    opts,
+                )
+                .await?
+        } else {
+            self.dispatch_catalog_entry_local(ent).await?
+        })
     }
 }
 
 #[async_trait]
 impl<'a> AsyncContextProvider for PartialContextProvider<'a> {
-    type TableFuncContextProvider = TableFnCtxProvider<'a>;
-
     async fn get_table_provider(
         &mut self,
         name: TableReference<'_>,
@@ -296,41 +400,19 @@ impl<'a> AsyncContextProvider for PartialContextProvider<'a> {
         None
     }
 
-    fn get_table_func(&mut self, name: TableReference<'_>) -> Option<Arc<dyn TableFunc>> {
-        self.table_function_for_reference(name)
-    }
-
-    fn table_fn_ctx_provider(&self) -> Self::TableFuncContextProvider {
-        Self::TableFuncContextProvider {
-            ctx: self.ctx,
-            state: self.state,
-        }
+    async fn get_table_func(
+        &mut self,
+        name: TableReference<'_>,
+        args: Vec<FuncParamValue>,
+        opts: HashMap<String, FuncParamValue>,
+    ) -> Option<Arc<dyn TableSource>> {
+        self.resolve_reference(name, Some(args), Some(opts))
+            .await
+            .map(|p| Arc::new(DefaultTableSource::new(p)) as _)
+            .ok()
     }
 
     fn options(&self) -> &ConfigOptions {
         self.state.config_options()
-    }
-}
-
-pub struct TableFnCtxProvider<'a> {
-    ctx: &'a LocalSessionContext,
-    state: &'a SessionState,
-}
-
-impl<'a> TableFuncContextProvider for TableFnCtxProvider<'a> {
-    fn get_database_entry(&self, name: &str) -> Option<&DatabaseEntry> {
-        self.ctx.get_session_catalog().resolve_database(name)
-    }
-
-    fn get_credentials_entry(&self, name: &str) -> Option<&CredentialsEntry> {
-        self.ctx.get_session_catalog().resolve_credentials(name)
-    }
-
-    fn get_session_vars(&self) -> SessionVars {
-        self.ctx.get_session_vars()
-    }
-
-    fn get_session_state(&self) -> &SessionState {
-        self.state
     }
 }

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -405,11 +405,11 @@ impl<'a> AsyncContextProvider for PartialContextProvider<'a> {
         name: TableReference<'_>,
         args: Vec<FuncParamValue>,
         opts: HashMap<String, FuncParamValue>,
-    ) -> Option<Arc<dyn TableSource>> {
-        self.resolve_reference(name, Some(args), Some(opts))
+    ) -> DataFusionResult<Arc<dyn TableSource>> {
+        self.resolve_reference(name.to_owned_reference(), Some(args), Some(opts))
             .await
             .map(|p| Arc::new(DefaultTableSource::new(p)) as _)
-            .ok()
+            .map_err(|e| DataFusionError::External(Box::new(e)))
     }
 
     fn options(&self) -> &ConfigOptions {


### PR DESCRIPTION
So this moves all of the tablefunc exec logic into the dispatcher (similar to how we are doing with tables). 

The functions are a bit more dynamic than the tables and as such, we sometimes need to determine the execution preference at runtime. 

**Ideally I wanted to do this during physical planning**. 

However, the logical planner needs the schema, so we needed to move the logic further upstream and determine if the function should run remote or locally before we get to the LogicalPlan. Otherwise we end up performing schema scans locally, and table scans remotely which causes the state to get out of sync.


--- 
Implicitly we know that: 
- some functions will always to run remotely when possible (s3, postgres, bigquery,...)
- some always locally (local filesystem)
- some determined at runtime
---

## So in order to determine the logic prior to planning, we had to do 2 things. 


- First we add some metadata to the function entries specifying their "runtime_preference" (Local, Remote, Unspecified)

- Next, we look at that metadata during dispatch.
  - we can easily rule out (Local & Remote preferences)
  - `Unspecified` requires us to inspect the args to determine the true destination at runtime.  

If at this point, we still don't know where to execute it, it should error as it would indicate a bug in our resolution logic. 

We could probably expand this metadata hint to other catalog entries as well. 