### PR TITLE
chore(bindings-node): add catch_unwind

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -90,10 +90,12 @@ export class Connection {
    */
   static defaultInMemory(): Promise<Connection>
   /**
-   * Run a SQL querying against a GlareDB database.
+   * Run a SQL operation against a GlareDB database.
    *
-   * Note that this will only plan the query. To execute the query, call any
-   * of `execute`, `show`, `toArrow`,  or `toPolars`
+   * All operations that write or modify data are executed
+   * directly, but all query operations run lazily when you process
+   * their results with `show`, `toArrow`, or
+   * `toPolars`, or call the `execute` method.
    *
    * # Examples
    *
@@ -127,6 +129,22 @@ export class Connection {
    * ```
    */
   sql(query: string): Promise<JsLogicalPlan>
+  /**
+   * Run a PRQL query against a GlareDB database. Does not change
+   * the state or dialect of the connection object.
+   *
+   * ```javascript
+   * import glaredb from "@glaredb/node"
+   *
+   * let con = glaredb.connect()
+   * let cursor = await con.sql('from my_table | take 1');
+   * await cursor.show()
+   * ```
+   *
+   * All operations execute lazily when their results are
+   * processed.
+   */
+  prql(query: string): Promise<JsLogicalPlan>
   /**
    * Execute a query.
    *

--- a/bindings/nodejs/src/connect.rs
+++ b/bindings/nodejs/src/connect.rs
@@ -42,7 +42,7 @@ impl ConnectOptions {
 }
 
 /// Connect to a GlareDB database.
-#[napi]
+#[napi(catch_unwind)]
 pub async fn connect(
     data_dir_or_cloud_url: Option<String>,
     options: Option<ConnectOptions>,

--- a/bindings/nodejs/src/logical_plan.rs
+++ b/bindings/nodejs/src/logical_plan.rs
@@ -29,29 +29,29 @@ impl JsLogicalPlan {
 
 #[napi]
 impl JsLogicalPlan {
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn to_string(&self) -> napi::Result<String> {
         Ok(format!("{:?}", self.lp))
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub async fn show(&self) -> napi::Result<()> {
         self.execute_inner().await?.show().await?;
         Ok(())
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub async fn execute(&self) -> napi::Result<()> {
         self.execute_inner().await?.execute().await?;
         Ok(())
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub async fn record_batches(&self) -> napi::Result<Vec<crate::record_batch::JsRecordBatch>> {
         self.execute_inner().await?.record_batches().await
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub async fn to_ipc(&self) -> napi::Result<napi::bindgen_prelude::Buffer> {
         let inner = self.execute_inner().await?.to_arrow_inner().await?;
         Ok(inner.into())


### PR DESCRIPTION
just adds `catch_unwind` to all public methods to prevent panics. 