### PR TITLE
fix: prql slt runner

### DIFF
--- a/crates/testing/src/slt/test.rs
+++ b/crates/testing/src/slt/test.rs
@@ -10,7 +10,6 @@ use pgrepr::types::arrow_to_pg_type;
 use regex::{Captures, Regex};
 use sqlexec::engine::{Engine, EngineStorageConfig, SessionStorageConfig, TrackedSession};
 use sqlexec::errors::ExecError;
-use sqlexec::parser;
 use sqlexec::remote::client::RemoteClient;
 use sqlexec::session::ExecutionResult;
 use sqllogictest::{
@@ -291,8 +290,8 @@ impl AsyncDB for TestClient {
             Self::Rpc(RpcTestClient { session, .. }) => {
                 let mut session = session.lock().await;
                 const UNNAMED: String = String::new();
+                let statements = session.parse_query(sql)?;
 
-                let statements = parser::parse_sql(sql)?;
                 for stmt in statements {
                     session
                         .prepare_statement(UNNAMED, Some(stmt), Vec::new())

--- a/justfile
+++ b/justfile
@@ -101,7 +101,8 @@ rpc-tests: protoc
     'sqllogictests/vars' \
     'sqllogictests/views' \
     'sqllogictests/virtual_catalog' \
-    'sqllogictests/xlsx'
+    'sqllogictests/xlsx' \
+    'sqllogictests/prql'
 
 #  Check formatting.
 fmt-check: protoc


### PR DESCRIPTION
closes #2012

We weren't using the prql aware parser, but instead the `parse_sql` function