### PR TITLE
feat: Implement `list_columns` for datasources.

### DIFF
--- a/crates/datasources/src/common/listing.rs
+++ b/crates/datasources/src/common/listing.rs
@@ -4,6 +4,7 @@
 //! data source. These essentially provide a trimmed down information schema.
 
 use async_trait::async_trait;
+use datafusion::arrow::datatypes::Fields;
 
 use super::errors::Result;
 
@@ -20,4 +21,7 @@ pub trait VirtualLister: Sync + Send {
 
     /// List tables for a data source.
     async fn list_tables(&self, schema: &str) -> Result<Vec<String>>;
+
+    /// List columns for a specific table in the datasource.
+    async fn list_columns(&self, schema: &str, table: &str) -> Result<Fields>;
 }

--- a/crates/datasources/src/debug/mod.rs
+++ b/crates/datasources/src/debug/mod.rs
@@ -6,7 +6,7 @@ use crate::common::listing::VirtualLister;
 use async_trait::async_trait;
 use datafusion::arrow::array::Int32Array;
 use datafusion::arrow::datatypes::{
-    DataType, Field, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+    DataType, Field, Fields, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
 };
 use datafusion::arrow::error::Result as ArrowResult;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -157,6 +157,25 @@ impl VirtualLister for DebugVirtualLister {
     async fn list_tables(&self, schema: &str) -> Result<Vec<String>, DatasourceCommonError> {
         let tables = (0..2).map(|i| format!("{schema}_table_{i}")).collect();
         Ok(tables)
+    }
+
+    async fn list_columns(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Fields, DatasourceCommonError> {
+        Ok((0..2)
+            .map(|i| {
+                let name = format!("{schema}_{table}_col_{i}");
+                let datatype = if i % 2 == 0 {
+                    DataType::Utf8
+                } else {
+                    DataType::Int64
+                };
+                let nullable = i % 2 == 0;
+                Field::new(name, datatype, nullable)
+            })
+            .collect())
     }
 }
 

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -12,7 +12,7 @@ use chrono::naive::{NaiveDateTime, NaiveTime};
 use chrono::{DateTime, NaiveDate, Timelike, Utc};
 use datafusion::arrow::array::Decimal128Builder;
 use datafusion::arrow::datatypes::{
-    DataType, Field, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef, TimeUnit,
+    DataType, Field, Fields, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef, TimeUnit,
 };
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::TableProvider;
@@ -461,6 +461,21 @@ WHERE
             virtual_tables.push(table);
         }
         Ok(virtual_tables)
+    }
+
+    async fn list_columns(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Fields, DatasourceCommonError> {
+        use DatasourceCommonError::ListingErrBoxed;
+
+        let (schema, _) = self
+            .get_table_schema(schema, table)
+            .await
+            .map_err(|e| ListingErrBoxed(Box::new(e)))?;
+
+        Ok(schema.fields)
     }
 }
 

--- a/crates/sqlbuiltins/src/functions/mod.rs
+++ b/crates/sqlbuiltins/src/functions/mod.rs
@@ -27,7 +27,7 @@ use self::mysql::ReadMysql;
 use self::object_store::{CSV_SCAN, JSON_SCAN, PARQUET_SCAN};
 use self::postgres::ReadPostgres;
 use self::snowflake::ReadSnowflake;
-use self::virtual_listing::{ListSchemas, ListTables};
+use self::virtual_listing::{ListColumns, ListSchemas, ListTables};
 
 /// Builtin table returning functions available for all sessions.
 pub static BUILTIN_TABLE_FUNCS: Lazy<BuiltinTableFuncs> = Lazy::new(BuiltinTableFuncs::new);
@@ -58,6 +58,7 @@ impl BuiltinTableFuncs {
             // Listing
             Arc::new(ListSchemas),
             Arc::new(ListTables),
+            Arc::new(ListColumns),
             // Series generating
             Arc::new(GenerateSeries),
         ];

--- a/testdata/sqllogictests/virtual_catalog.slt
+++ b/testdata/sqllogictests/virtual_catalog.slt
@@ -17,5 +17,13 @@ SELECT * FROM list_tables(virt_cat, debug_schema);
 debug_schema_table_0
 debug_schema_table_1
 
+# Test list_columns
+
+query TTT
+SELECT * FROM list_columns(virt_cat, debug_schema, "DebugTable");
+----
+debug_schema_DebugTable_col_0	Utf8	t
+debug_schema_DebugTable_col_1	Int64	f
+
 statement ok
 DROP DATABASE virt_cat;

--- a/testdata/sqllogictests_bigquery/external_database.slt
+++ b/testdata/sqllogictests_bigquery/external_database.slt
@@ -23,10 +23,21 @@ ${BIGQUERY_DATASET_ID}
 
 query T
 SELECT table_name
-	FROM list_tables(external_db, ${BIGQUERY_DATASET_ID})
+	FROM list_tables(external_db, "${BIGQUERY_DATASET_ID}")
 	WHERE table_name = 'bikeshare_stations';
 ----
 bikeshare_stations
+
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_db, "${BIGQUERY_DATASET_ID}", bikeshare_stations)
+	WHERE data_type = 'Int64';
+----
+city_asset_number	Int64	t
+council_district	Int64	t
+footprint_length	Int64	t
+number_of_docks		Int64	t
+station_id			Int64	t
 
 statement ok
 DROP DATABASE external_db;

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -12,5 +12,31 @@ SELECT count(*) FROM external_db.test.bikeshare_stations;
 ----
 102
 
+# Test virtual catalog.
+
+query T
+SELECT schema_name FROM list_schemas(external_db)
+	WHERE schema_name = 'test';
+----
+test
+
+query T
+SELECT table_name FROM list_tables(external_db, test)
+	WHERE table_name = 'bikeshare_stations';
+----
+bikeshare_stations
+
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_db, test, bikeshare_stations)
+	WHERE data_type = 'Float64';
+----
+city_asset_number	Float64	t
+council_district	Float64	t
+footprint_length	Float64	t
+footprint_width		Float64	t
+number_of_docks		Float64	t
+station_id			Float64	t
+
 statement ok
 DROP DATABASE external_db;

--- a/testdata/sqllogictests_mysql/external_database.slt
+++ b/testdata/sqllogictests_mysql/external_database.slt
@@ -46,5 +46,16 @@ SELECT table_name
 ----
 bikeshare_stations
 
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_database, glaredb_test, bikeshare_stations)
+	WHERE data_type = 'Int32';
+----
+city_asset_number	Int32	t
+council_district	Int32	t
+footprint_length	Int32	t
+number_of_docks		Int32	t
+station_id			Int32	t
+
 statement ok
 DROP DATABASE external_database;

--- a/testdata/sqllogictests_postgres/external_database.slt
+++ b/testdata/sqllogictests_postgres/external_database.slt
@@ -48,6 +48,17 @@ SELECT table_name
 ----
 bikeshare_stations
 
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_db, public, bikeshare_stations)
+	WHERE data_type = 'Int32';
+----
+city_asset_number	Int32	t
+council_district	Int32	t
+footprint_length	Int32	t
+number_of_docks		Int32	t
+station_id			Int32	t
+
 # Try to query non-existent table.
 statement error failed to find table: 'public.doesnotexist'
 SELECT * FROM external_db.public.doesnotexist

--- a/testdata/sqllogictests_snowflake/external_database.slt
+++ b/testdata/sqllogictests_snowflake/external_database.slt
@@ -31,5 +31,16 @@ SELECT table_name
 ----
 BIKESHARE_STATIONS
 
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_db, "PUBLIC", "BIKESHARE_STATIONS")
+	WHERE data_type = 'Decimal128(38, 0)';
+----
+city_asset_number	Decimal128(38, 0)	t
+council_district	Decimal128(38, 0)	t
+footprint_length	Decimal128(38, 0)	t
+number_of_docks		Decimal128(38, 0)	t
+station_id			Decimal128(38, 0)	t
+
 statement ok
 DROP DATABASE external_db;


### PR DESCRIPTION
Lists the columns information for datasources:

```
> CREATE EXTERNAL DATABASE "PgDb"
::: FROM postgres OPTIONS (
:::   host = 'pg.demo.glaredb.com',
:::   port = '5432',
:::   user = 'demo',
:::   password = 'demo',
:::   database = 'postgres',
::: );
Database created
>
> select * from list_columns("PgDb", public, nation);
┌─────────────┬───────────┬──────────┐
│ column_name │ data_type │ nullable │
│ ──          │ ──        │ ──       │
│ Utf8        │ Utf8      │ Boolean  │
╞═════════════╪═══════════╪══════════╡
│ n_nationkey │ Int32     │ true     │
│ n_name      │ Utf8      │ true     │
│ n_regionkey │ Int64     │ true     │
│ n_comment   │ Utf8      │ true     │
└─────────────┴───────────┴──────────┘
```

Syntax:

```sql
-- All the three arguments are identifiers so they can either be double
-- quoted or quoteless.
--
-- Prefer adding `"` (double quotation marks) on cloud.
--
select * from list_columns("<database>", "<schema>", "<table>");
```

Fixes #1540