### PR TITLE
chore: Add back __init__.py file

### DIFF
--- a/py-glaredb/glaredb/__init__.py
+++ b/py-glaredb/glaredb/__init__.py
@@ -1,0 +1,9 @@
+# pylint: disable-all
+from .glaredb import connect, sql, execute, __runtime
+
+__all__ = [
+    "connect",
+    "sql",
+    "execute",
+    "__runtime",
+]


### PR DESCRIPTION
I'm not sure what this is actually for, but it seems like it's needed for me to run stuff locally.

We previously had this file, but it was deleted in https://github.com/GlareDB/glaredb/pull/1909 which I don't believe was intentional.

Fixes https://github.com/GlareDB/glaredb/issues/2006