### PR TITLE
fix: Lower glibc version for python releases

### DIFF
--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - sean/fabric
   workflow_dispatch:
 
 permissions:
@@ -107,18 +105,18 @@ jobs:
           name: wheels
           path: py-glaredb/dist
 
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   needs: [linux, macos, windows]
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: wheels
-  #     - name: Publish to PyPI
-  #       uses: PyO3/maturin-action@v1
-  #       env:
-  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  #       with:
-  #         command: upload
-  #         args: --skip-existing *
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [linux, macos, windows]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing *

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -31,7 +31,7 @@ jobs:
         run: just protoc
       - uses: actions/setup-python@v4
         with:
-          python-version: {{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - sean/fabric
   workflow_dispatch:
 
 permissions:
@@ -29,10 +31,11 @@ jobs:
         run: just protoc
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: {{ env.PYTHON_VERSION }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          manylinux: "auto"
           docker-options: "--env PROTOC=${{ env.PROTOC }}"
           target: ${{ matrix.target }}
           args:  --release --out dist -m py-glaredb/Cargo.toml
@@ -43,79 +46,79 @@ jobs:
           name: wheels
           path: dist
 
-  windows:
-    runs-on: windows-latest-8-cores
-    strategy:
-      fail-fast: true
-      matrix:
-        target: [x64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: extractions/setup-just@v1
-      - name: install protoc
-        run: just protoc
+  # windows:
+  #   runs-on: windows-latest-8-cores
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target: [x64]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: extractions/setup-just@v1
+  #     - name: install protoc
+  #       run: just protoc
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          architecture: ${{ matrix.target }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
+  #         architecture: ${{ matrix.target }}
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
 
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist
-          working-directory: py-glaredb
-          sccache: 'true'
-          container: 'off'
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: py-glaredb/dist
+  #       with:
+  #         target: ${{ matrix.target }}
+  #         args: --release --out dist
+  #         working-directory: py-glaredb
+  #         sccache: 'true'
+  #         container: 'off'
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: py-glaredb/dist
 
-  macos:
-    runs-on: macos-12-xl
-    strategy:
-      fail-fast: true
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: extractions/setup-just@v1
-      - name: install protoc
-        run: just protoc
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist
-          working-directory: py-glaredb
-          sccache: 'true'
-          container: 'off'
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: py-glaredb/dist
+  # macos:
+  #   runs-on: macos-12-xl
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target: [x86_64, aarch64]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: extractions/setup-just@v1
+  #     - name: install protoc
+  #       run: just protoc
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.target }}
+  #         args: --release --out dist
+  #         working-directory: py-glaredb
+  #         sccache: 'true'
+  #         container: 'off'
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: py-glaredb/dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: [linux, macos, windows]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --skip-existing *
+  # release:
+  #   name: Release
+  #   runs-on: ubuntu-latest
+  #   needs: [linux, macos, windows]
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: wheels
+  #     - name: Publish to PyPI
+  #       uses: PyO3/maturin-action@v1
+  #       env:
+  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  #       with:
+  #         command: upload
+  #         args: --skip-existing *

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -46,66 +46,66 @@ jobs:
           name: wheels
           path: dist
 
-  # windows:
-  #   runs-on: windows-latest-8-cores
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target: [x64]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - uses: extractions/setup-just@v1
-  #     - name: install protoc
-  #       run: just protoc
+  windows:
+    runs-on: windows-latest-8-cores
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [x64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v1
+      - name: install protoc
+        run: just protoc
 
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.10'
-  #         architecture: ${{ matrix.target }}
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ matrix.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
 
-  #       with:
-  #         target: ${{ matrix.target }}
-  #         args: --release --out dist
-  #         working-directory: py-glaredb
-  #         sccache: 'true'
-  #         container: 'off'
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wheels
-  #         path: py-glaredb/dist
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: py-glaredb
+          sccache: 'true'
+          container: 'off'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: py-glaredb/dist
 
-  # macos:
-  #   runs-on: macos-12-xl
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target: [x86_64, aarch64]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - uses: extractions/setup-just@v1
-  #     - name: install protoc
-  #       run: just protoc
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.10'
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.target }}
-  #         args: --release --out dist
-  #         working-directory: py-glaredb
-  #         sccache: 'true'
-  #         container: 'off'
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wheels
-  #         path: py-glaredb/dist
+  macos:
+    runs-on: macos-12-xl
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v1
+      - name: install protoc
+        run: just protoc
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: py-glaredb
+          sccache: 'true'
+          container: 'off'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: py-glaredb/dist
 
   # release:
   #   name: Release


### PR DESCRIPTION
By using the manylinux container.

Needed for compatibility in fabric. Currently their version of python supports glibc up to version 2.27. We currently build with glibc 2.31. Eventually, I want to never have to deal with glibc again.

Manually tested:
<img width="1973" alt="Screenshot 2023-09-09 at 9 53 31 PM" src="https://github.com/GlareDB/glaredb/assets/4040560/2686c8ff-5754-4c52-8b17-fc1e76394e67">

