### PR TITLE
fix: add better error messages for parsing datasource urls

### DIFF
--- a/crates/datasources/src/common/url.rs
+++ b/crates/datasources/src/common/url.rs
@@ -78,7 +78,6 @@ impl DatasourceUrl {
                 // TODO: Check if it's actually a file path (maybe invalid but
                 // probably check).
                 let path = PathBuf::from(u);
-                let path = path.canonicalize()?;
                 return Ok(Self::File(path));
             }
             Err(e) => return Err(DatasourceCommonError::InvalidUrl(e.to_string())),

--- a/crates/datasources/src/common/url.rs
+++ b/crates/datasources/src/common/url.rs
@@ -58,10 +58,7 @@ impl FromFuncParamValue for DatasourceUrl {
     }
 
     fn is_param_valid(value: &FuncParamValue) -> bool {
-        match value {
-            FuncParamValue::Scalar(ScalarValue::Utf8(Some(_))) => true,
-            _ => false,
-        }
+        matches!(value, FuncParamValue::Scalar(ScalarValue::Utf8(Some(_))))
     }
 }
 

--- a/crates/datasources/src/object_store/local.rs
+++ b/crates/datasources/src/object_store/local.rs
@@ -31,7 +31,8 @@ impl ObjStoreAccess for LocalStoreAccess {
     }
 
     fn path(&self, location: &str) -> Result<ObjectStorePath> {
-        Ok(ObjectStorePath::from_filesystem_path(location)?)
+        ObjectStorePath::from_filesystem_path(location)
+            .map_err(|e| super::errors::ObjectStoreSourceError::ObjectStorePath(e))
     }
 
     /// Given relative paths and all other stuff, it's much simpler to use
@@ -49,13 +50,13 @@ impl ObjStoreAccess for LocalStoreAccess {
                 require_literal_leading_dot: true,
             },
         )?;
-
         let mut objects = Vec::new();
         for path in paths {
             let path = path?;
             let meta = path.metadata()?;
+            let loc = self.path(path.to_string_lossy().as_ref());
             let meta = ObjectMeta {
-                location: self.path(path.to_string_lossy().as_ref())?,
+                location: loc?,
                 last_modified: meta.modified()?.into(),
                 size: meta.len() as usize,
                 e_tag: None,

--- a/crates/datasources/src/object_store/local.rs
+++ b/crates/datasources/src/object_store/local.rs
@@ -32,7 +32,7 @@ impl ObjStoreAccess for LocalStoreAccess {
 
     fn path(&self, location: &str) -> Result<ObjectStorePath> {
         ObjectStorePath::from_filesystem_path(location)
-            .map_err(|e| super::errors::ObjectStoreSourceError::ObjectStorePath(e))
+            .map_err(super::errors::ObjectStoreSourceError::ObjectStorePath)
     }
 
     /// Given relative paths and all other stuff, it's much simpler to use

--- a/crates/datasources/src/object_store/local.rs
+++ b/crates/datasources/src/object_store/local.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -19,7 +20,18 @@ impl Display for LocalStoreAccess {
         write!(f, "LocalStoreAccess")
     }
 }
-
+impl LocalStoreAccess {
+    fn meta_from_path(&self, path: PathBuf) -> Result<ObjectMeta> {
+        let meta = path.metadata()?;
+        let path = path.canonicalize()?;
+        Ok(ObjectMeta {
+            location: self.path(path.to_string_lossy().as_ref())?,
+            last_modified: meta.modified()?.into(),
+            size: meta.len() as usize,
+            e_tag: None,
+        })
+    }
+}
 #[async_trait]
 impl ObjStoreAccess for LocalStoreAccess {
     fn base_url(&self) -> Result<ObjectStoreUrl> {
@@ -50,20 +62,20 @@ impl ObjStoreAccess for LocalStoreAccess {
                 require_literal_leading_dot: true,
             },
         )?;
+
         let mut objects = Vec::new();
+
         for path in paths {
             let path = path?;
-            let meta = path.metadata()?;
-            let loc = self.path(path.to_string_lossy().as_ref());
-            let meta = ObjectMeta {
-                location: loc?,
-                last_modified: meta.modified()?.into(),
-                size: meta.len() as usize,
-                e_tag: None,
-            };
+            let meta = self.meta_from_path(path)?;
             objects.push(meta);
         }
 
+        if objects.is_empty() {
+            let path = PathBuf::from(pattern);
+            let meta = self.meta_from_path(path)?;
+            objects.push(meta);
+        }
         Ok(objects)
     }
 }

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -101,10 +101,7 @@ impl TableFunc for ObjScanTableFunc {
         let urls = match url_arg {
             FuncParamValue::Scalar(ScalarValue::Utf8(Some(s))) => {
                 let url = DatasourceUrl::try_new(&s).map_err(|e| {
-                    ExtensionError::String(format!(
-                        "Unable to parse '{s}': {}",
-                        e.to_string()
-                    ))
+                    ExtensionError::String(format!("Unable to parse '{s}': {}", e))
                 })?;
                 vec![url]
             }

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -11,6 +11,7 @@ use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::{Signature, Volatility};
+use datafusion::scalar::ScalarValue;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{
     FromFuncParamValue, FuncParamValue, IdentValue, TableFunc, TableFuncContextProvider,
@@ -97,11 +98,22 @@ impl TableFunc for ObjScanTableFunc {
 
         let mut args = args.into_iter();
         let url_arg = args.next().unwrap();
-
-        let urls = if DatasourceUrl::is_param_valid(&url_arg) {
-            vec![url_arg.param_into()?]
-        } else {
-            url_arg.param_into::<Vec<DatasourceUrl>>()?
+        let urls = match url_arg {
+            FuncParamValue::Scalar(ScalarValue::Utf8(Some(s))) => {
+                let url = DatasourceUrl::try_new(&s).map_err(|e| {
+                    ExtensionError::String(format!(
+                        "Unable to parse '{s}': {}",
+                        e.to_string()
+                    ))
+                })?;
+                vec![url]
+            }
+            FuncParamValue::Array(_) => url_arg.param_into::<Vec<DatasourceUrl>>()?,
+            _ => {
+                return Err(ExtensionError::String(
+                    "Invalid input. Received 'ident' expected string or list of strings".to_owned(),
+                ));
+            }
         };
 
         if urls.is_empty() {

--- a/crates/sqlbuiltins/src/functions/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/object_store.rs
@@ -100,9 +100,8 @@ impl TableFunc for ObjScanTableFunc {
         let url_arg = args.next().unwrap();
         let urls = match url_arg {
             FuncParamValue::Scalar(ScalarValue::Utf8(Some(s))) => {
-                let url = DatasourceUrl::try_new(&s).map_err(|e| {
-                    ExtensionError::String(format!("Unable to parse '{s}': {}", e))
-                })?;
+                let url = DatasourceUrl::try_new(&s)
+                    .map_err(|e| ExtensionError::String(format!("Unable to parse '{s}': {}", e)))?;
                 vec![url]
             }
             FuncParamValue::Array(_) => url_arg.param_into::<Vec<DatasourceUrl>>()?,

--- a/testdata/sqllogictests/functions/parquet_scan.slt
+++ b/testdata/sqllogictests/functions/parquet_scan.slt
@@ -39,7 +39,7 @@ select count(*) from parquet_scan([
 ----
 2000
 
-statement error internal error: cannot execute simple query: db error: ERROR: External error: Unable to convert path "./testdata/parquet/userdata1.paruqet" to URL
+statement error No such file or directory
 select * from parquet_scan('./testdata/parquet/userdata1.paruqet');
 
 # Ambiguous name.


### PR DESCRIPTION
closes #1897
closes https://github.com/GlareDB/glaredb/issues/1936

The error messages should properly bubble up now. 

Additionally, we now canonicalize the relative paths during `DatasourceUrl::try_new`. This ensures that the path is absolute, and that it is a valid file/directory. 