### PR TITLE
feat: Extend SLTs to excercise remote data storage functionality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,4 +292,6 @@ jobs:
               --option access_key_id=$MINIO_ACCESS_KEY \
               --option secret_access_key=$MINIO_SECRET_KEY \
               --option bucket=$MINIO_BUCKET \
-              'sqllogictests_native/*' 
+              'sqllogictests/*' \
+              'sqllogictests_native/*'
+              

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,6 +177,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          MINIO_ACCESS_KEY: glaredb
+          MINIO_SECRET_KEY: glaredb_test
+          MINIO_BUCKET: glaredb-test-bucket
         run: |
           # Prepare SLT (Snowflake)
           export PATH="$HOME/bin:$PATH"
@@ -225,6 +228,9 @@ jobs:
 
           # Prepare SLT (MongoDB)
           export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
+          
+          # Prepare SLT (MinIO)
+          ./scripts/create-test-minio-store.sh
 
           echo "-------------------------------- WITHOUT TUNNEL TEST --------------------------------"
           just sql-logic-tests -v --exclude '*/tunnels/ssh'
@@ -279,3 +285,11 @@ jobs:
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_mongodb/*'
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_mysql/*'
           just sql-logic-tests --rpc-test --exclude '*/tunnels/ssh' 'sqllogictests_postgres/*'
+          
+          echo "-------------------------- REMOTE DATA STORAGE TESTS --------------------------------"
+          # Test using a remote object store for storing databases and catalog; For now only on MinIO (S3)
+          just sql-logic-tests --location http://localhost:9000 \
+              --option access_key_id=$MINIO_ACCESS_KEY \
+              --option secret_access_key=$MINIO_SECRET_KEY \
+              --option bucket=$MINIO_BUCKET \
+              'sqllogictests_native/*' 

--- a/crates/bench_runner/src/main.rs
+++ b/crates/bench_runner/src/main.rs
@@ -69,6 +69,8 @@ fn main() -> Result<()> {
             None,
             None,
             None,
+            Default::default(),
+            None,
             false,
             false,
         )

--- a/crates/glaredb/src/args/server.rs
+++ b/crates/glaredb/src/args/server.rs
@@ -43,6 +43,9 @@ pub struct ServerArgs {
     #[clap(short, long, hide = true, value_parser)]
     pub service_account_path: Option<String>,
 
+    #[clap(flatten)]
+    pub storage_config: StorageConfigArgs,
+
     /// Path to spill temporary files to.
     #[clap(long, value_parser)]
     pub spill_path: Option<PathBuf>,

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use object_store_util::conf::StorageConfig;
 use pgsrv::auth::{LocalAuthenticator, PasswordlessAuthenticator, SingleUserAuthenticator};
+use std::collections::HashMap;
 use std::fs;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -73,6 +74,7 @@ impl RunCommand for ServerArgs {
             password,
             data_dir,
             service_account_path,
+            storage_config,
             spill_path,
             ignore_pg_auth,
             disable_rpc_auth,
@@ -107,6 +109,8 @@ impl RunCommand for ServerArgs {
                 auth,
                 data_dir,
                 service_account_key,
+                storage_config.location,
+                HashMap::from_iter(storage_config.storage_options.clone()),
                 spill_path,
                 /* integration_testing = */ false,
                 disable_rpc_auth,

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -274,6 +274,11 @@ impl Engine {
         Engine::new(client, conf, Arc::new(Tracker::Nop), None).await
     }
 
+    pub fn with_tracker(mut self, tracker: Arc<Tracker>) -> Engine {
+        self.tracker = tracker;
+        self
+    }
+
     pub fn with_spill_path(mut self, spill_path: Option<PathBuf>) -> Engine {
         self.spill_path = spill_path;
         self

--- a/crates/testing/src/slt/cli.rs
+++ b/crates/testing/src/slt/cli.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use glaredb::args::StorageConfigArgs;
 use glaredb::server::{ComputeServer, ServerConfig};
 use tokio::{net::TcpListener, runtime::Builder, sync::mpsc, time::Instant};
 use tokio_postgres::config::Config as ClientConfig;
@@ -49,7 +50,7 @@ pub struct Cli {
     connection_string: Option<String>,
 
     /// List all the tests for the pattern (Dry Run).
-    #[clap(short, long, value_parser)]
+    #[clap(long, value_parser)]
     list: bool,
 
     /// Number of jobs to run in parallel
@@ -70,6 +71,9 @@ pub struct Cli {
     /// Run the tests in RPC mode.
     #[clap(long, value_parser)]
     rpc_test: bool,
+
+    #[clap(flatten)]
+    storage_config: StorageConfigArgs,
 
     /// Tests to run.
     ///
@@ -195,6 +199,8 @@ impl Cli {
                     }),
                     Some(temp_dir.path().to_path_buf()),
                     None,
+                    self.storage_config.location.clone(),
+                    HashMap::from_iter(self.storage_config.storage_options.clone()),
                     None,
                     /* integration_testing = */ true,
                     /* disable_rpc_auth = */ self.rpc_test,

--- a/scripts/create-test-minio-store.sh
+++ b/scripts/create-test-minio-store.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Spins up a MinIO docker container to test external databes/catalog storage against it.
+
+set -e
+
+MINIO_IMAGE="minio/minio:latest"
+CONTAINER_NAME="glaredb_minio_test"
+
+MINIO_CONSOLE_ADDRESS=:9001
+
+# Remove container if it exists
+if [[ -n "$(docker ps -a -q -f name=$CONTAINER_NAME)" ]]; then
+    docker rm -f $CONTAINER_NAME > /dev/null
+fi
+
+# Start minio.
+CONTAINER_ID="$(docker run \
+   -p 9000:9000 \
+   -p 9001:9001 \
+   -e MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY}" \
+   -e MINIO_SECRET_KEY="${MINIO_SECRET_KEY}" \
+   -e MINIO_CONSOLE_ADDRESS="${MINIO_CONSOLE_ADDRESS}" \
+   --rm \
+   --name $CONTAINER_NAME \
+   -d \
+   $MINIO_IMAGE server /data)"
+
+# Create the test container using the minio client
+docker run --rm --net=host --entrypoint=/bin/sh -i minio/mc:latest <<EOF
+#!/usr/bin/mc
+
+# Wait for minio server to become ready
+curl --retry 10 -f --retry-connrefused --retry-delay 1 http://localhost:9000/minio/health/live
+
+# Configure mc to connect to our above container as host
+mc config host add glaredb_minio http://localhost:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+
+# Remove the bucket if it already exists
+mc rm -r --force glaredb_minio/"$MINIO_BUCKET"
+
+# Finally create the test bucket
+mc mb glaredb_minio/"$MINIO_BUCKET"
+EOF

--- a/scripts/create-test-minio-store.sh
+++ b/scripts/create-test-minio-store.sh
@@ -28,8 +28,6 @@ CONTAINER_ID="$(docker run \
 
 # Create the test container using the minio client
 docker run --rm --net=host --entrypoint=/bin/sh -i minio/mc:latest <<EOF
-#!/usr/bin/mc
-
 # Wait for minio server to become ready
 curl --retry 10 -f --retry-connrefused --retry-delay 1 http://localhost:9000/minio/health/live
 


### PR DESCRIPTION
The simplest way to go about this seemed to be:
- extending the server command to also accept the storage config options (as the local command)
- add a script to spin up a MinIO server and create a bucket in it
- Add a relevant invocation to the `ci.yaml` file to trigger all that