### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -27,8 +27,6 @@ jobs:
           # Required to generate TPC-H data
           submodules: 'recursive'
 
-      - uses: dtolnay/rust-toolchain@1.73.0
-
       - uses: extractions/setup-just@v1
         name: Setup just
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -41,10 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -67,10 +59,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -98,10 +86,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -124,10 +108,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -136,9 +116,6 @@ jobs:
             ~/.cargo/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-
       - name: PG Protocol Tests
         run: |
           PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
@@ -153,10 +130,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache
@@ -177,10 +150,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
-        with:
-          components: clippy,rustfmt
       - uses: extractions/setup-just@v1
       - uses: actions/cache@v3
         name: Cache

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -23,7 +23,6 @@ jobs:
         target: [x86_64]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: extractions/setup-just@v1
       - name: install protoc
         run: just protoc
@@ -52,7 +51,6 @@ jobs:
         target: [x64]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: extractions/setup-just@v1
       - name: install protoc
         run: just protoc
@@ -84,7 +82,6 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: extractions/setup-just@v1
       - name: install protoc
         run: just protoc

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.73"
+channel = "1.73.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
closes #1946

adding a [rust-toolchain.toml](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) will prevent any inconsistencies during development as noticed in #1946.