### PR TITLE
chore(py-glaredb): keyword args for connect

### DIFF
--- a/crates/glaredb/src/args/local.rs
+++ b/crates/glaredb/src/args/local.rs
@@ -63,12 +63,16 @@ pub struct LocalClientOpts {
     /// (Internal)
     ///
     /// Note: in the future, this will be 'on' by default
+    ///
+    /// Note: Keep in sync with py-glaredb connect
     #[clap(long, default_value="true", action = clap::ArgAction::Set, hide = true)]
     pub disable_tls: bool,
 
     /// Address of the GlareDB cloud server.
     ///
     /// (Internal)
+    ///
+    /// Note: Keep in sync with py-glaredb connect
     #[clap(long, default_value = "https://console.glaredb.com", hide = true)]
     pub cloud_addr: String,
 }

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -80,7 +80,7 @@ impl From<Option<String>> for PythonSessionConf {
 }
 
 #[pyfunction]
-#[pyo3(signature = (data_dir_or_cloud_url = None, spill_path = None, disable_tls = true, cloud_addr = String::from("https://console.glaredb.com")))]
+#[pyo3(signature = (data_dir_or_cloud_url = None, /, *, spill_path = None, disable_tls = true, cloud_addr = String::from("https://console.glaredb.com")))]
 fn connect(
     py: Python,
     data_dir_or_cloud_url: Option<String>,

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -80,7 +80,7 @@ impl From<Option<String>> for PythonSessionConf {
 }
 
 #[pyfunction]
-#[pyo3(signature = (data_dir_or_cloud_url, spill_path = None, disable_tls = true, cloud_addr = String::from("https://console.glaredb.com")))]
+#[pyo3(signature = (data_dir_or_cloud_url = None, spill_path = None, disable_tls = true, cloud_addr = String::from("https://console.glaredb.com")))]
 fn connect(
     py: Python,
     data_dir_or_cloud_url: Option<String>,

--- a/py-glaredb/src/lib.rs
+++ b/py-glaredb/src/lib.rs
@@ -79,9 +79,8 @@ impl From<Option<String>> for PythonSessionConf {
     }
 }
 
-/// Create and connect to a GlareDB engine.
-// TODO: kwargs
 #[pyfunction]
+#[pyo3(signature = (data_dir_or_cloud_url/, *spill_path, disable_tls=false, cloud_addr="https://console.glaredb.com"))]
 fn connect(
     py: Python,
     data_dir_or_cloud_url: Option<String>,


### PR DESCRIPTION
This alters the pyFunction `connect` to have two additional optional arguments `disable_tls` and `cloud_addr`. These arguments match those that are defined in `LocalClientOpts`.

### Before

```
glaredb.connect([data_dir_or_cloud_url], [spill_path])
```

### After

`data_dir_or_cloud_url` is positional, and all other args are keyword with defaults and variable in order

```
glaredb.connect([data_dir_or_cloud_url],
	[spill_path],
	[disable_tls],
	[cloud_addr]
)
```

### Example Uses

#### Local

```py
import glaredb

conn = glaredb.connect()
conn.sql("SELECT 'hello local';").show()
┌─────────────────────┐
│ Utf8("hello local") │
│ ──                  │
│ Utf8                │
╞═════════════════════╡
│ hello local         │
└─────────────────────┘
```

#### Hybrid (using keyword args in any order)

```py
import glaredb

cloud_url = "<user>:<pass>@<org>.remote.qa.glaredb.com:6443/<db_name>"

conn = glaredb.connect(cloud_url, cloud_addr="https://qa.glaredb.com", disable_tls=False)
conn.sql("SELECT 'hello remote';").show()
┌──────────────────────┐
│ Utf8("hello remote") │
│ ──                   │
│ Utf8                 │
╞══════════════════════╡
│ hello remote         │
└──────────────────────┘
```

Resolves: #1829