### PR TITLE
feat: Serialize InterleaveExec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,26 +131,41 @@ jobs:
 
       - name: SQL Logic Tests (RPC)
         run: |
-          just sql-logic-tests -v --rpc-test 'sqllogictests/rpc' \
-                                             'sqllogictests/time' \
-                                             'sqllogictests/cast/*' \
+          just sql-logic-tests -v --rpc-test 'sqllogictests/cast/*' \
                                              'sqllogictests/cte/*' \
+                                             'sqllogictests/joins/*' \
+                                             'sqllogictests/topn/*' \
+                                             'sqllogictests/aggregates' \
                                              'sqllogictests/alter' \
                                              'sqllogictests/create_table' \
                                              'sqllogictests/credentials' \
                                              'sqllogictests/csv' \
                                              'sqllogictests/debug' \
+                                             'sqllogictests/delete' \
                                              'sqllogictests/demo_pg' \
                                              'sqllogictests/drop' \
                                              'sqllogictests/infer' \
+                                             'sqllogictests/information_schema' \
                                              'sqllogictests/metabase' \
                                              'sqllogictests/name' \
                                              'sqllogictests/object_names' \
+                                             'sqllogictests/rpc' \
                                              'sqllogictests/select' \
+                                             'sqllogictests/simple' \
+                                             'sqllogictests/table' \
+                                             'sqllogictests/time' \
                                              'sqllogictests/tunnels' \
+                                             'sqllogictests/update' \
                                              'sqllogictests/vars' \
                                              'sqllogictests/views' \
-                                             'sqllogictests/simple'
+                                             'sqllogictests/virtual_catalog'
+
+          # Run a single set of remote data source tests for now. The rest should be
+          # added when rpc is further along.
+          POSTGRES_TEST_DB=$(./scripts/create-test-postgres-db.sh)
+          export POSTGRES_CONN_STRING=$(echo "$POSTGRES_TEST_DB" | sed -n 1p)
+
+          just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_postgres/*'
 
       - name: PG Protocol Tests
         run: ./scripts/protocol-test.sh

--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -287,10 +287,13 @@ pub struct ValuesExec {
 }
 
 #[derive(Clone, PartialEq, Message)]
+pub struct InterleaveExec {}
+
+#[derive(Clone, PartialEq, Message)]
 pub struct ExecutionPlanExtension {
     #[prost(
         oneof = "ExecutionPlanExtensionType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27"
     )]
     pub inner: Option<ExecutionPlanExtensionType>,
 }
@@ -354,4 +357,6 @@ pub enum ExecutionPlanExtensionType {
     // Other
     #[prost(message, tag = "26")]
     ValuesExec(ValuesExec),
+    #[prost(message, tag = "27")]
+    InterleaveExec(InterleaveExec),
 }


### PR DESCRIPTION
Adds serialization for InterleaveExec which allows unions to work.

Also enabled more SLT tests now that more of the catalog is working.

Closes https://github.com/GlareDB/glaredb/issues/1678