### PR TITLE
chore(bindings-node): update examples

### DIFF
--- a/bindings/nodejs/example.js
+++ b/bindings/nodejs/example.js
@@ -1,5 +1,0 @@
-import glaredb from './glaredb.js'
-
-let con = await glaredb.connect();
-let res = await con.sql("select * from '../../testdata/json/userdata1.json' where id = -1");
-await res.show()

--- a/bindings/nodejs/examples/commonjs.js
+++ b/bindings/nodejs/examples/commonjs.js
@@ -1,0 +1,13 @@
+const glaredb = require('../glaredb.js');
+
+async function main() {
+  try {
+    let con = await glaredb.connect();
+    let res = await con.sql("select * from '../../../testdata/json/userdata1.json' limit 1");
+    await res.show()
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+main().catch(console.error);

--- a/bindings/nodejs/examples/esm.js
+++ b/bindings/nodejs/examples/esm.js
@@ -1,0 +1,5 @@
+import glaredb from '../glaredb.js'
+
+let con = await glaredb.connect();
+let res = await con.sql("select * from '../../../testdata/json/userdata1.json' limit 1");
+await res.show()


### PR DESCRIPTION
removes the `example.js` and instead adds  `examples/commonjs` and `examples/esm`. 

The commonjs one can be run with node without any transpilation or special configuration

```sh
node examples/commonjs.js
```

The esm one requires module support which is not provided with node out of the box, but is easily run via bun

```sh
bun examples/esm.js
```

closes #2063 