### PR TITLE
feat(kdl): kdl_match function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,6 +3564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdl"
+version = "5.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11eecaf214881ac67e858089a815fa8cad941abcf21113970a6c5bc6e6e557c8"
+dependencies = [
+ "miette",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,6 +4122,29 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -6769,6 +6803,7 @@ dependencies = [
  "datasources",
  "futures",
  "itertools 0.12.0",
+ "kdl",
  "logutil",
  "metastore",
  "object_store",

--- a/crates/sqlexec/Cargo.toml
+++ b/crates/sqlexec/Cargo.toml
@@ -35,6 +35,7 @@ tokio-postgres = "0.7.8"
 once_cell = "1.18.0"
 url.workspace = true
 parking_lot = "0.12.1"
+kdl = "5.0.0-alpha.1"
 serde = { workspace = true }
 itertools = "0.12.0"
 reqwest = { version = "0.11.22", default-features = false, features = ["json"] }

--- a/testdata/sqllogictests/functions/kdl.slt
+++ b/testdata/sqllogictests/functions/kdl.slt
@@ -1,0 +1,17 @@
+statement ok
+create table cows (id integer, docs string);
+
+insert into cows (0, 'name = "betsy" details { a=1; b=100 }')
+
+statement ok
+select count(*) from test where kdl_matches(test.docs, "a = 1");
+---
+0
+
+statement error
+select * from test where kdl_matches(test.docs, "a = 1");
+
+statement ok
+select count(*) from test where kdl_matches(test.docs, "name = betsy");
+---
+1


### PR DESCRIPTION
This is definitely a WIP (though I think it's relatively safe, as
these things go,) and I mostly wanted to see what it would take to do
something like this.

KDL is a pretty neat way of expressing "documents" and comes with a
pretty complete ecosystem of tools and the query language means this
is pretty easy to support without all that much heavy lifting.

I wanted to stop and get feedback before digging further in, and
obviously see what CI had to say for itself. 

In my mind there were a couple of other interesting
things/possibilites that I wanted to mention, because I had been
thinking about it.

- I really wanted to have a way of type alaising a field so that it
  could have KDL data in it and GlareDB (and in particular the storage
  engine) could think about optimizations within that. Adding UDFs
  seems tractable, and while I think ultimately we'd want to store KDL
  data in UTF-8 fields: it'd be nice to be able to error if someone
  passed the wrong kind of field.

- It's a project for another day, but it would be interesting to see
  if you could make a binary format based on the data model:
  
  - length prefixes for more efficent skipping.
  
  - store the encoding format for numbers (int32 for number of 32bit
    integers of storage; plus 32bits for a bitmask to store
    [is_float;is_varint,is_string])

  - maybe use the sign bit of the length prefixes for "streaming" to
    indicate if this length includes the end of
    document/message/component or if after the provided length the
    _next_ length is a continuation of the same object.