### PR TITLE
fix: Coalesce partitions in `RemoteScanExec`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,8 +269,7 @@ jobs:
           just sql-logic-tests --rpc-test 'sqllogictests_iceberg/*'
           just sql-logic-tests --rpc-test 'sqllogictests_native/*'
           just sql-logic-tests --rpc-test 'sqllogictests_object_store/*'
-          # See https://github.com/GlareDB/glaredb/issues/1812
-          # just sql-logic-tests --rpc-test 'sqllogictests_snowflake/*'
+          just sql-logic-tests --rpc-test 'sqllogictests_snowflake/*'
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_mongodb/*'
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_mysql/*'
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_postgres/*'


### PR DESCRIPTION
Since we're executing and collecting the complete stream in `RemoteScanExec`, we need to coalesce all the partitions before executing else we end up running only the first partition.

Fixes #1812