### PR TITLE
fix: Remove terminal width detection from pretty table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ name = "arrow_util"
 version = "0.6.0"
 dependencies = [
  "comfy-table",
+ "crossterm",
  "datafusion",
  "once_cell",
  "textwrap",
@@ -2566,7 +2567,6 @@ dependencies = [
  "arrow_util",
  "clap",
  "colored",
- "crossterm",
  "datafusion",
  "datafusion_ext",
  "futures",

--- a/crates/arrow_util/Cargo.toml
+++ b/crates/arrow_util/Cargo.toml
@@ -10,3 +10,4 @@ datafusion = { workspace = true }
 comfy-table = "7.1.0"
 once_cell = "1.18.0"
 textwrap = { version = "0.16.0", default-features = false, features = ["unicode-width"] }
+crossterm = "0.27.0"

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -32,6 +32,19 @@ pub fn pretty_format_batches(
     PrettyTable::try_new(schema, batches, max_width, max_rows)
 }
 
+/// Get the terminal's width in characters.
+///
+/// This can be used as the `max_width` argument when pretty formatting to
+/// ensure the formatted table doesn't exceed the width of the terminal.
+///
+/// If the width can't be determine or is unreasonable (0), then a default width
+/// of 80 is used.
+pub fn term_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(width, _)| if width == 0 { 80 } else { width as usize })
+        .unwrap_or(80)
+}
+
 #[derive(Debug)]
 struct PrettyTable {
     table: Table,
@@ -88,7 +101,6 @@ impl PrettyTable {
             None => vec![ColumnValues::default(); col_headers.len()],
         };
 
-        let max_width = max_width.or(table.width().map(|v| v as usize));
         let format =
             TableFormat::from_headers_and_sample_vals(&col_headers, &first_vals, max_width);
 

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -33,7 +33,6 @@ futures = "0.3.29"
 colored = "2.0.4"
 reedline = "0.25.0"
 nu-ansi-term = "0.49.0"
-crossterm = "0.27.0"
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -2,7 +2,7 @@ use crate::args::{LocalClientOpts, OutputMode, StorageConfigArgs};
 use crate::highlighter::{SQLHighlighter, SQLHinter, SQLValidator};
 use crate::prompt::SQLPrompt;
 use anyhow::{anyhow, Result};
-use arrow_util::pretty::pretty_format_batches;
+use arrow_util::pretty;
 use clap::ValueEnum;
 use colored::Colorize;
 use datafusion::arrow::csv::writer::WriterBuilder as CsvWriterBuilder;
@@ -326,8 +326,8 @@ async fn print_stream(
         OutputMode::Table => {
             // If width not explicitly set by the user, try to get the width of ther
             // terminal.
-            let width = max_width.unwrap_or(term_width());
-            let disp = pretty_format_batches(&schema, &batches, Some(width), max_rows)?;
+            let width = max_width.unwrap_or(pretty::term_width());
+            let disp = pretty::pretty_format_batches(&schema, &batches, Some(width), max_rows)?;
             println!("{disp}");
         }
         OutputMode::Csv => {
@@ -396,10 +396,4 @@ fn get_history_path() -> PathBuf {
     home_dir.push(".glaredb");
     home_dir.push("history.txt");
     home_dir
-}
-
-fn term_width() -> usize {
-    crossterm::terminal::size()
-        .map(|(width, _)| width as usize)
-        .unwrap_or(80)
 }

--- a/js-glaredb/src/execution_result.rs
+++ b/js-glaredb/src/execution_result.rs
@@ -1,4 +1,4 @@
-use arrow_util::pretty::pretty_format_batches;
+use arrow_util::pretty;
 
 use datafusion::arrow::ipc::writer::FileWriter;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -75,8 +75,9 @@ async fn print_batch(result: &mut ExecutionResult) -> napi::Result<()> {
                 .collect::<Result<Vec<RecordBatch>, _>>()
                 .map_err(JsGlareDbError::from)?;
 
-            let disp = pretty_format_batches(&schema, &batches, None, None)
-                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            let disp =
+                pretty::pretty_format_batches(&schema, &batches, Some(pretty::term_width()), None)
+                    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
             println!("{}", disp);
             Ok(())

--- a/py-glaredb/src/execution_result.rs
+++ b/py-glaredb/src/execution_result.rs
@@ -1,6 +1,6 @@
 use crate::util::pyprint;
 use anyhow::Result;
-use arrow_util::pretty::pretty_format_batches;
+use arrow_util::pretty;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::ToPyArrow;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -129,8 +129,9 @@ fn print_batch(result: &mut ExecutionResult, py: Python<'_>) -> PyResult<()> {
                     .collect::<Result<Vec<RecordBatch>, _>>()
             })?;
 
-            let disp = pretty_format_batches(&schema, &batches, None, None)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            let disp =
+                pretty::pretty_format_batches(&schema, &batches, Some(pretty::term_width()), None)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
             pyprint(disp, py)
         }


### PR DESCRIPTION
And instead alway require that it's passed in. Removes some magic and makes things a bit more reproducible.

Fixes https://github.com/GlareDB/glaredb/issues/2005 (terminal width was getting reported as zero inside eshell)