### PR TITLE
feat: Support `INSERT INTO` for external sources.

### DIFF
--- a/crates/datasources/src/common/util.rs
+++ b/crates/datasources/src/common/util.rs
@@ -49,15 +49,22 @@ pub fn encode_literal_to_text(
     buf: &mut String,
     lit: &ScalarValue,
 ) -> Result<()> {
-    // Should be handled by "IS [NOT] NULL" ...
-    debug_assert!(!lit.is_null());
-    // Should be handled by "IS (TRUE/FALSE)" ...
-    debug_assert!(!matches!(lit, ScalarValue::Boolean(_)));
+    if lit.is_null() {
+        buf.write_str("NULL")?;
+        return Ok(());
+    }
 
     if is_literal_quotable(datasource, lit) {
         buf.write_str("'")?;
     }
     match lit {
+        ScalarValue::Boolean(Some(v)) => {
+            if *v {
+                buf.write_str("TRUE")?;
+            } else {
+                buf.write_str("FALSE")?;
+            }
+        }
         ScalarValue::Int8(Some(v)) => encode_int(buf, *v)?,
         ScalarValue::Int16(Some(v)) => encode_int(buf, *v)?,
         ScalarValue::Int32(Some(v)) => encode_int(buf, *v)?,

--- a/crates/datasources/src/postgres/query_exec.rs
+++ b/crates/datasources/src/postgres/query_exec.rs
@@ -1,0 +1,187 @@
+use std::{
+    any::Any,
+    fmt,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use datafusion::{
+    arrow::{
+        array::UInt64Array,
+        datatypes::{DataType, Field, Schema as ArrowSchema},
+        record_batch::RecordBatch,
+    },
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::TaskContext,
+    physical_expr::PhysicalSortExpr,
+    physical_plan::{
+        metrics::{ExecutionPlanMetricsSet, MetricsSet},
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
+        SendableRecordBatchStream, Statistics,
+    },
+};
+use datafusion_ext::metrics::DataSourceMetricsStreamAdapter;
+use futures::{future::BoxFuture, ready, FutureExt, Stream};
+use once_cell::sync::Lazy;
+
+use super::PostgresAccessState;
+
+static COUNT_SCHEMA: Lazy<Arc<ArrowSchema>> = Lazy::new(|| {
+    Arc::new(ArrowSchema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+});
+
+pub fn create_count_record_batch(count: u64) -> RecordBatch {
+    RecordBatch::try_new(
+        COUNT_SCHEMA.clone(),
+        vec![Arc::new(UInt64Array::from_value(
+            count, /* rows = */ 1,
+        ))],
+    )
+    .unwrap()
+}
+
+#[derive(Debug)]
+pub struct PostgresQueryExec {
+    query: String,
+    state: Arc<PostgresAccessState>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl PostgresQueryExec {
+    pub fn new(query: String, state: Arc<PostgresAccessState>) -> Self {
+        PostgresQueryExec {
+            query,
+            state,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl ExecutionPlan for PostgresQueryExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> Arc<ArrowSchema> {
+        COUNT_SCHEMA.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::Execution(
+            "cannot replace children for PostgresQueryExec".to_string(),
+        ))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let stream = QueryStream {
+            state: QueryExecState::Idle,
+            opener: QueryOpener {
+                query: self.query.clone(),
+                state: self.state.clone(),
+            },
+        };
+        Ok(Box::pin(DataSourceMetricsStreamAdapter::new(
+            stream,
+            partition,
+            &self.metrics,
+        )))
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+impl DisplayAs for PostgresQueryExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PostgresQueryExec(query = {})", self.query)
+    }
+}
+
+#[derive(Clone)]
+struct QueryOpener {
+    query: String,
+    state: Arc<PostgresAccessState>,
+}
+
+impl QueryOpener {
+    fn open(&self) -> BoxFuture<'static, Result<u64, tokio_postgres::Error>> {
+        let this = self.clone();
+        Box::pin(async move { this.state.client.execute(&this.query, &[]).await })
+    }
+}
+
+enum QueryExecState {
+    Idle,
+    Open {
+        fut: BoxFuture<'static, Result<u64, tokio_postgres::Error>>,
+    },
+    Done,
+    Error,
+}
+
+struct QueryStream {
+    state: QueryExecState,
+    opener: QueryOpener,
+}
+
+impl Stream for QueryStream {
+    type Item = DataFusionResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match &mut self.state {
+                QueryExecState::Idle => {
+                    let fut = self.opener.open();
+                    self.state = QueryExecState::Open { fut }
+                }
+                QueryExecState::Open { fut } => match ready!(fut.poll_unpin(cx)) {
+                    Ok(count) => {
+                        let record_batch = create_count_record_batch(count);
+                        self.state = QueryExecState::Done;
+                        return Poll::Ready(Some(Ok(record_batch)));
+                    }
+                    Err(e) => {
+                        self.state = QueryExecState::Error;
+                        return Poll::Ready(Some(Err(DataFusionError::External(Box::new(e)))));
+                    }
+                },
+                QueryExecState::Done | QueryExecState::Error => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+impl RecordBatchStream for QueryStream {
+    fn schema(&self) -> Arc<ArrowSchema> {
+        COUNT_SCHEMA.clone()
+    }
+}

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -496,7 +496,7 @@ impl From<FunctionType> for catalog::function_entry::FunctionType {
 }
 
 /// The runtime preference for a function.
-#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq, Hash)]
 pub enum RuntimePreference {
     Unspecified,
     Local,

--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -270,8 +270,8 @@ pub struct DeleteExec {
 
 #[derive(Clone, PartialEq, Message)]
 pub struct InsertExec {
-    #[prost(message, tag = "1")]
-    pub table: Option<TableEntry>,
+    #[prost(bytes, tag = "1")]
+    pub provider_id: Vec<u8>, // UUID
 }
 
 #[derive(Clone, PartialEq, Message)]

--- a/crates/sqlexec/src/planner/logical_plan/insert.rs
+++ b/crates/sqlexec/src/planner/logical_plan/insert.rs
@@ -2,14 +2,17 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use datafusion::prelude::SessionContext;
-use protogen::metastore::types::catalog::TableEntry;
+use protogen::metastore::types::catalog::RuntimePreference;
+
+use crate::planner::physical_plan::remote_scan::ProviderReference;
 
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Insert {
     pub source: DfLogicalPlan,
-    pub table: TableEntry,
+    pub provider: ProviderReference,
+    pub runtime_preference: RuntimePreference,
 }
 
 impl UserDefinedLogicalNodeCore for Insert {

--- a/crates/sqlexec/src/planner/physical_plan/remote_scan.rs
+++ b/crates/sqlexec/src/planner/physical_plan/remote_scan.rs
@@ -15,6 +15,7 @@ use datafusion::prelude::Expr;
 use futures::{stream, TryStreamExt};
 use std::any::Any;
 use std::fmt;
+use std::hash::Hash;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -29,6 +30,25 @@ pub enum ProviderReference {
     RemoteReference(Uuid),
     /// We have the provider ready to go.
     Provider(Arc<dyn TableProvider>),
+}
+
+impl PartialEq for ProviderReference {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::RemoteReference(id), Self::RemoteReference(other_id)) => id.eq(other_id),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ProviderReference {}
+
+impl Hash for ProviderReference {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if let Self::RemoteReference(id) = self {
+            id.hash(state)
+        }
+    }
 }
 
 impl fmt::Debug for ProviderReference {

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -62,10 +62,12 @@ use crate::parser::{
 use crate::planner::errors::{internal, PlanError, Result};
 use crate::planner::logical_plan::*;
 use crate::planner::preprocess::{preprocess, CastRegclassReplacer, EscapedStringToDoubleQuoted};
+use crate::remote::table::StubRemoteTableProvider;
 use crate::resolve::EntryResolver;
 
 use super::context_builder::PartialContextProvider;
 use super::extension::ExtensionNode;
+use super::physical_plan::remote_scan::ProviderReference;
 
 /// Plan SQL statements for a session.
 pub struct SessionPlanner<'a> {
@@ -872,12 +874,33 @@ impl<'a> SessionPlanner<'a> {
                     .insert_to_source_plan(&table_name, &columns, source)
                     .await?;
 
-                let resolver = EntryResolver::from_context(self.ctx);
-                let ent = resolver
-                    .resolve_entry_from_reference(table_name)?
-                    .try_into_table_entry()?;
+                let state = self.ctx.df_ctx().state();
+                let mut ctx_provider = PartialContextProvider::new(self.ctx, &state)?;
 
-                Ok(Insert { table: ent, source }.into_logical_plan())
+                let provider = ctx_provider.table_provider(table_name.clone()).await?;
+                let (runtime_preference, provider) = match (
+                    provider.preference,
+                    provider
+                        .provider
+                        .as_any()
+                        .downcast_ref::<StubRemoteTableProvider>(),
+                ) {
+                    (RuntimePreference::Remote, Some(stub)) => (
+                        RuntimePreference::Remote,
+                        ProviderReference::RemoteReference(stub.id()),
+                    ),
+                    _ => (
+                        RuntimePreference::Local,
+                        ProviderReference::Provider(provider.provider),
+                    ),
+                };
+
+                Ok(Insert {
+                    source,
+                    provider,
+                    runtime_preference,
+                }
+                .into_logical_plan())
             }
 
             ast::Statement::AlterTable {

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -49,6 +49,7 @@ use crate::planner::physical_plan::drop_tunnel::DropTunnelExec;
 use crate::planner::physical_plan::drop_views::DropViewsExec;
 use crate::planner::physical_plan::insert::InsertExec;
 use crate::planner::physical_plan::remote_exec::RemoteExecutionExec;
+use crate::planner::physical_plan::remote_scan::ProviderReference;
 use crate::planner::physical_plan::send_recv::SendRecvJoinExec;
 use crate::planner::physical_plan::set_var::SetVarExec;
 use crate::planner::physical_plan::show_var::ShowVarExec;
@@ -274,8 +275,8 @@ impl ExtensionPlanner for DDLExtensionPlanner {
             ExtensionType::Insert => {
                 let lp = require_downcast_lp::<Insert>(node);
                 Ok(Some(Arc::new(InsertExec {
-                    table: lp.table.clone(),
                     source: physical_inputs.get(0).unwrap().clone(),
+                    provider: lp.provider.clone(),
                 })))
             }
             ExtensionType::Delete => {
@@ -422,8 +423,8 @@ impl<'a> PhysicalPlanner for RemotePhysicalPlanner<'a> {
         // Execute the some plans into locally.
         let physical: Arc<dyn ExecutionPlan> = match ddl_rewriter {
             DDLRewriter::None => physical,
-            DDLRewriter::InsertIntoTempTable(table) => Arc::new(InsertExec {
-                table,
+            DDLRewriter::InsertIntoLocalTable(provider) => Arc::new(InsertExec {
+                provider: ProviderReference::Provider(provider),
                 source: physical,
             }),
             DDLRewriter::CreateTempTable(create_temp_table) => Arc::new(CreateTempTableExec {

--- a/crates/sqlexec/src/remote/table.rs
+++ b/crates/sqlexec/src/remote/table.rs
@@ -39,6 +39,11 @@ impl StubRemoteTableProvider {
         }
     }
 
+    /// Returns the provider ID.
+    pub fn id(&self) -> Uuid {
+        self.provider_id
+    }
+
     pub fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
         buf.extend_from_slice(self.provider_id.as_bytes());
         Ok(())


### PR DESCRIPTION
Lays down the framework for inserting into external sources.

Supporting inserts *should* be as simple as implementing the `insert_into` method for table providers.

This PR implements `insert_into` for Postgres datasource.

Fixes: #1883

Epic: #1143