### PR TITLE
chore: Enable corepack before setting up node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,11 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-node/issues/899
+      - name: Enable Corepack before setting up Node
+        run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/nodejs-release.yml
+++ b/.github/workflows/nodejs-release.yml
@@ -62,6 +62,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
       - run: just protoc
+
+      # https://github.com/actions/setup-node/issues/899
+      - name: Enable Corepack before setting up Node
+        run: corepack enable
+
       - name: Setup node
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
@@ -127,6 +132,7 @@ jobs:
           name: bindings-${{ matrix.settings.target }}
           path: bindings/nodejs/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
+
   publish:
     name: Publish
     runs-on: ubuntu-2004-8-cores
@@ -136,6 +142,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
       - run: just protoc
+
+      # https://github.com/actions/setup-node/issues/899
+      - name: Enable Corepack before setting up Node
+        run: corepack enable
+
       - name: Setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
See https://github.com/actions/setup-node/issues/899

When defining `packageManager` in package.json, github runners will now error about using the wrong yarn version. This change seems like it'll be a temp fix until either the setup-node action or github runner gets update (to what exactly, I'm not sure, but we should follow the issue).