### PR TITLE
chore: Use ld_classic when linking on mac

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,9 @@
 [alias]
 xtask = "run --bin xtask --"
+
+[target."aarch64-apple-darwin"]
+# Get proper backtraces in mac Sonoma. Currently there's an issue with the new
+# linker that prevents backtraces from getting printed correctly.
+#
+# <https://github.com/rust-lang/rust/issues/113783>
+rustflags=["-Clink-arg=-Wl,-ld_classic"]


### PR DESCRIPTION
I was having some issues with panics not showing backtraces, and instead showing the following:

```
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
```

This seems to be from the latest mac update using a new linker. See https://github.com/rust-lang/rust/issues/113783

As an aside, I think might have an errant panic somewhere that's not getting bubbled up properly.