### PR TITLE
chore: Tighten up execution response error

### DIFF
--- a/crates/sqlexec/src/planner/physical_plan/remote_exec.rs
+++ b/crates/sqlexec/src/planner/physical_plan/remote_exec.rs
@@ -164,9 +164,12 @@ impl Stream for ExecutionResponseBatchStream {
                         None => Poll::Ready(None),
                     }
                 }
-                Err(e) => Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                    "failed to pull next batch from stream: {e}"
-                ))))),
+                Err(e) => {
+                    let msg = e.message();
+                    Poll::Ready(Some(Err(DataFusionError::Execution(format!(
+                        "Remote node error: {msg}"
+                    )))))
+                }
             },
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),


### PR DESCRIPTION
Before:

```
> create table t1 (a int);
Error: Execution error: failed to pull next batch from stream: status: Unknown, message: "Execution error: failed to create table in catalog: Failed Metastore request: Duplicate name: t1", details: [], metadata: MetadataMap { headers: {} }
```

After:

```
> create table t1 (a int);
Error: Execution error: Remote node error: Execution error: failed to create table in catalog: Failed Metastore request: Duplicate name: t1
```

Closes https://github.com/GlareDB/glaredb/issues/1713