### PR TITLE
chore: Remove release profile settings from py-glaredb

### DIFF
--- a/py-glaredb/Cargo.toml
+++ b/py-glaredb/Cargo.toml
@@ -29,7 +29,3 @@ uuid = "1.4.1"
 async-trait = "0.1.72"
 anyhow = "1.0.72"
 once_cell = "1.18.0"
-
-[profile.release]
-codegen-units = 1
-lto = "fat"


### PR DESCRIPTION
Not used and it was causing warnings

Closes https://github.com/GlareDB/glaredb/issues/1833