### PR TITLE
feat(sqlexec rpc): client auth error messages

### DIFF
--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -209,7 +209,7 @@ impl RemoteClient {
         body.insert("password", params.password);
         body.insert("org_name", params.org);
         body.insert("db_name", params.db_name);
-        body.insert("api_version", 1.to_string());
+        body.insert("api_version", 2.to_string());
         body.insert("client_type", client_type.to_string());
 
         info!("client authentication");


### PR DESCRIPTION
Examples:

1. Auth errors (connection string, `--cloud-addr` mismatch etc)
```shell
$ cargo run --bin glaredb -- --cloud-url=<URL> --cloud-addr=https://console.glaredb.com
GlareDB (v0.6.1)
Error: authentication failed
```

2. Version out of date (0.7.0):

```shell
$ cargo run --bin glaredb -- --cloud-url=<URL> --cloud-addr=https://qa.glaredb.com
GlareDB (v0.6.1)
Error: version unsupported: update to glaredb v0.7.0 or later: hint: curl https://glaredb.com/install.sh | sh
```