### PR TITLE
chore: Remove temp catalog, session vars (mostly) from remote session

### DIFF
--- a/crates/sqlexec/src/context/mod.rs
+++ b/crates/sqlexec/src/context/mod.rs
@@ -34,6 +34,7 @@ use crate::{errors::Result, metastore::catalog::SessionCatalog};
 ///
 /// If `memory_limit_bytes` in session varables is non-zero, a new memory pool
 /// will be created with the max set to this value.
+// TODO: Remove `vars`.
 pub(crate) fn new_datafusion_runtime_env(
     vars: &SessionVars,
     catalog: &SessionCatalog,
@@ -76,6 +77,7 @@ pub(crate) fn new_datafusion_runtime_env(
 
 /// Create a new datafusion config opts common to both local and remote
 /// sessions.
+// TODO: Remove `vars`.
 pub(crate) fn new_datafusion_session_config_opts(vars: &SessionVars) -> ConfigOptions {
     // NOTE: We handle catalog/schema defaults and information schemas
     // ourselves.

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -172,11 +172,10 @@ impl Engine {
     /// since we don't guarantee that sessions get closed).
     pub async fn new_remote_session_context(
         &self,
-        vars: SessionVars,
+        conn_id: Uuid,
+        database_id: Uuid,
         storage: SessionStorageConfig,
     ) -> Result<RemoteSessionContext> {
-        let conn_id = vars.connection_id();
-        let database_id = vars.database_id();
         let metastore = self.supervisor.init_client(conn_id, database_id).await?;
         let native = self
             .storage
@@ -186,7 +185,6 @@ impl Engine {
         let catalog = SessionCatalog::new(state);
 
         let context = RemoteSessionContext::new(
-            vars,
             catalog,
             metastore.into(),
             native,


### PR DESCRIPTION
Related to distributed execution.

Goal: Try to make the remote session as stateless as possible to allow for it to execute any plan for a specific database.

There's still some need for `SessionVars` when creating the datafusion runtime/context, but I just used the default for now. It's likely that we'll just be provided a well-typed struct for session configuration soonish.