### PR TITLE
feat: Enable binary encoding when requested by the client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,9 @@ jobs:
         run: |
           PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
 
+      - name: PG Protocol Tests (SLT Runner)
+        run: just slt -v 'pgproto/*'
+
   sql-logic-tests:
     name: SQL Logic Tests
     runs-on: ubuntu-latest-8-cores

--- a/crates/pgrepr/src/writer.rs
+++ b/crates/pgrepr/src/writer.rs
@@ -175,7 +175,9 @@ impl Writer for BinaryWriter {
     }
 
     fn write_decimal(_buf: &mut BytesMut, _v: &Decimal128) -> Result<()> {
-        unimplemented!()
+        Err(PgReprError::InternalError(
+            "cannot encode decimal (numeric) value into PG binary".to_string(),
+        ))
     }
 }
 

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -478,7 +478,10 @@ pub struct Portal {
 impl Portal {
     /// Returns an iterator over the fields of output schema (if any).
     pub fn output_fields(&self) -> Option<OutputFields<'_>> {
-        self.stmt.output_fields()
+        self.stmt.output_fields().map(|mut output_fields| {
+            output_fields.result_formats = Some(self.result_formats.as_slice().iter());
+            output_fields
+        })
     }
 }
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -529,6 +529,7 @@ impl Session {
         _max_rows: i32,
     ) -> Result<ExecutionResult> {
         let portal = self.ctx.get_portal(portal_name)?;
+
         let plan = match &portal.stmt.plan {
             Some(plan) => plan.clone(),
             None => return Ok(ExecutionResult::EmptyQuery),

--- a/crates/testing/tests/sqllogictests/main.rs
+++ b/crates/testing/tests/sqllogictests/main.rs
@@ -5,13 +5,14 @@ use anyhow::Result;
 use hooks::{AllTestsHook, SshTunnelHook};
 use std::sync::Arc;
 use testing::slt::runner::SltRunner;
-use tests::SshKeysTest;
+use tests::{PgBinaryEncoding, SshKeysTest};
 
 fn main() -> Result<()> {
     SltRunner::new()
         .test_files_dir("../../testdata")?
         // Rust tests
         .test("sqllogictests/ssh_keys", Box::new(SshKeysTest))?
+        .test("pgproto/binary_encoding", Box::new(PgBinaryEncoding))?
         // Add hooks
         .hook("*", Arc::new(AllTestsHook))?
         // SSH Tunnels hook


### PR DESCRIPTION
Missing:
- [ ] Binary encoding for decimals (numerics) #947

Fixes #1921