### PR TITLE
fix: Trim whitespaces when checking SLT output

### DIFF
--- a/crates/testing/src/slt/test.rs
+++ b/crates/testing/src/slt/test.rs
@@ -338,11 +338,11 @@ impl AsyncDB for TestClient {
                                                 row_output.push("(empty)".to_string())
                                             } else {
                                                 let scalar = String::from_utf8(buf.to_vec()).map_err(|e| {
-                                                ExecError::Internal(format!(
-                                                    "invalid text formatted result from pg encoder: {e}"
-                                                ))
-                                            })?;
-                                                row_output.push(scalar);
+                                                    ExecError::Internal(format!(
+                                                        "invalid text formatted result from pg encoder: {e}"
+                                                    ))
+                                                })?;
+                                                row_output.push(scalar.trim().to_owned());
                                             }
                                         }
                                     }
@@ -370,7 +370,7 @@ impl AsyncDB for TestClient {
                                         if v.is_empty() {
                                             row_output.push("(empty)".to_string());
                                         } else {
-                                            row_output.push(v.to_string());
+                                            row_output.push(v.to_string().trim().to_owned());
                                         }
                                     }
                                     None => row_output.push("NULL".to_string()),

--- a/testdata/sqllogictests/explain.slt
+++ b/testdata/sqllogictests/explain.slt
@@ -5,3 +5,34 @@ explain select 1;
 
 statement ok
 explain analyze select 1;
+
+# Test for #1754
+# Ensure `RuntimeGroupExec` is pulled as far up as possible in the `EXPLAIN`ed output
+#
+# Omitting this test for now.
+# See https://github.com/GlareDB/glaredb/pull/1781#discussion_r1330072240
+
+halt
+
+statement ok
+create temp table t1754 as values (1, 'one'), (2, 'two'), (3, 'three');
+
+query TT
+explain
+select * from t1754
+where column1 != 2
+order by column2
+limit 1;
+----
+logical_plan Limit: skip=0, fetch=1
+  Sort: t1754.column2 ASC NULLS LAST, fetch=1
+    Filter: t1754.column1 != Int64(2)
+      TableScan: t1754 projection=[column1, column2]
+physical_plan RuntimeGroupExec: runtime_preference=local
+  GlobalLimitExec: skip=0, fetch=1
+    SortPreservingMergeExec: [column2@1 ASC NULLS LAST], fetch=1
+      SortExec: fetch=1, expr=[column2@1 ASC NULLS LAST]
+        CoalesceBatchesExec: target_batch_size=8192
+          FilterExec: column1@0 != 2
+            RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+              MemoryExec: partitions=1, partition_sizes=[2]


### PR DESCRIPTION
The explain test failed due to not matching a new line character at the
end. It's much simpler to omit any leading or trailing whitespaces from
a row given the nature of SLTs.

Fixes #1793