### PR TITLE
feat: Add 'access_mode' column for databases and tables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,13 +282,13 @@ jobs:
           echo "-------------------------------- WITHOUT TUNNEL TEST --------------------------------"
           # Run all data source tests without running tunnel tests or the basic
           # SLT tests.
-          just slt -v --exclude 'sqllogictests/*' --exclude '*/tunnels/ssh'
+          just slt --exclude 'sqllogictests/*' --exclude '*/tunnels/ssh'
 
           echo "-------------------------------- WITH TUNNEL TEST --------------------------------"
           # SSH tests are prone to fail if we make a lot of connections at the
           # same time. Hence, it makes sense to run all the SSH tests one-by-one
           # in order to test the SSH tunnels (which is our aim).
-          just sql-logic-tests -v --jobs=1 '*/tunnels/ssh'
+          just sql-logic-tests --jobs=1 '*/tunnels/ssh'
 
           echo "-------------------------------- RPC TESTS --------------------------------"
           just rpc-tests

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -317,20 +317,22 @@ impl FromStr for SourceAccessMode {
 
 impl Display for SourceAccessMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let access_mode: catalog::SourceAccessMode = (*self).into();
-        write!(f, "{}", access_mode.as_str_name())
+        write!(f, "{}", self.as_str())
     }
 }
 
 impl SourceAccessMode {
-    #[inline]
-    pub fn has_read_access(&self) -> bool {
+    pub const fn has_read_access(&self) -> bool {
         matches!(self, Self::ReadOnly | Self::ReadWrite)
     }
 
-    #[inline]
-    pub fn has_write_access(&self) -> bool {
+    pub const fn has_write_access(&self) -> bool {
         matches!(self, Self::ReadWrite)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        // TODO: Maybe lowercase this.
+        catalog::SourceAccessMode::from(*self).as_str_name()
     }
 }
 
@@ -878,5 +880,23 @@ mod tests {
         };
 
         assert_eq!(expected, converted);
+    }
+
+    #[test]
+    fn source_access_mode_as_str() {
+        let mode = SourceAccessMode::ReadOnly;
+        assert_eq!("READ_ONLY", mode.as_str());
+        let mode = SourceAccessMode::ReadWrite;
+        assert_eq!("READ_WRITE", mode.as_str());
+    }
+
+    #[test]
+    fn source_access_mode_from_str() {
+        let mode = SourceAccessMode::from_str("READ_ONLY").unwrap();
+        assert_eq!(SourceAccessMode::ReadOnly, mode);
+        let mode = SourceAccessMode::from_str("READ_WRITE").unwrap();
+        assert_eq!(SourceAccessMode::ReadWrite, mode);
+
+        let _ = SourceAccessMode::from_str("DELETE").unwrap_err();
     }
 }

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -74,6 +74,7 @@ pub static GLARE_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         ("builtin", DataType::Boolean, false),
         ("external", DataType::Boolean, false),
         ("datasource", DataType::Utf8, false),
+        ("access_mode", DataType::Utf8, false), // `SourceAccessMode::as_str()`
     ]),
 });
 
@@ -124,6 +125,7 @@ pub static GLARE_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         ("builtin", DataType::Boolean, false),
         ("external", DataType::Boolean, false),
         ("datasource", DataType::Utf8, false),
+        ("access_mode", DataType::Utf8, false), // `SourceAccessMode::as_str()`
     ]),
 });
 
@@ -280,10 +282,22 @@ pub static GLARE_EXTERNAL_DATASOURCES: Lazy<BuiltinView> = Lazy::new(|| BuiltinV
     schema: INTERNAL_SCHEMA,
     name: "external_datasources",
     sql: "
-WITH datasources(oid, name, datasource, object_type, external) AS (
-    SELECT oid, database_name, datasource, 'database', external FROM glare_catalog.databases
+WITH datasources(oid, name, datasource, object_type, external, access_mode) AS (
+    SELECT oid,
+           database_name,
+           datasource,
+           'database',
+           external,
+           access_mode
+    FROM glare_catalog.databases
     UNION
-    SELECT oid, table_name, datasource, 'table', external FROM glare_catalog.tables
+    SELECT oid,
+           table_name,
+           datasource,
+           'table',
+           external,
+           access_mode
+    FROM glare_catalog.tables
 )
 SELECT * FROM datasources WHERE external = true",
 });

--- a/crates/sqlexec/src/dispatch/system.rs
+++ b/crates/sqlexec/src/dispatch/system.rs
@@ -6,7 +6,7 @@ use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::logical_expr::TypeSignature;
 use datasources::common::ssh::key::SshKey;
 use datasources::common::ssh::SshConnectionParameters;
-use protogen::metastore::types::catalog::{CatalogEntry, EntryType, TableEntry};
+use protogen::metastore::types::catalog::{CatalogEntry, EntryType, SourceAccessMode, TableEntry};
 use protogen::metastore::types::options::TunnelOptions;
 use sqlbuiltins::builtins::{
     DATABASE_DEFAULT, GLARE_COLUMNS, GLARE_CREDENTIALS, GLARE_DATABASES, GLARE_DEPLOYMENT_METADATA,
@@ -75,6 +75,7 @@ impl<'a> SystemTableDispatcher<'a> {
         let mut builtin = BooleanBuilder::new();
         let mut external = BooleanBuilder::new();
         let mut datasource = StringBuilder::new();
+        let mut access_mode = StringBuilder::new();
 
         for db in self
             .catalog
@@ -92,6 +93,7 @@ impl<'a> SystemTableDispatcher<'a> {
             };
 
             datasource.append_value(db.options.as_str());
+            access_mode.append_value(db.access_mode.as_str());
         }
 
         let batch = RecordBatch::try_new(
@@ -102,6 +104,7 @@ impl<'a> SystemTableDispatcher<'a> {
                 Arc::new(builtin.finish()),
                 Arc::new(external.finish()),
                 Arc::new(datasource.finish()),
+                Arc::new(access_mode.finish()),
             ],
         )
         .unwrap();
@@ -237,6 +240,7 @@ impl<'a> SystemTableDispatcher<'a> {
         let mut builtin = BooleanBuilder::new();
         let mut external = BooleanBuilder::new();
         let mut datasource = StringBuilder::new();
+        let mut access_mode = StringBuilder::new();
 
         for table in self
             .catalog
@@ -267,6 +271,7 @@ impl<'a> SystemTableDispatcher<'a> {
             };
 
             datasource.append_value(table.options.as_str());
+            access_mode.append_value(table.access_mode.as_str());
         }
 
         // Append temporary tables.
@@ -280,6 +285,7 @@ impl<'a> SystemTableDispatcher<'a> {
             builtin.append_value(table.meta.builtin);
             external.append_value(table.meta.external);
             datasource.append_value(table.options.as_str());
+            access_mode.append_value(SourceAccessMode::ReadWrite.as_str());
         }
 
         let batch = RecordBatch::try_new(
@@ -293,6 +299,7 @@ impl<'a> SystemTableDispatcher<'a> {
                 Arc::new(builtin.finish()),
                 Arc::new(external.finish()),
                 Arc::new(datasource.finish()),
+                Arc::new(access_mode.finish()),
             ],
         )
         .unwrap();

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ sql-logic-tests *args: protoc
 
 # Run SQL Logic Tests over RPC
 rpc-tests: protoc
-  just sql-logic-tests -v --rpc-test \
+  just sql-logic-tests --rpc-test \
     'sqllogictests/cast/*' \
     'sqllogictests/cte/*' \
     'sqllogictests/functions/delta_scan' \

--- a/testdata/sqllogictests/allowed_operations.slt
+++ b/testdata/sqllogictests/allowed_operations.slt
@@ -1,3 +1,5 @@
+# Tests for asserting access mode settings for external tables and databases.
+
 # For external databases
 
 statement ok
@@ -6,17 +8,38 @@ CREATE EXTERNAL DATABASE debug_db FROM debug;
 statement error Not allowed to write
 INSERT INTO debug_db.public.never_ending VALUES (1, 2, 3);
 
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_db';
+----
+READ_ONLY
+
 statement ok
 ALTER DATABASE debug_db SET ACCESS_MODE TO READ_WRITE;
 
 statement error Insert into not implemented for this table
 INSERT INTO debug_db.public.never_ending VALUES (1, 2, 3);
 
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_db';
+----
+READ_WRITE
+
 statement ok
 ALTER DATABASE debug_db SET ACCESS_MODE TO READ_ONLY;
 
 statement error Not allowed to write
 INSERT INTO debug_db.public.never_ending VALUES (1, 2, 3);
+
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_db';
+----
+READ_ONLY
 
 # For external tables
 
@@ -29,14 +52,36 @@ CREATE EXTERNAL TABLE debug_table
 statement error Not allowed to write
 INSERT INTO debug_table VALUES (1, 2, 3);
 
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_table';
+----
+READ_ONLY
+
 statement ok
 ALTER TABLE debug_table SET ACCESS_MODE TO READ_WRITE;
 
 statement error Insert into not implemented for this table
 INSERT INTO debug_table VALUES (1, 2, 3);
 
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_table';
+----
+READ_WRITE
+
 statement ok
 ALTER TABLE debug_table SET ACCESS_MODE TO READ_ONLY;
 
 statement error Not allowed to write
 INSERT INTO debug_table VALUES (1, 2, 3);
+
+query T
+SELECT access_mode
+FROM glare_catalog.external_datasources
+WHERE name = 'debug_table';
+----
+READ_ONLY
+


### PR DESCRIPTION
Tables:

```
> CREATE EXTERNAL TABLE debug_table
:::     FROM debug (
:::         table_type 'never_ending'
:::     );
Table created
> select * from glare_catalog.tables;
┌────────┬──────────────┬────────────┬──────────────┬───┬─────────┬──────────┬────────────┬─────────────┐
│    oid │ database_oid │ schema_oid │ schema_name  │ … │ builtin │ external │ datasource │ access_mode │
│     ── │           ── │         ── │ ──           │   │ ──      │ ──       │ ──         │ ──          │
│ UInt32 │       UInt32 │     UInt32 │ Utf8         │   │ Boolean │ Boolean  │ Utf8       │ Utf8        │
╞════════╪══════════════╪════════════╪══════════════╪═══╪═════════╪══════════╪════════════╪═════════════╡
│  16488 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16485 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16493 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16492 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16491 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16486 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16484 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  20000 │        16384 │      16386 │ public       │ … │ false   │ true     │ debug      │ READ_ONLY   │
│  16487 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16490 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16489 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
└────────┴──────────────┴────────────┴──────────────┴───┴─────────┴──────────┴────────────┴─────────────┘
> create table hello as select 1 as a;
Table created
> select * from glare_catalog.tables;
┌────────┬──────────────┬────────────┬──────────────┬───┬─────────┬──────────┬────────────┬─────────────┐
│    oid │ database_oid │ schema_oid │ schema_name  │ … │ builtin │ external │ datasource │ access_mode │
│     ── │           ── │         ── │ ──           │   │ ──      │ ──       │ ──         │ ──          │
│ UInt32 │       UInt32 │     UInt32 │ Utf8         │   │ Boolean │ Boolean  │ Utf8       │ Utf8        │
╞════════╪══════════════╪════════════╪══════════════╪═══╪═════════╪══════════╪════════════╪═════════════╡
│  16487 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16490 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16485 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16486 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  20001 │        16384 │      16386 │ public       │ … │ false   │ false    │ internal   │ READ_WRITE  │
│  16484 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16493 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  20000 │        16384 │      16386 │ public       │ … │ false   │ true     │ debug      │ READ_ONLY   │
│  16488 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16489 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16491 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
│  16492 │        16384 │      16385 │ glare_catal… │ … │ true    │ false    │ internal   │ READ_ONLY   │
└────────┴──────────────┴────────────┴──────────────┴───┴─────────┴──────────┴────────────┴─────────────┘
```

Databases:

```
> CREATE EXTERNAL DATABASE debug_db FROM debug;
Database created
> select * from glare_catalog.databases;
┌────────┬───────────────┬─────────┬──────────┬────────────┬─────────────┐
│    oid │ database_name │ builtin │ external │ datasource │ access_mode │
│     ── │ ──            │ ──      │ ──       │ ──         │ ──          │
│ UInt32 │ Utf8          │ Boolean │ Boolean  │ Utf8       │ Utf8        │
╞════════╪═══════════════╪═════════╪══════════╪════════════╪═════════════╡
│  20002 │ debug_db      │ false   │ true     │ debug      │ READ_ONLY   │
│  16384 │ default       │ true    │ false    │ internal   │ READ_ONLY   │
└────────┴───────────────┴─────────┴──────────┴────────────┴─────────────┘
> ALTER DATABASE debug_db SET ACCESS_MODE TO READ_WRITE;
Database altered
> select * from glare_catalog.databases;
┌────────┬───────────────┬─────────┬──────────┬────────────┬─────────────┐
│    oid │ database_name │ builtin │ external │ datasource │ access_mode │
│     ── │ ──            │ ──      │ ──       │ ──         │ ──          │
│ UInt32 │ Utf8          │ Boolean │ Boolean  │ Utf8       │ Utf8        │
╞════════╪═══════════════╪═════════╪══════════╪════════════╪═════════════╡
│  20002 │ debug_db      │ false   │ true     │ debug      │ READ_WRITE  │
│  16384 │ default       │ true    │ false    │ internal   │ READ_ONLY   │
└────────┴───────────────┴─────────┴──────────┴────────────┴─────────────┘
```

(See https://github.com/GlareDB/glaredb/issues/2161 for 'default' be marked incorrectly)