### PR TITLE
fix: explains

### DIFF
--- a/crates/sqlexec/src/planner/physical_plan/remote_scan.rs
+++ b/crates/sqlexec/src/planner/physical_plan/remote_scan.rs
@@ -3,6 +3,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::SessionState;
 use datafusion::execution::TaskContext;
+use datafusion::physical_plan::display::ProjectSchemaDisplay;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
@@ -129,6 +130,11 @@ impl ExecutionPlan for RemoteScanExec {
 
 impl DisplayAs for RemoteScanExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RemoteScanExec")
+        write!(
+            f,
+            "RemoteScanExec: projection={}",
+            ProjectSchemaDisplay(&self.projected_schema)
+        )?;
+        Ok(())
     }
 }

--- a/crates/sqlexec/src/remote/rewriter.rs
+++ b/crates/sqlexec/src/remote/rewriter.rs
@@ -35,10 +35,10 @@ impl TreeNodeRewriter for LocalSideTableRewriter {
     type N = LogicalPlan;
 
     fn pre_visit(&mut self, node: &Self::N) -> Result<RewriteRecursion> {
-        if matches!(node, LogicalPlan::TableScan(..)) {
-            Ok(RewriteRecursion::Mutate)
-        } else {
-            Ok(RewriteRecursion::Continue)
+        match node {
+            LogicalPlan::Explain(_) => Ok(RewriteRecursion::Stop),
+            LogicalPlan::TableScan(_) => Ok(RewriteRecursion::Mutate),
+            _ => Ok(RewriteRecursion::Continue),
         }
     }
 


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/1642
<img width="1043" alt="image" src="https://github.com/GlareDB/glaredb/assets/21327470/e05b21be-6e91-407d-a3a3-ec8105cfc49b">


If it's an `Explain`, we don't need/want to rewrite the query at all. 

also adds the projection to the `RemoteScanExec`. Eventually we'd want that to be fully transparent in the explain instead of a black box, but this is at least a start and better indicates to the user what is happening with the query.