### PR TITLE
feat: experimental prql support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,21 @@ dependencies = [
 
 [[package]]
 name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon 1.0.2",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
@@ -112,7 +127,7 @@ dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon",
+ "anstyle-wincon 2.1.0",
  "colorchoice",
  "utf8parse",
 ]
@@ -143,6 +158,16 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
@@ -156,6 +181,9 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "apache-avro"
@@ -182,6 +210,16 @@ dependencies = [
  "typed-builder 0.14.0",
  "uuid",
  "zerocopy",
+]
+
+[[package]]
+name = "ariadne"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72fe02fc62033df9ba41cba57ee19acf5e742511a140c7dbc3a873e19a19a1bd"
+dependencies = [
+ "unicode-width",
+ "yansi",
 ]
 
 [[package]]
@@ -1017,6 +1055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23170228b96236b5a7299057ac284a321457700bc8c41a4476052f0f4ba5349d"
+dependencies = [
+ "hashbrown 0.12.3",
+ "stacker",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +1101,7 @@ version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
 dependencies = [
- "anstream",
+ "anstream 0.5.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -2047,6 +2095,18 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4312,6 +4372,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "prql-ast"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d91522f9f16d055409b9ffec55693a96e3424fe5d8e7c8331adcf6d7ee363a"
+dependencies = [
+ "enum-as-inner 0.6.0",
+ "semver 1.0.19",
+ "serde",
+ "strum 0.25.0",
+]
+
+[[package]]
+name = "prql-compiler"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d56865532fcf1abaa31fbb6da6fd9e90edc441c5c78bfe2870ee75187c7a3c"
+dependencies = [
+ "anstream 0.3.2",
+ "anyhow",
+ "ariadne",
+ "csv",
+ "enum-as-inner 0.6.0",
+ "itertools 0.11.0",
+ "log",
+ "once_cell",
+ "prql-ast",
+ "prql-parser",
+ "regex",
+ "semver 1.0.19",
+ "serde",
+ "serde_json",
+ "sqlformat",
+ "sqlparser",
+ "strum 0.25.0",
+ "strum_macros 0.25.2",
+]
+
+[[package]]
+name = "prql-parser"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9360352e413390cfd26345f49279622b87581a3b748340d3f42d4d616c2a1ec1"
+dependencies = [
+ "chumsky",
+ "itertools 0.11.0",
+ "prql-ast",
+ "semver 1.0.19",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5709,6 +5828,7 @@ dependencies = [
  "pgrepr",
  "protogen",
  "proxyutil",
+ "prql-compiler",
  "regex",
  "reqwest",
  "serde",
@@ -5724,6 +5844,17 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7b278788e7be4d0d29c0f39497a0eef3fba6bbc8e70d8bf7fde46edeaa9e85"
+dependencies = [
+ "itertools 0.11.0",
+ "nom",
+ "unicode_categories",
 ]
 
 [[package]]
@@ -5756,6 +5887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ae05a8250b968a3f7db93155a84d68b2e6cea1583949af5ca5b5170c76c075"
 dependencies = [
  "log",
+ "serde",
  "sqlparser_derive",
 ]
 
@@ -5797,6 +5929,19 @@ dependencies = [
  "signature",
  "ssh-encoding",
  "zeroize",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]
@@ -6444,7 +6589,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.4.0",
  "futures-channel",
  "futures-io",
  "futures-util",
@@ -6578,6 +6723,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
@@ -7042,6 +7193,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yup-oauth2"

--- a/crates/datafusion_ext/src/vars.rs
+++ b/crates/datafusion_ext/src/vars.rs
@@ -14,8 +14,8 @@ use datafusion::variable::{VarProvider, VarType};
 use inner::*;
 use uuid::Uuid;
 
-pub use inner::SessionVarsInner;
 pub use inner::Dialect;
+pub use inner::SessionVarsInner;
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::borrow::ToOwned;

--- a/crates/datafusion_ext/src/vars.rs
+++ b/crates/datafusion_ext/src/vars.rs
@@ -15,6 +15,7 @@ use inner::*;
 use uuid::Uuid;
 
 pub use inner::SessionVarsInner;
+pub use inner::Dialect;
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::borrow::ToOwned;
@@ -92,6 +93,7 @@ impl SessionVars {
      max_tunnel_count: Option<usize>,
      max_credentials_count: Option<usize>,
      is_cloud_instance: bool,
+     dialect: Dialect
     }
 }
 

--- a/crates/datafusion_ext/src/vars/constants.rs
+++ b/crates/datafusion_ext/src/vars/constants.rs
@@ -188,6 +188,14 @@ pub(super) const IS_CLOUD_INSTANCE: ServerVar<bool> = ServerVar {
     description: "Determines if the server is local or cloud",
 };
 
+pub(super) const DIALECT: ServerVar<Dialect> = ServerVar {
+    name: "dialect",
+    value: &Dialect::Sql,
+    group: "glaredb",
+    user_configurable: true,
+    description: "Dialect of the sql engine",
+};
+
 /// Note that these are not normally shown in the search path.
 pub(super) const IMPLICIT_SCHEMAS: [&str; 2] = [
     POSTGRES_SCHEMA,

--- a/crates/datafusion_ext/src/vars/inner.rs
+++ b/crates/datafusion_ext/src/vars/inner.rs
@@ -13,6 +13,13 @@ use std::sync::Arc;
 use tracing::error;
 use uuid::Uuid;
 
+#[derive(Debug, Default, Clone)]
+pub enum Dialect {
+    #[default]
+    Sql,
+    Prql,
+}
+
 /// Variables for a session.
 #[derive(Debug)]
 pub struct SessionVarsInner {
@@ -39,7 +46,9 @@ pub struct SessionVarsInner {
     pub max_tunnel_count: SessionVar<Option<usize>>,
     pub max_credentials_count: SessionVar<Option<usize>>,
     pub is_cloud_instance: SessionVar<bool>,
+    pub dialect: SessionVar<Dialect>,
 }
+
 impl SessionVarsInner {
     /// Return an iterator to the variables that should be sent to the client on
     /// session start.
@@ -100,6 +109,8 @@ impl SessionVarsInner {
             Ok(&self.max_credentials_count)
         } else if name.eq_ignore_ascii_case(IS_CLOUD_INSTANCE.name) {
             Ok(&self.is_cloud_instance)
+        } else if name.eq_ignore_ascii_case(DIALECT.name) {
+            Ok(&self.dialect)
         } else {
             Err(VarError::UnknownVariable(name.to_string()).into())
         }
@@ -151,6 +162,8 @@ impl SessionVarsInner {
             self.max_tunnel_count.set_from_str(val, setter)
         } else if name.eq_ignore_ascii_case(MAX_CREDENTIALS_COUNT.name) {
             self.max_credentials_count.set_from_str(val, setter)
+        } else if name.eq_ignore_ascii_case(DIALECT.name) {
+            self.dialect.set_from_str(val, setter)
         } else {
             Err(VarError::UnknownVariable(name.to_string()).into())
         }
@@ -180,6 +193,7 @@ impl SessionVarsInner {
             self.max_tunnel_count.config_entry(),
             self.max_credentials_count.config_entry(),
             self.is_cloud_instance.config_entry(),
+            self.dialect.config_entry(),
         ]
     }
 }
@@ -209,6 +223,7 @@ impl Default for SessionVarsInner {
             max_tunnel_count: SessionVar::new(&MAX_TUNNEL_COUNT),
             max_credentials_count: SessionVar::new(&MAX_CREDENTIALS_COUNT),
             is_cloud_instance: SessionVar::new(&IS_CLOUD_INSTANCE),
+            dialect: SessionVar::new(&DIALECT),
         }
     }
 }

--- a/crates/datafusion_ext/src/vars/value.rs
+++ b/crates/datafusion_ext/src/vars/value.rs
@@ -94,3 +94,20 @@ impl Value for [String] {
         self.join(",")
     }
 }
+
+impl Value for Dialect {
+    fn try_parse(s: &str) -> Option<Self::Owned> {
+        match s {
+            "sql" => Some(Dialect::Sql),
+            "prql" => Some(Dialect::Prql),
+            _ => None,
+        }
+    }
+
+    fn format(&self) -> String {
+        match self {
+            Dialect::Sql => "sql".to_string(),
+            Dialect::Prql => "prql".to_string(),
+        }
+    }
+}

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 
 use datafusion_ext::vars::SessionVars;
 use sqlexec::engine::{Engine, SessionStorageConfig, TrackedSession};
-use sqlexec::parser;
 use sqlexec::remote::client::RemoteClient;
 use sqlexec::session::ExecutionResult;
 use std::env;
@@ -203,7 +202,7 @@ impl LocalSession {
 
         const UNNAMED: String = String::new();
 
-        let statements = parser::parse_sql(text)?;
+        let statements = self.sess.parse_query(text)?;
         for stmt in statements {
             self.sess
                 .prepare_statement(UNNAMED, Some(stmt), Vec::new())

--- a/crates/sqlexec/Cargo.toml
+++ b/crates/sqlexec/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.12.1"
 serde = { workspace = true }
 itertools = "0.11.0"
 reqwest = { version = "0.11.18", default-features = false, features = ["json"] }
+prql-compiler = "0.9.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/sqlexec/src/parser.rs
+++ b/crates/sqlexec/src/parser.rs
@@ -373,7 +373,7 @@ impl CustomParser<'_> {
     const DIALECT: &'static GenericDialect = &GenericDialect {};
 
     pub fn new(sql: &str, use_prql: bool) -> Result<CustomParser<'_>, ParserError> {
-        let tokens = Tokenizer::new(Self::DIALECT, &sql).tokenize()?;
+        let tokens = Tokenizer::new(Self::DIALECT, sql).tokenize()?;
         let mut parser = Parser::new(Self::DIALECT).with_tokens(tokens);
         if use_prql {
             // Special case for SET statements, which are not supported by PRQL.

--- a/testdata/sqllogictests/prql.slt
+++ b/testdata/sqllogictests/prql.slt
@@ -1,0 +1,14 @@
+statement ok
+set dialect = 'prql'
+
+statement ok
+from glare_catalog.tables | take 1
+
+statement error sql parser error: Error compiling PRQL:
+select * from glare_catalog.tables limit 1
+
+statement ok
+set dialect = 'sql'
+
+statement ok
+select * from glare_catalog.tables limit 1


### PR DESCRIPTION
allows users to use the experimental `prql` language instead of sql

closes #1772 

See https://prql-lang.org/ for more info.


To use, simply set the dialect
```sql
set dialect = 'prql';
```
then you can use prql syntax

```elm
from my_table 
filter some_column == "hello world"
take 1
```

To switch back to sql, just set the dialct to `sql`

```sql
set dialect = 'sql';
```

## Note: 
custom table functions & expressions are not yet supported, This gives us relatively limited prql functionality & should be marked as experimental. 
 
