### PR TITLE
feat: Track more data source metrics during execution

### DIFF
--- a/crates/datafusion_ext/src/lib.rs
+++ b/crates/datafusion_ext/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod metrics;
 pub mod planner;
 pub mod runtime;
 pub mod vars;

--- a/crates/datafusion_ext/src/metrics.rs
+++ b/crates/datafusion_ext/src/metrics.rs
@@ -164,13 +164,13 @@ impl ExecutionPlan for DataSourceMetricsExecAdapter {
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
-        self.child.metrics()
+        Some(self.metrics.clone_inner())
     }
 }
 
 impl DisplayAs for DataSourceMetricsExecAdapter {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DataSourceExecAdapter")
+        write!(f, "DataSourceMetricsExecAdapter")
     }
 }
 

--- a/crates/datafusion_ext/src/metrics.rs
+++ b/crates/datafusion_ext/src/metrics.rs
@@ -1,0 +1,134 @@
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    arrow::record_batch::RecordBatch,
+    error::Result,
+    physical_plan::{
+        metrics::{BaselineMetrics, ExecutionPlanMetricsSet, Gauge, MetricBuilder},
+        ExecutionPlan, RecordBatchStream,
+    },
+};
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+const BYTES_PROCESSED_GAUGE_NAME: &str = "bytes_processed";
+
+/// Standard metrics we should be collecting for all data sources during
+/// queries.
+#[derive(Debug, Clone)]
+pub struct DataSourceMetrics {
+    /// Track bytes processed by source plans.
+    pub bytes_processed: Gauge,
+
+    /// Baseline metrics like output rows and elapsed time.
+    pub baseline: BaselineMetrics,
+}
+
+impl DataSourceMetrics {
+    pub fn new(partition: usize, metrics: &ExecutionPlanMetricsSet) -> Self {
+        let bytes_processed =
+            MetricBuilder::new(metrics).gauge(BYTES_PROCESSED_GAUGE_NAME, partition);
+        let baseline = BaselineMetrics::new(metrics, partition);
+
+        Self {
+            bytes_processed,
+            baseline,
+        }
+    }
+
+    pub fn record_poll(
+        &self,
+        poll: Poll<Option<Result<RecordBatch>>>,
+    ) -> Poll<Option<Result<RecordBatch>>> {
+        if let Poll::Ready(maybe_batch) = &poll {
+            match maybe_batch {
+                Some(Ok(batch)) => {
+                    self.bytes_processed.add(batch.get_array_memory_size());
+                    self.baseline.record_output(batch.num_rows());
+                }
+                Some(Err(_)) => self.baseline.done(),
+                None => self.baseline.done(),
+            }
+        }
+        poll
+    }
+}
+
+/// Thin wrapper around a record batch stream that automatically records metrics
+/// about batches that are sent through the stream.
+pub struct MetricsStreamAdapter<S> {
+    pub stream: S,
+    pub metrics: DataSourceMetrics,
+}
+
+impl<S> MetricsStreamAdapter<S> {
+    /// Create a new stream with a new set of data source metrics for the given
+    /// partition.
+    pub fn new(stream: S, partition: usize, metrics: &ExecutionPlanMetricsSet) -> Self {
+        Self {
+            stream,
+            metrics: DataSourceMetrics::new(partition, metrics),
+        }
+    }
+}
+
+impl<S: RecordBatchStream + Unpin> Stream for MetricsStreamAdapter<S> {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let poll = self.stream.poll_next_unpin(cx);
+        self.metrics.record_poll(poll)
+    }
+}
+
+impl<S: RecordBatchStream + Unpin> RecordBatchStream for MetricsStreamAdapter<S> {
+    fn schema(&self) -> SchemaRef {
+        self.stream.schema()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregatedMetrics {
+    /// Total time taken for a plan to execute.
+    pub elapsed_compute_ns: u64,
+    /// Total output rows for the plan.
+    pub output_rows: u64,
+    /// Total bytes processed.
+    pub bytes_processed: u64,
+}
+
+impl AggregatedMetrics {
+    /// Computes aggregated metrics from a plan.
+    ///
+    /// The plan should have already been executed to completion, otherwise
+    /// partial or incorrect results will be reported.
+    pub fn new_from_plan(plan: &dyn ExecutionPlan) -> Self {
+        let mut agg = AggregatedMetrics {
+            elapsed_compute_ns: 0,
+            output_rows: 0,
+            bytes_processed: 0,
+        };
+
+        agg.aggregate_recurse(plan);
+
+        agg
+    }
+
+    fn aggregate_recurse(&mut self, plan: &dyn ExecutionPlan) {
+        // TODO: What to do about output rows?
+
+        let metrics = match plan.metrics() {
+            Some(metrics) => metrics,
+            None => return,
+        };
+        self.elapsed_compute_ns += metrics.elapsed_compute().unwrap_or_default() as u64;
+        self.bytes_processed += metrics
+            .sum_by_name(BYTES_PROCESSED_GAUGE_NAME)
+            .map(|m| m.as_usize() as u64)
+            .unwrap_or_default();
+
+        for child in plan.children() {
+            self.aggregate_recurse(child.as_ref());
+        }
+    }
+}

--- a/crates/datafusion_ext/src/metrics.rs
+++ b/crates/datafusion_ext/src/metrics.rs
@@ -211,8 +211,6 @@ impl RecordBatchStream for BoxedStreamAdapater {
 pub struct AggregatedMetrics {
     /// Total time taken for a plan to execute.
     pub elapsed_compute_ns: u64,
-    /// Total output rows for the plan.
-    pub output_rows: u64,
     /// Total bytes processed.
     pub bytes_processed: u64,
 }
@@ -225,7 +223,6 @@ impl AggregatedMetrics {
     pub fn new_from_plan(plan: &dyn ExecutionPlan) -> Self {
         let mut agg = AggregatedMetrics {
             elapsed_compute_ns: 0,
-            output_rows: 0,
             bytes_processed: 0,
         };
         agg.aggregate_recurse(plan);
@@ -233,8 +230,6 @@ impl AggregatedMetrics {
     }
 
     fn aggregate_recurse(&mut self, plan: &dyn ExecutionPlan) {
-        // TODO: What to do about output rows?
-
         let metrics = match plan.metrics() {
             Some(metrics) => metrics,
             None => return,

--- a/crates/datafusion_ext/src/runtime/runtime_group.rs
+++ b/crates/datafusion_ext/src/runtime/runtime_group.rs
@@ -2,6 +2,7 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
     Statistics,
@@ -68,6 +69,10 @@ impl ExecutionPlan for RuntimeGroupExec {
 
     fn statistics(&self) -> Statistics {
         self.child.statistics()
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
     }
 }
 

--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -9,7 +9,7 @@ use datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown, TableTy
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::{ExecutionPlan, Statistics};
 use datafusion::prelude::Expr;
-use datafusion_ext::metrics::DataSourceExecAdapter;
+use datafusion_ext::metrics::DataSourceMetricsExecAdapter;
 use deltalake::operations::create::CreateBuilder;
 use deltalake::operations::delete::DeleteBuilder;
 use deltalake::operations::update::UpdateBuilder;
@@ -291,7 +291,7 @@ impl TableProvider for NativeTable {
             Ok(Arc::new(EmptyExec::new(false, schema)))
         } else {
             let plan = self.delta.scan(session, projection, filters, limit).await?;
-            Ok(Arc::new(DataSourceExecAdapter::new(plan)))
+            Ok(Arc::new(DataSourceMetricsExecAdapter::new(plan)))
         }
     }
 

--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -9,6 +9,7 @@ use datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown, TableTy
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::{ExecutionPlan, Statistics};
 use datafusion::prelude::Expr;
+use datafusion_ext::metrics::DataSourceExecAdapter;
 use deltalake::operations::create::CreateBuilder;
 use deltalake::operations::delete::DeleteBuilder;
 use deltalake::operations::update::UpdateBuilder;
@@ -289,7 +290,8 @@ impl TableProvider for NativeTable {
             let schema = TableProvider::schema(&self.delta);
             Ok(Arc::new(EmptyExec::new(false, schema)))
         } else {
-            self.delta.scan(session, projection, filters, limit).await
+            let plan = self.delta.scan(session, projection, filters, limit).await?;
+            Ok(Arc::new(DataSourceExecAdapter::new(plan)))
         }
     }
 

--- a/crates/datasources/src/object_store/http.rs
+++ b/crates/datasources/src/object_store/http.rs
@@ -125,7 +125,6 @@ impl ObjStoreAccess for HttpStoreAccess {
             file_format: file_format.clone(),
             base_url,
             objects,
-            _predicate_pushdown: true,
         });
         providers.push(prov);
 
@@ -163,7 +162,6 @@ impl HttpStoreAccess {
             base_url,
             objects,
             file_format,
-            _predicate_pushdown: true,
         })
     }
 }

--- a/crates/datasources/src/object_store/mod.rs
+++ b/crates/datasources/src/object_store/mod.rs
@@ -16,7 +16,7 @@ use datafusion::logical_expr::TableType;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
-use datafusion_ext::metrics::DataSourceExecAdapter;
+use datafusion_ext::metrics::DataSourceMetricsExecAdapter;
 use errors::ObjectStoreSourceError;
 use futures::StreamExt;
 use glob::{MatchOptions, Pattern};
@@ -333,7 +333,7 @@ impl TableProvider for ObjStoreTableProvider {
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        Ok(Arc::new(DataSourceExecAdapter::new(plan)))
+        Ok(Arc::new(DataSourceMetricsExecAdapter::new(plan)))
     }
 }
 

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -19,12 +19,15 @@ use datafusion::execution::context::SessionState;
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
 use datafusion_ext::errors::ExtensionError;
 use datafusion_ext::functions::VirtualLister;
+use datafusion_ext::metrics::MetricsStreamAdapter;
 use errors::{PostgresError, Result};
 use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, Stream, StreamExt};
 use protogen::metastore::types::options::TunnelOptions;
@@ -700,6 +703,7 @@ pub struct PostgresBinaryCopyExec {
     pg_types: Arc<Vec<PostgresType>>,
     arrow_schema: ArrowSchemaRef,
     opener: StreamOpener,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl PostgresBinaryCopyExec {
@@ -719,6 +723,7 @@ impl PostgresBinaryCopyExec {
                     pg_types: Arc::new(pg_types),
                     arrow_schema: Arc::new(arrow_schema),
                     opener,
+                    metrics: ExecutionPlanMetricsSet::new(),
                 })
             }
             BinaryCopyConfig::State {
@@ -732,6 +737,7 @@ impl PostgresBinaryCopyExec {
                     pg_types,
                     arrow_schema,
                     opener,
+                    metrics: ExecutionPlanMetricsSet::new(),
                 })
             }
         }
@@ -764,13 +770,13 @@ impl ExecutionPlan for PostgresBinaryCopyExec {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
         Err(DataFusionError::Execution(
-            "cannot replace children for BinaryCopyExec".to_string(),
+            "cannot replace children for PostgresBinaryCopyExec".to_string(),
         ))
     }
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> DatafusionResult<SendableRecordBatchStream> {
         let stream = ChunkStream {
@@ -779,23 +785,31 @@ impl ExecutionPlan for PostgresBinaryCopyExec {
             opener: self.opener.clone(),
             arrow_schema: self.arrow_schema.clone(),
         };
-        Ok(Box::pin(stream))
+        Ok(Box::pin(MetricsStreamAdapter::new(
+            stream,
+            partition,
+            &self.metrics,
+        )))
     }
 
     fn statistics(&self) -> Statistics {
         Statistics::default()
     }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
 }
 
 impl DisplayAs for PostgresBinaryCopyExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BinaryCopyExec",)
+        write!(f, "PostgresBinaryCopyExec",)
     }
 }
 
 impl fmt::Debug for PostgresBinaryCopyExec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BinaryCopyExec")
+        f.debug_struct("PostgresBinaryCopyExec")
             .field("pg_types", &self.pg_types)
             .field("arrow_schema", &self.arrow_schema)
             .finish()

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -27,7 +27,7 @@ use datafusion::physical_plan::{
 };
 use datafusion_ext::errors::ExtensionError;
 use datafusion_ext::functions::VirtualLister;
-use datafusion_ext::metrics::MetricsStreamAdapter;
+use datafusion_ext::metrics::DataSourceMetricsStreamAdapter;
 use errors::{PostgresError, Result};
 use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, Stream, StreamExt};
 use protogen::metastore::types::options::TunnelOptions;
@@ -785,7 +785,7 @@ impl ExecutionPlan for PostgresBinaryCopyExec {
             opener: self.opener.clone(),
             arrow_schema: self.arrow_schema.clone(),
         };
-        Ok(Box::pin(MetricsStreamAdapter::new(
+        Ok(Box::pin(DataSourceMetricsStreamAdapter::new(
             stream,
             partition,
             &self.metrics,

--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -293,6 +293,9 @@ pub struct InterleaveExec {}
 pub struct RuntimeGroupExec {}
 
 #[derive(Clone, PartialEq, Message)]
+pub struct DataSourceMetricsExecAdapter {}
+
+#[derive(Clone, PartialEq, Message)]
 pub struct AnalyzeExec {
     #[prost(bool, tag = "1")]
     pub verbose: bool,
@@ -306,7 +309,7 @@ pub struct AnalyzeExec {
 pub struct ExecutionPlanExtension {
     #[prost(
         oneof = "ExecutionPlanExtensionType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30"
     )]
     pub inner: Option<ExecutionPlanExtensionType>,
 }
@@ -376,4 +379,6 @@ pub enum ExecutionPlanExtensionType {
     RuntimeGroupExec(RuntimeGroupExec),
     #[prost(message, tag = "29")]
     AnalyzeExec(AnalyzeExec),
+    #[prost(message, tag = "30")]
+    DataSourceMetricsExecAdapter(DataSourceMetricsExecAdapter),
 }

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -451,9 +451,7 @@ impl<'a> ExternalDispatcher<'a> {
         let objects = accessor.list_globbed(location).await?;
 
         let state = self.df_ctx.state();
-        let provider = accessor
-            .into_table_provider(&state, ft, objects, /* predicate_pushdown = */ true)
-            .await?;
+        let provider = accessor.into_table_provider(&state, ft, objects).await?;
 
         Ok(provider)
     }


### PR DESCRIPTION
Adds additional metrics tracking for data sources:

```
> CREATE EXTERNAL DATABASE my_pg
::: FROM postgres OPTIONS (
:::   host = 'pg.demo.glaredb.com',
:::   port = '5432',
:::   user = 'demo',
:::   password = 'demo',
:::   database = 'postgres',
::: );
Database created
> explain analyze select * from my_pg.public.customer;
┌───────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ plan_type         │ plan                                                                                                                                             │
│ ──                │ ──                                                                                                                                               │
│ Utf8              │ Utf8                                                                                                                                             │
╞═══════════════════╪══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
│ Plan with Metrics │ RuntimeGroupExec: runtime_preference=local, metrics=[]↵                                                                                          │
│                   │   RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1, metrics=[send_time=514.826µs, fetch_time=1.588055543s, repart_time=1ns]↵ │
│                   │     PostgresBinaryCopyExec, metrics=[output_rows=150000, elapsed_compute=1ns, bytes_processed=40962000]↵                                         │
│                   │                                                                                                                                                  │
└───────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

This also includes a `bytes_processed` counter for tracking the number of bytes when reading in batches. The idea is that we can walk the plan after execution to get the total number of bytes processed, and emit that _somewhere_.

---

I opened this up to get thoughts before moving on to replace the `session_query_metrics` table and related code and look at how we want to persist them.