### PR TITLE
fix: Add 'proxied_for_database' metadata header

### DIFF
--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -35,6 +35,14 @@
 // connection authentication. The response from Cloud indicates if the
 // connection is authenticated. Cloud also returns additional data about how to
 // connect to the remote compute engine.
+//
+// The proxy will then set the following headers in the metadata map:
+//
+// - "proxied_for_database"
+//
+// Where the value is the UUID of the database (as a string, since that's what
+// we get back from Cloud). The receiving node will then check to ensure that
+// this database matches the database of the session being connected to.
 
 syntax = "proto3";
 
@@ -97,7 +105,7 @@ message DispatchAccessRequest {
   repeated bytes args = 3;
   // gRPC doesn't really provide a way for Option<Vec<T>> or Option<Map<K,V>>
   // so we use a map and just check if it's empty or not in rust.
-  map < string, bytes > options = 4;
+  map<string, bytes> options = 4;
 }
 
 // Execute a physical plan and get the stream.

--- a/crates/proxyutil/src/metadata_constants.rs
+++ b/crates/proxyutil/src/metadata_constants.rs
@@ -5,3 +5,8 @@ pub const PASSWORD_KEY: &str = "password";
 pub const DB_NAME_KEY: &str = "db_name";
 pub const ORG_KEY: &str = "org";
 pub const COMPUTE_ENGINE_KEY: &str = "compute_engine";
+
+/// Metadata constant used by the proxy to set which database the proxy is
+/// proxying the connection for. The server will read the metadata to assert
+/// that the connection has been authenticated for the correct database.
+pub const PROXIED_FOR_DATABASE: &str = "proxied_for_database";

--- a/crates/rpcsrv/src/errors.rs
+++ b/crates/rpcsrv/src/errors.rs
@@ -52,6 +52,9 @@ pub enum RpcsrvError {
     TonicStatus(#[from] tonic::Status),
 
     #[error("{0}")]
+    String(String),
+
+    #[error("{0}")]
     Internal(String),
 }
 

--- a/crates/rpcsrv/src/session.rs
+++ b/crates/rpcsrv/src/session.rs
@@ -21,13 +21,21 @@ pub struct RemoteSession {
     /// Wrapped in an Arc and Mutex since the lifetime of the session is not
     /// tied to a single connection, and so needs to be tracked in a shared map.
     session: Arc<Mutex<RemoteSessionContext>>,
+
+    /// Database this context is for.
+    database_id: Uuid,
 }
 
 impl RemoteSession {
-    pub fn new(context: RemoteSessionContext) -> Self {
+    pub fn new(context: RemoteSessionContext, db_id: Uuid) -> Self {
         RemoteSession {
             session: Arc::new(Mutex::new(context)),
+            database_id: db_id,
         }
+    }
+
+    pub fn get_db_id(&self) -> &Uuid {
+        &self.database_id
     }
 
     /// Get the catalog state suitable for sending back to the requesting


### PR DESCRIPTION
To check that the session we're connecting to is for the database we've been authenticated for.