### PR TITLE
feat: Runtime group exec pull up in EXPLAIN statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To see all options use `--help`:
 
 ### Hybrid Execution
 
-1. Sign up at <https://console.cloud.com> for a **free** fully-managed
+1. Sign up at <https://console.glaredb.com> for a **free** fully-managed
    deployment of GlareDB
 2. Copy the connection string from GlareDB Cloud, for example:
 

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -30,6 +30,7 @@ use std::slice;
 use std::sync::Arc;
 use tokio_postgres::types::Type as PgType;
 
+use datafusion_ext::runtime::group_pull_up::RuntimeGroupPullUp;
 use uuid::Uuid;
 
 use super::{new_datafusion_runtime_env, new_datafusion_session_config_opts};
@@ -81,7 +82,8 @@ impl LocalSessionContext {
             .with_extension(Arc::new(catalog_mutator))
             .with_extension(Arc::new(native_tables.clone()))
             .with_extension(Arc::new(TempCatalog::default()));
-        let state = SessionState::with_config_rt(conf, Arc::new(runtime));
+        let state = SessionState::with_config_rt(conf, Arc::new(runtime))
+            .add_physical_optimizer_rule(Arc::new(RuntimeGroupPullUp {}));
 
         let df_ctx = DfSessionContext::with_state(state);
         df_ctx.register_variable(datafusion::variable::VarType::UserDefined, Arc::new(vars));

--- a/testdata/sqllogictests/explain.slt
+++ b/testdata/sqllogictests/explain.slt
@@ -5,3 +5,28 @@ explain select 1;
 
 statement ok
 explain analyze select 1;
+
+# Test for #1754
+# Ensure `RuntimeGroupExec` is pulled as far up as possible in the `EXPLAIN`ed output
+statement ok
+create temp table t1754 as values (1, 'one'), (2, 'two'), (3, 'three');
+
+query TT
+explain
+select * from t1754
+where column1 != 2
+order by column2
+limit 1;
+----
+logical_plan Limit: skip=0, fetch=1
+  Sort: t1754.column2 ASC NULLS LAST, fetch=1
+    Filter: t1754.column1 != Int64(2)
+      TableScan: t1754 projection=[column1, column2]
+physical_plan RuntimeGroupExec: runtime_preference=local
+  GlobalLimitExec: skip=0, fetch=1
+    SortPreservingMergeExec: [column2@1 ASC NULLS LAST], fetch=1
+      SortExec: fetch=1, expr=[column2@1 ASC NULLS LAST]
+        CoalesceBatchesExec: target_batch_size=8192
+          FilterExec: column1@0 != 2
+            RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+              MemoryExec: partitions=1, partition_sizes=[2]


### PR DESCRIPTION
Instead of performing a "manual" physical optimization for `RuntimeGroupExec`, which in case of `EXPLAIN` doesn't work since the entire input is stringified by that point, rely on DataFusion's default physical planner handling of `EXPLAIN`s. To achieve this simply add the corresponding optimizer to the internal session state while creating it.

Closes #1754