### PR TITLE
fix: Allow returning query response through pgsrv with empty column

### DIFF
--- a/crates/pgsrv/src/messages.rs
+++ b/crates/pgsrv/src/messages.rs
@@ -333,12 +333,6 @@ impl<'a> FieldDescriptionBuilder<'a> {
     }
 
     pub fn build(self) -> Result<FieldDescription> {
-        if self.name.is_empty() {
-            return Err(PgSrvError::InternalError(
-                "name of the field in field description cannot be empty".to_string(),
-            ));
-        }
-
         let pg_type = self.pg_type.ok_or(PgSrvError::InternalError(
             "type cannot be `None` in field description".to_string(),
         ))?;

--- a/testdata/csv/empty_col.csv
+++ b/testdata/csv/empty_col.csv
@@ -1,0 +1,3 @@
+,col1,col2
+0,a,hello
+1,b,world

--- a/testdata/sqllogictests/csv.slt
+++ b/testdata/sqllogictests/csv.slt
@@ -19,3 +19,24 @@ select count(*), status from bikeshare_stations group by status order by status;
 ----
 78 active
 24 closed
+
+# Empty column name (#1750)
+
+query ITT rowsort
+select * from '../../testdata/csv/empty_col.csv'
+----
+0 a hello
+1 b world
+
+query T rowsort
+select col1 from '../../testdata/csv/empty_col.csv'
+----
+a
+b
+
+# Weird, but it works
+query T rowsort
+select "" from '../../testdata/csv/empty_col.csv'
+----
+0
+1


### PR DESCRIPTION
This specifically fixes the case where we query a csv file with an unnamed column. Previously we were explicity checking the column name was empty, and now we don't.

This has the consequence of allowing a user to select the empty column with `select "" from ...`, but I guess that's expected.

Closes https://github.com/GlareDB/glaredb/issues/1750