### PR TITLE
feat: more logging options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,9 +980,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
+checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -3153,6 +3153,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 name = "logutil"
 version = "0.4.0"
 dependencies = [
+ "chrono",
  "tracing",
  "tracing-log",
  "tracing-subscriber",

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -1,8 +1,25 @@
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use glaredb::args::LocalArgs;
 use glaredb::commands::Commands;
 use tracing::info;
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+enum LoggingMode {
+    #[default]
+    Pretty,
+    Json,
+    Compact,
+}
+
+impl From<LoggingMode> for logutil::LoggingMode {
+    fn from(mode: LoggingMode) -> Self {
+        match mode {
+            LoggingMode::Pretty => logutil::LoggingMode::Pretty,
+            LoggingMode::Json => logutil::LoggingMode::Json,
+            LoggingMode::Compact => logutil::LoggingMode::Compact,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[clap(name = "GlareDB")]
@@ -14,8 +31,8 @@ struct Cli {
     verbose: u8,
 
     /// Output logs in json format.
-    #[clap(long)]
-    json_logging: bool,
+    #[clap(long, value_enum)]
+    log_mode: Option<LoggingMode>,
 
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -38,9 +55,9 @@ fn main() -> Result<()> {
 
     // Disable logging when running locally since it'll clobber the repl
     // _unless_ the user specified a logging related option.
-    match (&command, cli.json_logging, cli.verbose) {
-        (Commands::Local { .. }, false, 0) => (),
-        _ => logutil::init(cli.verbose, cli.json_logging),
+    match (&command, cli.log_mode, cli.verbose) {
+        (Commands::Local { .. }, None, 0) => (),
+        _ => logutil::init(cli.verbose, cli.log_mode.unwrap_or_default().into()),
     }
 
     info!(version = env!("CARGO_PKG_VERSION"), "starting...");

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use glaredb::args::LocalArgs;
 use glaredb::commands::Commands;
-use tracing::info;
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
 enum LoggingMode {
     #[default]
@@ -59,8 +58,6 @@ fn main() -> Result<()> {
         (Commands::Local { .. }, None, 0) => (),
         _ => logutil::init(cli.verbose, cli.log_mode.unwrap_or_default().into()),
     }
-
-    info!(version = env!("CARGO_PKG_VERSION"), "starting...");
 
     command.run()
 }

--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -5,7 +5,7 @@ use glaredb::commands::Commands;
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
 enum LoggingMode {
     #[default]
-    Pretty,
+    Full,
     Json,
     Compact,
 }
@@ -13,7 +13,7 @@ enum LoggingMode {
 impl From<LoggingMode> for logutil::LoggingMode {
     fn from(mode: LoggingMode) -> Self {
         match mode {
-            LoggingMode::Pretty => logutil::LoggingMode::Pretty,
+            LoggingMode::Full => logutil::LoggingMode::Full,
             LoggingMode::Json => logutil::LoggingMode::Json,
             LoggingMode::Compact => logutil::LoggingMode::Compact,
         }

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -83,7 +83,10 @@ impl RunCommand for ServerArgs {
         let segment_key = segment_key.and_then(|s| if s.is_empty() { None } else { Some(s) });
 
         let auth: Box<dyn LocalAuthenticator> = match password {
-            Some(password) => Box::new(SingleUserAuthenticator { user, password }),
+            Some(password) => Box::new(SingleUserAuthenticator {
+                user: user,
+                password,
+            }),
             None => Box::new(PasswordlessAuthenticator {
                 drop_auth_messages: ignore_pg_auth,
             }),

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -84,7 +84,7 @@ impl RunCommand for ServerArgs {
 
         let auth: Box<dyn LocalAuthenticator> = match password {
             Some(password) => Box::new(SingleUserAuthenticator {
-                user: user,
+                user,
                 password,
             }),
             None => Box::new(PasswordlessAuthenticator {

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -83,10 +83,7 @@ impl RunCommand for ServerArgs {
         let segment_key = segment_key.and_then(|s| if s.is_empty() { None } else { Some(s) });
 
         let auth: Box<dyn LocalAuthenticator> = match password {
-            Some(password) => Box::new(SingleUserAuthenticator {
-                user,
-                password,
-            }),
+            Some(password) => Box::new(SingleUserAuthenticator { user, password }),
             None => Box::new(PasswordlessAuthenticator {
                 drop_auth_messages: ignore_pg_auth,
             }),

--- a/crates/logutil/Cargo.toml
+++ b/crates/logutil/Cargo.toml
@@ -9,3 +9,4 @@ edition = {workspace = true}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json", "env-filter"] }
 tracing-log = "0.1"
+chrono = "0.4.29"

--- a/crates/logutil/src/lib.rs
+++ b/crates/logutil/src/lib.rs
@@ -1,5 +1,5 @@
 //! Utilities for logging and tracing.
-use tracing::{info, subscriber, Level};
+use tracing::{subscriber, trace, Level};
 use tracing_subscriber::{
     filter::EnvFilter,
     fmt::{
@@ -94,7 +94,7 @@ pub fn init(verbosity: impl Into<Verbosity>, mode: LoggingMode) {
     }
     .unwrap();
 
-    info!(set_level = %level, "log level set");
+    trace!(set_level = %level, "log level set");
 }
 
 struct PrettyTime;

--- a/crates/logutil/src/lib.rs
+++ b/crates/logutil/src/lib.rs
@@ -39,7 +39,7 @@ impl From<Verbosity> for Level {
 #[derive(Default)]
 pub enum LoggingMode {
     #[default]
-    Pretty,
+    Full,
     Json,
     Compact,
 }
@@ -83,8 +83,8 @@ pub fn init(verbosity: impl Into<Verbosity>, mode: LoggingMode) {
             let subscriber = json_fmt(level).with_env_filter(env_filter).finish();
             subscriber::set_global_default(subscriber)
         }
-        LoggingMode::Pretty => {
-            let subscriber = pretty_fmt(level).with_env_filter(env_filter).finish();
+        LoggingMode::Full => {
+            let subscriber = full_fmt(level).with_env_filter(env_filter).finish();
             subscriber::set_global_default(subscriber)
         }
         LoggingMode::Compact => {
@@ -122,7 +122,7 @@ fn standard_fmt(level: Level) -> SubscriberBuilder {
         .with_file(true)
 }
 
-fn pretty_fmt(level: Level) -> SubscriberBuilder<Pretty, Format<Pretty>> {
+fn full_fmt(level: Level) -> SubscriberBuilder<Pretty, Format<Pretty>> {
     standard_fmt(level).pretty()
 }
 

--- a/crates/metastore/src/local.rs
+++ b/crates/metastore/src/local.rs
@@ -11,7 +11,7 @@ use tracing::info;
 
 /// Starts an in-process, in-memory metastore.
 pub async fn start_inprocess_inmemory() -> Result<MetastoreServiceClient<Channel>> {
-    info!("starting in-process metastore");
+    info!("Starting in-memory metastore");
     start_inprocess(Arc::new(InMemory::new())).await
 }
 

--- a/crates/metastore/src/srv.rs
+++ b/crates/metastore/src/srv.rs
@@ -33,7 +33,7 @@ pub struct Service {
 impl Service {
     pub fn new(store: Arc<dyn ObjectStore>) -> Service {
         let process_id = Uuid::new_v4();
-        info!(%process_id, "creating new Metastore service with process id");
+        info!(%process_id, "Creating new Metastore service");
 
         let storage = Arc::new(Storage::new(process_id, store));
         Service {

--- a/crates/protogen/src/rpcsrv/types/service.rs
+++ b/crates/protogen/src/rpcsrv/types/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use datafusion::arrow::datatypes::Schema;
 use prost::Message;
@@ -321,6 +321,25 @@ pub enum ResolvedTableReference {
         schema: String,
         name: String,
     },
+}
+
+impl Display for ResolvedTableReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolvedTableReference::Internal { table_oid } => {
+                write!(f, "InternalTableReference({})", table_oid)
+            }
+            ResolvedTableReference::External {
+                database,
+                schema,
+                name,
+            } => write!(
+                f,
+                "{}.{}.{}",
+                database, schema, name
+            ),
+        }
+    }
 }
 
 impl TryFrom<service::ResolvedTableReference> for ResolvedTableReference {

--- a/crates/protogen/src/rpcsrv/types/service.rs
+++ b/crates/protogen/src/rpcsrv/types/service.rs
@@ -333,11 +333,7 @@ impl Display for ResolvedTableReference {
                 database,
                 schema,
                 name,
-            } => write!(
-                f,
-                "{}.{}.{}",
-                database, schema, name
-            ),
+            } => write!(f, "{}.{}.{}", database, schema, name),
         }
     }
 }

--- a/crates/rpcsrv/src/handler.rs
+++ b/crates/rpcsrv/src/handler.rs
@@ -125,7 +125,7 @@ impl RpcHandler {
         &self,
         req: DispatchAccessRequest,
     ) -> Result<TableProviderResponse> {
-        info!(session_id=%req.session_id, table_ref=?req.table_ref, "dispatching table access");
+        info!(session_id=%req.session_id, table_ref=%req.table_ref, "dispatching table access");
         let args = req
             .args
             .map(|args| {
@@ -182,7 +182,7 @@ impl RpcHandler {
     }
 
     fn close_session_inner(&self, req: CloseSessionRequest) -> Result<CloseSessionResponse> {
-        info!(session_id=%req.session_id, "closing session");
+        info!(session_id=%req.session_id, "Closing Session");
         self.sessions.remove(&req.session_id);
         Ok(CloseSessionResponse {})
     }

--- a/crates/testing/src/slt/cli.rs
+++ b/crates/testing/src/slt/cli.rs
@@ -95,7 +95,7 @@ impl Cli {
             return Err(anyhow!("No tests to run. Exiting..."));
         }
 
-        logutil::init(cli.verbose, false);
+        logutil::init(cli.verbose, Default::default());
 
         // Abort the program on panic. This will ensure that slt tests will
         // never pass if there's a panic somewhere.

--- a/testdata/sqllogictests/joins/inner_join/using_join.slt
+++ b/testdata/sqllogictests/joins/inner_join/using_join.slt
@@ -1,4 +1,5 @@
 # Test USING joins
+# Test USING joins
 
 statement ok
 create schema using_join;


### PR DESCRIPTION
depends on #1717

closes #1662

- adds `--log-mode=[compact,full,json]` instead of `--json-logging`
- moves a few info logs to `debug` as they didn't seem to be super useful for non debugging purposes. 
now when i start the server, i can get a more compact output in my terminal without a wall of text

The `full` format is the default & behaves the same as it currently does. 

### Full -- `./glaredb server`
<img width="975" alt="image" src="https://github.com/GlareDB/glaredb/assets/21327470/d19c62a6-da49-4ee0-a67d-8c3b07c6852b">


### Compact -- `./glaredb --log-mode=compact server`
<img width="975" alt="image" src="https://github.com/GlareDB/glaredb/assets/21327470/be85e80a-21b2-457c-9fc1-cf18a6c08e14">

 
 ### JSON -- `./glaredb --log-mode=json server`
<img width="975" alt="image" src="https://github.com/GlareDB/glaredb/assets/21327470/27447873-a73d-4273-9965-8f7768b5850a">


