### PR TITLE
chore: Fix flaky SSH tunnel tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,8 +228,13 @@ jobs:
 
           echo "-------------------------------- WITHOUT TUNNEL TEST --------------------------------"
           just sql-logic-tests -v --exclude '*/tunnels/ssh'
+
           echo "-------------------------------- WITH TUNNEL TEST --------------------------------"
-          just sql-logic-tests -v '*/tunnels/ssh'
+          # SSH tests are prone to fail if we make a lot of connections at the
+          # same time. Hence, it makes sense to run all the SSH tests one-by-one
+          # in order to test the SSH tunnels (which is our aim).
+          just sql-logic-tests -v --jobs=1 '*/tunnels/ssh'
+
           echo "-------------------------------- RPC TESTS --------------------------------"
           just sql-logic-tests -v --rpc-test \
                                              'sqllogictests/cast/*' \

--- a/crates/testing/tests/sqllogictests/hooks.rs
+++ b/crates/testing/tests/sqllogictests/hooks.rs
@@ -172,6 +172,9 @@ SELECT public_key
         let deadline = Instant::now() + Duration::from_secs(120);
         while Instant::now() < deadline {
             if check_container(container_id).await.is_ok() {
+                // Yes the check completed, but let's just wait a second for the
+                // server to start (if there is anything pending).
+                tokio_sleep(Duration::from_secs(1)).await;
                 return Ok(());
             }
             tokio_sleep(Duration::from_millis(250)).await;


### PR DESCRIPTION
1. Sleep a bit more after certain about the server has started.
2. Run each SSH tunnel job one-by-one.

Fixes #1054 (hopefully)