### PR TITLE
!experiment(rpc_proxy): client_auth_optional

### DIFF
--- a/crates/glaredb/src/rpc_proxy.rs
+++ b/crates/glaredb/src/rpc_proxy.rs
@@ -50,7 +50,11 @@ impl RpcProxy {
             let identity = Identity::from_pem(cert, key);
 
             server
-                .tls_config(ServerTlsConfig::new().identity(identity))?
+                .tls_config(
+                    ServerTlsConfig::new()
+                        .identity(identity)
+                        .client_auth_optional(true),
+                )?
                 .add_service(ExecutionServiceServer::new(self.handler))
                 .serve(addr)
                 .await?;


### PR DESCRIPTION
This is progress towards #1828. After testing, the next step would be to turn the `disable_tls` in `LocalClientOpts` and `connect` annotation in py-glaredb