### PR TITLE
chore: set default for `--disable-tls`

### DIFF
--- a/crates/glaredb/src/args/local.rs
+++ b/crates/glaredb/src/args/local.rs
@@ -67,7 +67,7 @@ pub struct LocalClientOpts {
     pub domain: Option<String>,
 
     /// Path to CA certificate for rpcsrv proxy TLS (required for TLS protocol).
-    #[clap(long, hide = true)]
+    #[clap(long, default_value = "true", hide = true)]
     pub disable_tls: bool,
 }
 


### PR DESCRIPTION
We're only at a partial impl right now, and I don't want to break
current (working) interfaces. We will eventually make it "ON" by
default once it's fully implemented.