### PR TITLE
fix: Increase schema infer max rec size to 20480.

### DIFF
--- a/crates/datasources/src/common/mod.rs
+++ b/crates/datasources/src/common/mod.rs
@@ -8,6 +8,7 @@ use datafusion::{
     arrow::datatypes::Schema, execution::context::SessionState, optimizer::utils::conjunction,
     physical_expr::create_physical_expr, physical_plan::PhysicalExpr, prelude::Expr,
 };
+
 pub mod errors;
 pub mod listing;
 pub mod sink;

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -192,9 +192,11 @@ impl TableFunc for ObjScanTableFunc {
 
         let Self(ft, _) = self;
         let ft: Arc<dyn FileFormat> = match ft {
-            FileType::CSV => {
-                Arc::new(CsvFormat::default().with_file_compression_type(file_compression))
-            }
+            FileType::CSV => Arc::new(
+                CsvFormat::default()
+                    .with_file_compression_type(file_compression)
+                    .with_schema_infer_max_rec(Some(20480)),
+            ),
             FileType::PARQUET => Arc::new(ParquetFormat::default()),
             FileType::JSON => {
                 Arc::new(JsonFormat::default().with_file_compression_type(file_compression))

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -412,7 +412,11 @@ impl<'a> ExternalDispatcher<'a> {
 
         let ft: FileType = file_type.parse()?;
         let ft: Arc<dyn FileFormat> = match ft {
-            FileType::CSV => Arc::new(CsvFormat::default().with_file_compression_type(compression)),
+            FileType::CSV => Arc::new(
+                CsvFormat::default()
+                    .with_file_compression_type(compression)
+                    .with_schema_infer_max_rec(Some(20480)),
+            ),
             FileType::PARQUET => Arc::new(ParquetFormat::default()),
             FileType::JSON => {
                 Arc::new(JsonFormat::default().with_file_compression_type(compression))


### PR DESCRIPTION
This is a temporary fix where a CSV file might have an identifier such as `NA` signifying `NULL` in a non-string column.

Context: #1707