### PR TITLE
fix(tls): NotValidForName

### DIFF
--- a/crates/glaredb/src/rpc_proxy.rs
+++ b/crates/glaredb/src/rpc_proxy.rs
@@ -47,7 +47,7 @@ impl RpcProxy {
             let cert = std::fs::read_to_string(CERT_PATH)?;
             let key = std::fs::read_to_string(CERT_KEY_PATH)?;
 
-            let identity = Identity::from_pem(cert, key);
+            let identity = Identity::from_pem(&cert, &key);
 
             server
                 .tls_config(ServerTlsConfig::new().identity(identity))?


### PR DESCRIPTION
Currently receiving an error:

`error: InvalidCertificate(NotValidForName)`

This attempts to fix that.