### PR TITLE
feat: add further optimizations for hybrid unions

### DIFF
--- a/crates/datafusion_ext/src/runtime/group_pull_up.rs
+++ b/crates/datafusion_ext/src/runtime/group_pull_up.rs
@@ -82,7 +82,6 @@ impl PhysicalOptimizerRule for RuntimeGroupPullUp {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         plan.transform_up(&|plan| {
             if !can_pull_through_node(plan.as_ref()) {
-                println!("can't pull through node");
                 return Ok(Transformed::No(plan));
             }
 


### PR DESCRIPTION
groups related children in unions 


for example: takes a query 

```sql
select * from local where c = 1
union (select * from local where c = 2)
union (select * from remote where c = 3)
```


and rewrites the initial plan of 

```mermaid
graph TD

UnionExec --> FilterExec1 & FilterExec2 & FilterExec3
  FilterExec1 --> RemoteExec1
  FilterExec2 --> LocalExec1
  FilterExec3 --> LocalExec2
subgraph Remote
  RemoteExec1 --> EmptyExec1["EmptyExec (test_schema)"]
end

subgraph Local1[Local]
  LocalExec1 --> EmptyExec2["EmptyExec (test_schema)"]
end

subgraph Local2[Local]
  LocalExec2 --> EmptyExec3["EmptyExec (test_schema)"]
end
```

to 
```mermaid
graph TD
  UnionExec --> RemoteExec & LocalExec
  subgraph Local
  LocalExec -->
  UnionExecLocal[UnionExec] --> LocalExec1 & LocalExec2
  LocalExec1 --> EmptyExec2["EmptyExec (test_schema)"]
  LocalExec2 --> EmptyExec3["EmptyExec (test_schema)"]
end 
subgraph Remote 
  RemoteExec --> FilterExec --> EmptyExec1["EmptyExec (test_schema)"]
end
```