### PR TITLE
fix: case sensitivity in create table

### DIFF
--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -865,8 +865,11 @@ impl<'a> SessionPlanner<'a> {
                         .iter()
                         .zip(df_fields.iter())
                         .map(|(field, df_field)| {
-                            cast(col(df_field.name()), field.data_type().clone())
-                                .alias(field.name())
+                            cast(
+                                col(df_field.unqualified_column()),
+                                field.data_type().clone(),
+                            )
+                            .alias(field.name())
                         })
                         .collect();
 

--- a/testdata/csv/case_sensitive_columns.csv
+++ b/testdata/csv/case_sensitive_columns.csv
@@ -1,0 +1,4 @@
+Name,AGE,Gender,email,name,Email
+Alice,25,Female,alice@example.com,alice,aliceA@example.com
+Bob,30,Male,bob@example.com,bob,bobB@example.com
+Charlie,35,Male,charlie@example.com,charlie,charlieC@example.com

--- a/testdata/sqllogictests/create_table.slt
+++ b/testdata/sqllogictests/create_table.slt
@@ -78,3 +78,44 @@ query I
 select count(*) from glare_catalog.tables where builtin = false and table_name = 't1';
 ----
 1
+
+
+#2034 case sensitive table names
+statement ok 
+create table case_sensitive as select * from '../../testdata/csv/case_sensitive_columns.csv';
+
+statement error Duplicate name: case_sensitive
+create table "case_sensitive" as select * from '../../testdata/csv/case_sensitive_columns.csv';
+
+statement ok
+create table "Case_Sensitive" as select * from '../../testdata/csv/case_sensitive_columns.csv';
+
+statement ok
+create table "Case Sensitive" as select * from '../../testdata/csv/case_sensitive_columns.csv';
+
+query I rowsort
+select name from case_sensitive
+----
+alice
+bob
+charlie
+
+query I rowsort
+select "Name" from case_sensitive
+----
+Alice
+Bob
+Charlie
+
+statement error
+select age from "case_sensitive"
+
+statement ok
+select "AGE" from "case_sensitive"
+
+statement ok
+select * from "Case_Sensitive"
+
+statement ok
+select * from "Case Sensitive"
+


### PR DESCRIPTION
closes #2034 

Turns out there was some implicit casting with `Into<Column>` + `DfField::name` that was casting it to lowercase. Using `DfField::unqualified_column` instead preserves the original field name. 