### PR TITLE
chore: Reduce number of release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Build Release
 
 on:
   schedule:
-    # Run every day at 12:00
-    - cron: 0 12 * * *
+    # Run every Monday at 12:00
+    - cron: 0 12 * * 1
   workflow_dispatch:
   push:
     tags:


### PR DESCRIPTION
Build every Monday instead of every day. We're not currently making use of these "nightly" builds, and so there's some wasted work going. Having _some_ automated builds is nice though to catch possible breakages prior to actually trying to release.

cc @greyscaled 