### PR TITLE
feat: Implement Delta/Iceberg external table validation during initial setup

### DIFF
--- a/crates/sqlexec/src/planner/errors.rs
+++ b/crates/sqlexec/src/planner/errors.rs
@@ -94,6 +94,20 @@ impl From<crate::errors::ExecError> for PlanError {
     }
 }
 
+macro_rules! impl_from_dispatch_variant {
+    ($FromType:ty) => {
+        impl From<$FromType> for PlanError {
+            #[inline]
+            fn from(err: $FromType) -> Self {
+                PlanError::Dispatch(crate::dispatch::DispatchError::from(err))
+            }
+        }
+    };
+}
+impl_from_dispatch_variant!(datasources::lake::delta::errors::DeltaError);
+impl_from_dispatch_variant!(datasources::lake::iceberg::errors::IcebergError);
+impl_from_dispatch_variant!(datasources::object_store::errors::ObjectStoreSourceError);
+
 #[allow(unused_macros)]
 macro_rules! internal {
     ($($arg:tt)*) => {

--- a/testdata/sqllogictests_object_store/gcs/delta.slt
+++ b/testdata/sqllogictests_object_store/gcs/delta.slt
@@ -39,3 +39,12 @@ select * from delta_gcs_opts order by a;
 ----
 1   hello
 2   world
+
+# Tests connection options validation during initial setup
+statement error
+create external table delta_gcs_opts
+from delta
+options (
+	location 'gs://${GCS_BUCKET_NAME}/delta/table1',
+    service_account_key 'wrong_key'
+);

--- a/testdata/sqllogictests_object_store/local/iceberg.slt
+++ b/testdata/sqllogictests_object_store/local/iceberg.slt
@@ -1,4 +1,11 @@
 # Tests external iceberg table in the local file system.
+statement error No such file or directory
+create external table iceberg_local
+from iceberg
+options (
+	location 'file://${PWD}/testdata/iceberg/tables/non_existent'
+);
+
 statement ok
 create external table iceberg_local
 from iceberg

--- a/testdata/sqllogictests_object_store/s3/delta.slt
+++ b/testdata/sqllogictests_object_store/s3/delta.slt
@@ -45,3 +45,14 @@ select * from delta_s3_opts order by a;
 ----
 1   hello
 2   world
+
+# Tests connection options validation during initial setup
+statement error
+create external table delta_s3_opts
+from delta
+options (
+	location 's3://${AWS_S3_BUCKET_NAME}/delta/table1',
+	access_key_id = '${AWS_ACCESS_KEY_ID}',
+    secret_access_key = 'wrong_access_key',
+    region '${AWS_S3_REGION}'
+);


### PR DESCRIPTION
Align handling of Delta and Iceberg external tables with other variants by eagerly validating the object store connectivity.

Closes #1817