### PR TITLE
fix: Don't union object store sources if only one source

### DIFF
--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -99,7 +99,12 @@ impl TableProvider for MultiSourceTableProvider {
                 .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?;
             plans.push(plan);
         }
-        Ok(Arc::new(UnionExec::new(plans)) as _)
+
+        if plans.len() == 1 {
+            Ok(plans.pop().unwrap())
+        } else {
+            Ok(Arc::new(UnionExec::new(plans)))
+        }
     }
 }
 


### PR DESCRIPTION
The extra UnionExec impacts some optimization rules (particularly repartitioning).