### PR TITLE
feat: Enable passing SQL script as an argument

### DIFF
--- a/crates/glaredb/src/args/local.rs
+++ b/crates/glaredb/src/args/local.rs
@@ -11,6 +11,9 @@ pub struct LocalArgs {
 
     #[clap(flatten)]
     pub opts: LocalClientOpts,
+
+    /// Execute an SQL file.
+    pub file: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]


### PR DESCRIPTION
**`test.sql`**:

```sql
-- Create a new table
CREATE TABLE test (
    col1 INTEGER,
    col2 TEXT
);

-- Insert some values into the table
INSERT INTO test VALUES
    (1, 'Hello'),
    (2, 'Bye');

-- Run a very complicated query
SELECT * FROM test;
```

Shell:

```shell
> glaredb test.sql # or glaredb local test.sql
Table created
Inserted 2 rows
┌───────┬───────┐
│  col1 │ col2  │
│    ── │ ──    │
│ Int32 │ Utf8  │
╞═══════╪═══════╡
│     1 │ Hello │
│     2 │ Bye   │
└───────┴───────┘
```