### PR TITLE
chore: Split session catalog out into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "catalog"
+version = "0.7.0"
+dependencies = [
+ "datafusion",
+ "logutil",
+ "metastore",
+ "object_store",
+ "parking_lot",
+ "protogen",
+ "sqlbuiltins",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6776,6 +6794,7 @@ dependencies = [
  "arrow_util",
  "async-trait",
  "bytes",
+ "catalog",
  "dashmap",
  "datafusion",
  "datafusion-proto",

--- a/crates/catalog/Cargo.toml
+++ b/crates/catalog/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "catalog"
+version.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+datafusion = { workspace = true }
+logutil = { path = "../logutil" }
+metastore = { path = "../metastore" }
+object_store = { workspace = true }
+parking_lot = "0.12.1"
+protogen = { path = "../protogen" }
+sqlbuiltins = { path = "../sqlbuiltins" }
+thiserror.workspace = true
+tokio = { workspace = true }
+tonic = { workspace = true }
+tracing = "0.1"
+uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/crates/catalog/src/errors.rs
+++ b/crates/catalog/src/errors.rs
@@ -1,0 +1,44 @@
+use protogen::metastore::strategy::ResolveErrorStrategy;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Catalog error: {msg}")]
+pub struct CatalogError {
+    /// Error message that may be presented to the user.
+    pub msg: String,
+    /// An error may be resolved by following the given strategy if provided.
+    pub strategy: Option<ResolveErrorStrategy>,
+}
+
+impl CatalogError {
+    pub fn new(msg: impl Into<String>) -> Self {
+        CatalogError {
+            msg: msg.into(),
+            strategy: None,
+        }
+    }
+}
+
+pub type Result<T, E = CatalogError> = std::result::Result<T, E>;
+
+impl From<protogen::errors::ProtoConvError> for CatalogError {
+    fn from(value: protogen::errors::ProtoConvError) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<tonic::Status> for CatalogError {
+    fn from(value: tonic::Status) -> Self {
+        // Try to get the strategy from the response from metastore. This can be
+        // used to try to resolve the error automatically.
+        let strat = value
+            .metadata()
+            .get(protogen::metastore::strategy::RESOLVE_ERROR_STRATEGY_META)
+            .map(|val| ResolveErrorStrategy::from_bytes(val.as_ref()))
+            .unwrap_or(ResolveErrorStrategy::Unknown);
+
+        Self {
+            msg: value.message().to_string(),
+            strategy: Some(strat),
+        }
+    }
+}

--- a/crates/catalog/src/lib.rs
+++ b/crates/catalog/src/lib.rs
@@ -1,0 +1,4 @@
+//! Session catalog definitions and interface to metastore.
+pub mod client;
+pub mod errors;
+pub mod session_catalog;

--- a/crates/sqlbuiltins/src/functions/system.rs
+++ b/crates/sqlbuiltins/src/functions/system.rs
@@ -1,0 +1,65 @@
+//! Table functions for triggering system-related functionality. Users are
+//! unlikely to use these, but there's no harm if they do.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::{Signature, Volatility};
+use datafusion_ext::errors::{ExtensionError, Result};
+use datafusion_ext::functions::{FuncParamValue, TableFunc, TableFuncContextProvider};
+use datafusion_ext::system::SystemOperation;
+use datasources::native::access::NativeTableStorage;
+use datasources::postgres::{PostgresAccess, PostgresTableProvider, PostgresTableProviderConfig};
+use futures::Future;
+use protogen::metastore::types::catalog::RuntimePreference;
+
+#[derive(Debug, Clone, Copy)]
+pub struct CacheExternalDatabaseTables;
+
+#[async_trait]
+impl TableFunc for CacheExternalDatabaseTables {
+    fn runtime_preference(&self) -> RuntimePreference {
+        RuntimePreference::Remote
+    }
+
+    fn name(&self) -> &str {
+        "cache_external_database_tables"
+    }
+
+    fn signature(&self) -> Option<Signature> {
+        Some(Signature::uniform(0, Vec::new(), Volatility::Stable))
+    }
+
+    async fn create_provider(
+        &self,
+        context: &dyn TableFuncContextProvider,
+        _args: Vec<FuncParamValue>,
+        _opts: HashMap<String, FuncParamValue>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct CacheExternalDatabaseTablesOperation {}
+
+impl SystemOperation for CacheExternalDatabaseTablesOperation {
+    fn name(&self) -> &'static str {
+        "cache_external_database_tables"
+    }
+
+    fn create_future(
+        &self,
+        context: Arc<TaskContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), DataFusionError>> + Send>> {
+        let fut = async move { Ok(()) };
+
+        Box::pin(fut)
+    }
+}

--- a/crates/sqlexec/Cargo.toml
+++ b/crates/sqlexec/Cargo.toml
@@ -9,6 +9,7 @@ edition = { workspace = true }
 arrow_util = { path = "../arrow_util" }
 logutil = { path = "../logutil" }
 protogen = { path = "../protogen" }
+catalog = { path = "../catalog" }
 proxyutil = { path = "../proxyutil" }
 pgrepr = { path = "../pgrepr" }
 telemetry = { path = "../telemetry" }

--- a/crates/sqlexec/src/background_jobs/storage.rs
+++ b/crates/sqlexec/src/background_jobs/storage.rs
@@ -1,0 +1,170 @@
+//! Background jobs for storage tracking.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use datasources::native::access::NativeTableStorage;
+use protogen::metastore::types::{
+    catalog::TableEntry,
+    service::{Mutation, UpdateDeploymentStorage},
+};
+use tokio::time::Instant;
+
+use crate::errors::Result;
+use catalog::client::MetastoreClientHandle;
+
+use super::BgJob;
+
+#[derive(Debug)]
+pub struct BackgroundJobStorageTracker {
+    native_store: NativeTableStorage,
+    metastore: MetastoreClientHandle,
+}
+
+impl BackgroundJobStorageTracker {
+    #[allow(dead_code)]
+    pub fn new(native_store: NativeTableStorage, metastore: MetastoreClientHandle) -> Arc<Self> {
+        Arc::new(Self {
+            native_store,
+            metastore,
+        })
+    }
+}
+
+#[async_trait]
+impl BgJob for BackgroundJobStorageTracker {
+    fn name(&self) -> String {
+        format!("storage_tracker_{}", self.native_store.db_id())
+    }
+
+    fn start_at(&self) -> Instant {
+        // Start after 5 minutes of scheduling the job, so we can batch jobs for
+        // frequently updating tables.
+        Instant::now() + Duration::from_secs(5 * 60)
+    }
+
+    async fn start(&self) -> Result<()> {
+        let total_size = self.native_store.calculate_db_size().await?;
+
+        // Update the storage size in metastore.
+        self.metastore.refresh_cached_state().await?;
+        let state = self.metastore.get_cached_state().await?;
+        self.metastore
+            .try_mutate(
+                state.version,
+                vec![Mutation::UpdateDeploymentStorage(UpdateDeploymentStorage {
+                    new_storage_size: total_size as u64,
+                })],
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct BackgroundJobDeleteTable {
+    native_store: NativeTableStorage,
+    table_entry: TableEntry,
+}
+
+impl BackgroundJobDeleteTable {
+    #[allow(dead_code)]
+    pub fn new(native_store: NativeTableStorage, table_entry: TableEntry) -> Arc<Self> {
+        Arc::new(Self {
+            native_store,
+            table_entry,
+        })
+    }
+}
+
+#[async_trait]
+impl BgJob for BackgroundJobDeleteTable {
+    fn name(&self) -> String {
+        format!(
+            "delete_table_{}_{}",
+            self.native_store.db_id(),
+            self.table_entry.meta.name
+        )
+    }
+
+    fn start_at(&self) -> Instant {
+        // schedule the delete task to run immediately
+        Instant::now()
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.native_store.delete_table(&self.table_entry).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::DataType;
+    use datasources::native::access::{NativeTableStorage, SaveMode};
+    use metastore::local::start_inprocess_inmemory;
+    use protogen::metastore::types::{
+        catalog::{EntryMeta, EntryType, SourceAccessMode, TableEntry},
+        options::{InternalColumnDefinition, TableOptions, TableOptionsInternal},
+    };
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    use crate::background_jobs::JobRunner;
+    use crate::engine::EngineStorageConfig;
+    use catalog::client::{MetastoreClientSupervisor, DEFAULT_METASTORE_CLIENT_CONFIG};
+
+    use super::BackgroundJobStorageTracker;
+
+    #[tokio::test]
+    async fn test_background_job_storage_tracker() {
+        let db_id = Uuid::new_v4();
+        let dir = tempdir().unwrap();
+        let conf = EngineStorageConfig::try_from_path_buf(&dir.path().to_path_buf()).unwrap();
+
+        let storage = NativeTableStorage::new(db_id, conf.url(), conf.new_object_store().unwrap());
+
+        // Add some tables inside the temp dir to get a non-zero storage size.
+        storage
+            .create_table(
+                &TableEntry {
+                    meta: EntryMeta {
+                        entry_type: EntryType::Table,
+                        id: 12345,
+                        parent: 54321,
+                        name: "table_1".to_string(),
+                        builtin: false,
+                        external: false,
+                        is_temp: false,
+                    },
+                    options: TableOptions::Internal(TableOptionsInternal {
+                        columns: vec![InternalColumnDefinition {
+                            name: "id".to_string(),
+                            nullable: true,
+                            arrow_type: DataType::Int32,
+                        }],
+                    }),
+                    tunnel_id: None,
+                    access_mode: SourceAccessMode::ReadOnly,
+                },
+                SaveMode::ErrorIfExists,
+            )
+            .await
+            .unwrap();
+
+        let meta_chan = start_inprocess_inmemory().await.unwrap();
+        let metastore = MetastoreClientSupervisor::new(meta_chan, DEFAULT_METASTORE_CLIENT_CONFIG);
+        let metastore = metastore.init_client(db_id).await.unwrap();
+
+        let tracker = BackgroundJobStorageTracker::new(storage, metastore.clone());
+        let jobs = JobRunner::new(Default::default());
+        jobs.add(tracker).unwrap();
+        jobs.close().await.unwrap();
+
+        // Check if data exists in metastore.
+        metastore.refresh_cached_state().await.unwrap();
+        let state = metastore.get_cached_state().await.unwrap();
+        assert_ne!(state.deployment.storage_size, 0);
+    }
+}

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -1,10 +1,10 @@
 use crate::environment::EnvironmentReader;
 use crate::errors::{internal, ExecError, Result};
-use crate::metastore::catalog::{CatalogMutator, SessionCatalog, TempCatalog};
 use crate::parser::StatementWithExtensions;
 use crate::planner::logical_plan::*;
 use crate::planner::session_planner::SessionPlanner;
 use crate::remote::client::{RemoteClient, RemoteSessionClient};
+use catalog::session_catalog::{CatalogMutator, SessionCatalog, TempCatalog};
 use datafusion::arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use datafusion::common::SchemaReference;
 use datafusion::execution::context::{

--- a/crates/sqlexec/src/context/mod.rs
+++ b/crates/sqlexec/src/context/mod.rs
@@ -11,6 +11,7 @@ pub mod remote;
 
 use std::{path::PathBuf, sync::Arc};
 
+use catalog::session_catalog::SessionCatalog;
 use datafusion::{
     config::{CatalogOptions, ConfigOptions, Extensions, OptimizerOptions},
     execution::{
@@ -23,7 +24,7 @@ use datafusion_ext::vars::SessionVars;
 use datasources::object_store::init_session_registry;
 use protogen::metastore::types::catalog::CatalogEntry;
 
-use crate::{errors::Result, metastore::catalog::SessionCatalog};
+use crate::errors::Result;
 
 /// Create a new datafusion runtime env common to both remote and local
 /// sessions.

--- a/crates/sqlexec/src/context/remote.rs
+++ b/crates/sqlexec/src/context/remote.rs
@@ -18,9 +18,9 @@ use crate::{
     dispatch::external::ExternalDispatcher,
     errors::{ExecError, Result},
     extension_codec::GlareDBExtensionCodec,
-    metastore::catalog::{CatalogMutator, SessionCatalog},
     remote::{provider_cache::ProviderCache, staged_stream::StagedClientStreams},
 };
+use catalog::session_catalog::{CatalogMutator, SessionCatalog};
 
 use super::{new_datafusion_runtime_env, new_datafusion_session_config_opts};
 

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -45,7 +45,7 @@ use protogen::metastore::types::options::{
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
 use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 
-use crate::metastore::catalog::SessionCatalog;
+use catalog::session_catalog::SessionCatalog;
 
 use super::listing::CatalogLister;
 use super::{DispatchError, Result};

--- a/crates/sqlexec/src/dispatch/listing.rs
+++ b/crates/sqlexec/src/dispatch/listing.rs
@@ -4,7 +4,7 @@ use datafusion_ext::{errors::ExtensionError, functions::VirtualLister};
 use protogen::metastore::types::catalog::CatalogEntry;
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
 
-use crate::metastore::catalog::SessionCatalog;
+use catalog::session_catalog::SessionCatalog;
 
 pub struct CatalogLister {
     pub catalog: SessionCatalog,

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -21,13 +21,11 @@ use protogen::metastore::types::catalog::{
 use sqlbuiltins::functions::BUILTIN_TABLE_FUNCS;
 
 use crate::context::local::LocalSessionContext;
+use crate::dispatch::system::SystemTableDispatcher;
 use crate::parser::CustomParser;
 use crate::planner::errors::PlanError;
 use crate::planner::session_planner::SessionPlanner;
-use crate::{
-    dispatch::system::SystemTableDispatcher,
-    metastore::catalog::{SessionCatalog, TempCatalog},
-};
+use catalog::session_catalog::{SessionCatalog, TempCatalog};
 
 use self::external::ExternalDispatcher;
 use self::listing::CatalogLister;

--- a/crates/sqlexec/src/dispatch/system.rs
+++ b/crates/sqlexec/src/dispatch/system.rs
@@ -14,7 +14,7 @@ use sqlbuiltins::builtins::{
     SCHEMA_CURRENT_SESSION,
 };
 
-use crate::metastore::catalog::{SessionCatalog, TempCatalog};
+use catalog::session_catalog::{SessionCatalog, TempCatalog};
 
 use super::{DispatchError, Result};
 

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::context::remote::RemoteSessionContext;
 use crate::errors::{ExecError, Result};
-use crate::metastore::client::{MetastoreClientSupervisor, DEFAULT_METASTORE_CLIENT_CONFIG};
 use crate::session::Session;
+use catalog::client::{MetastoreClientSupervisor, DEFAULT_METASTORE_CLIENT_CONFIG};
 use std::collections::HashMap;
 
 use object_store::aws::AmazonS3ConfigKey;
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::metastore::catalog::SessionCatalog;
+use catalog::session_catalog::SessionCatalog;
 use datafusion_ext::vars::SessionVars;
 use datasources::common::errors::DatasourceCommonError;
 use datasources::common::url::{DatasourceUrl, DatasourceUrlType};

--- a/crates/sqlexec/src/errors.rs
+++ b/crates/sqlexec/src/errors.rs
@@ -143,10 +143,7 @@ pub enum ExecError {
     DispatchError(#[from] crate::dispatch::DispatchError),
 
     #[error(transparent)]
-    MetastoreWorker(#[from] crate::metastore::client::MetastoreClientError),
-
-    #[error(transparent)]
-    SessionCatalog(#[from] crate::metastore::catalog::SessionCatalogError),
+    Catalog(#[from] catalog::errors::CatalogError),
 
     #[error("{0:?}")]
     TonicTransport(#[from] tonic::transport::Error),

--- a/crates/sqlexec/src/lib.rs
+++ b/crates/sqlexec/src/lib.rs
@@ -4,7 +4,6 @@ pub mod engine;
 pub mod environment;
 pub mod errors;
 pub mod extension_codec;
-pub mod metastore;
 pub mod parser;
 pub mod remote;
 pub mod session;

--- a/crates/sqlexec/src/metastore/mod.rs
+++ b/crates/sqlexec/src/metastore/mod.rs
@@ -1,4 +1,0 @@
-//! Module facilitating interaction with metastore.
-
-pub mod catalog;
-pub mod client;

--- a/crates/sqlexec/src/planner/physical_plan/alter_database.rs
+++ b/crates/sqlexec/src/planner/physical_plan/alter_database.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/alter_table.rs
+++ b/crates/sqlexec/src/planner/physical_plan/alter_table.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/alter_tunnel_rotate_keys.rs
+++ b/crates/sqlexec/src/planner/physical_plan/alter_tunnel_rotate_keys.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/create_credentials.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_credentials.rs
@@ -3,7 +3,7 @@ use super::*;
 use protogen::metastore::types::{options::CredentialsOptions, service, service::Mutation};
 use protogen::sqlexec::physical_plan::ExecutionPlanExtensionType;
 
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::errors::internal;
 use protogen::export::prost::Message;
 

--- a/crates/sqlexec/src/planner/physical_plan/create_external_database.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_external_database.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/create_external_table.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_external_table.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullObjectReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/create_schema.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_schema.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullSchemaReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/create_table.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_table.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use catalog::session_catalog::{CatalogMutator, SessionCatalog};
 use datafusion::{
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
     datasource::TableProvider,
@@ -21,7 +22,6 @@ use tracing::debug;
 use super::GENERIC_OPERATION_PHYSICAL_SCHEMA;
 use crate::{
     errors::ExecError,
-    metastore::catalog::{CatalogMutator, SessionCatalog},
     planner::{logical_plan::OwnedFullObjectReference, physical_plan::new_operation_batch},
 };
 use futures::StreamExt;

--- a/crates/sqlexec/src/planner/physical_plan/create_temp_table.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_temp_table.rs
@@ -5,7 +5,8 @@ use datafusion::{
 };
 use futures::StreamExt;
 
-use crate::{metastore::catalog::TempCatalog, planner::logical_plan::OwnedFullObjectReference};
+use crate::planner::logical_plan::OwnedFullObjectReference;
+use catalog::session_catalog::TempCatalog;
 
 use super::*;
 

--- a/crates/sqlexec/src/planner/physical_plan/create_tunnel.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_tunnel.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/create_view.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_view.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullObjectReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/drop_credentials.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_credentials.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/drop_database.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_database.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/drop_schemas.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_schemas.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullSchemaReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/drop_tables.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_tables.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullObjectReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/drop_temp_tables.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_temp_tables.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::TempCatalog;
+use catalog::session_catalog::TempCatalog;
 use crate::planner::logical_plan::OwnedFullObjectReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/planner/physical_plan/drop_tunnel.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_tunnel.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};

--- a/crates/sqlexec/src/planner/physical_plan/drop_views.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_views.rs
@@ -1,4 +1,4 @@
-use crate::metastore::catalog::CatalogMutator;
+use catalog::session_catalog::CatalogMutator;
 use crate::planner::logical_plan::OwnedFullObjectReference;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -1,8 +1,8 @@
 use crate::{
     errors::{ExecError, Result},
     extension_codec::GlareDBExtensionCodec,
-    metastore::catalog::SessionCatalog,
 };
+use catalog::session_catalog::SessionCatalog;
 use datafusion::{datasource::TableProvider, physical_plan::ExecutionPlan};
 use datafusion_ext::functions::FuncParamValue;
 use datafusion_proto::{physical_plan::AsExecutionPlan, protobuf::PhysicalPlanNode};

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use std::sync::Arc;
 
-use crate::metastore::catalog::{SessionCatalog, TempCatalog};
+use catalog::session_catalog::{SessionCatalog, TempCatalog};
 use crate::planner::extension::ExtensionType;
 use crate::planner::logical_plan::{
     AlterDatabase, AlterTable, AlterTunnelRotateKeys, CopyTo, CreateCredentials,

--- a/crates/sqlexec/src/resolve.rs
+++ b/crates/sqlexec/src/resolve.rs
@@ -1,12 +1,9 @@
 use datafusion::sql::TableReference;
+use crate::context::local::LocalSessionContext;
+use catalog::session_catalog::{SessionCatalog, TempCatalog};
 use protogen::metastore::types::catalog::{CatalogEntry, DatabaseEntry, TableEntry};
 use sqlbuiltins::builtins::{CURRENT_SESSION_SCHEMA, DEFAULT_CATALOG};
 use std::{borrow::Cow, sync::Arc};
-
-use crate::{
-    context::local::LocalSessionContext,
-    metastore::catalog::{SessionCatalog, TempCatalog},
-};
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("failed to resolve: {0}")]

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use crate::metastore::catalog::{CatalogMutator, SessionCatalog};
+use catalog::session_catalog::{CatalogMutator, SessionCatalog};
 use crate::planner::physical_plan::{
     get_count_from_batch, get_operation_from_batch, GENERIC_OPERATION_AND_COUNT_PHYSICAL_SCHEMA,
     GENERIC_OPERATION_PHYSICAL_SCHEMA,


### PR DESCRIPTION
Adds a `catalog` crate which contains `SessionCatalog`, `TempCatalog` and the metastore client. This is mostly needed to allow table functions to have access to the catalog directly, and not have to write one-off methods on the table function context to get entries.

This may also allow us to move the physical/logical plans into their own crate if we feel that helps with code organization.