### PR TITLE
fix: prql over psql

### DIFF
--- a/crates/datafusion_ext/src/vars/inner.rs
+++ b/crates/datafusion_ext/src/vars/inner.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tracing::error;
 use uuid::Uuid;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum Dialect {
     #[default]
     Sql,


### PR DESCRIPTION
Since the `;` is needed to designate end of statement, we need to remove it before parsing.

closes #1920 

