### PR TITLE
chore: Send query text when executing query over RPC

### DIFF
--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -112,6 +112,8 @@ message PhysicalPlanExecuteRequest {
   //
   // Required for sending metrics.
   bytes user_id = 3;
+  // Query text (for collecting metrics).
+  string query_text = 4;
 }
 
 message TableProviderResponse {

--- a/crates/protogen/src/rpcsrv/types/service.rs
+++ b/crates/protogen/src/rpcsrv/types/service.rs
@@ -270,6 +270,7 @@ pub struct PhysicalPlanExecuteRequest {
     pub database_id: Uuid,
     pub physical_plan: Vec<u8>,
     pub user_id: Option<Uuid>,
+    pub query_text: String,
 }
 
 impl TryFrom<service::PhysicalPlanExecuteRequest> for PhysicalPlanExecuteRequest {
@@ -279,6 +280,7 @@ impl TryFrom<service::PhysicalPlanExecuteRequest> for PhysicalPlanExecuteRequest
             database_id: Uuid::from_slice(&value.database_id)?,
             physical_plan: value.physical_plan,
             user_id: Uuid::from_slice(&value.user_id).ok(),
+            query_text: value.query_text,
         })
     }
 }
@@ -292,6 +294,7 @@ impl From<PhysicalPlanExecuteRequest> for service::PhysicalPlanExecuteRequest {
                 .user_id
                 .map(|v| v.into_bytes().into())
                 .unwrap_or_default(),
+            query_text: value.query_text,
         }
     }
 }

--- a/crates/sqlexec/src/lib.rs
+++ b/crates/sqlexec/src/lib.rs
@@ -14,7 +14,7 @@ mod functions;
 mod planner;
 mod resolve;
 
-pub use planner::logical_plan::LogicalPlan;
+pub use planner::logical_plan::{LogicalPlan, OperationInfo};
 
 pub mod export {
     pub use datafusion::sql::sqlparser;

--- a/crates/sqlexec/src/planner/logical_plan/mod.rs
+++ b/crates/sqlexec/src/planner/logical_plan/mod.rs
@@ -99,6 +99,26 @@ pub static GENERIC_OPERATION_AND_COUNT_LOGICAL_SCHEMA: Lazy<DFSchemaRef> = Lazy:
     )
 });
 
+#[derive(Clone, Debug, Default)]
+pub struct OperationInfo {
+    query: Option<String>,
+}
+
+impl OperationInfo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_query_text(mut self, query_text: impl Into<String>) -> Self {
+        self.query = Some(query_text.into());
+        self
+    }
+
+    pub fn query_text(&self) -> &str {
+        self.query.as_deref().unwrap_or_default()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum LogicalPlan {
     /// Plans related to querying the underlying data store. This will run

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -382,6 +382,7 @@ impl RemoteSessionClient {
     pub async fn physical_plan_execute(
         &mut self,
         physical_plan: Arc<dyn ExecutionPlan>,
+        query_text: String,
     ) -> Result<Streaming<service::RecordBatchResponse>> {
         // Encode the physical plan into a protobuf message.
         let physical_plan = {
@@ -398,6 +399,7 @@ impl RemoteSessionClient {
             database_id: self.database_id(),
             physical_plan,
             user_id: self.user_id,
+            query_text,
         })
         .into_request();
         self.inner.append_auth_metadata(request.metadata_mut());

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -397,6 +397,7 @@ impl ExtensionPlanner for DDLExtensionPlanner {
 
 pub struct RemotePhysicalPlanner<'a> {
     pub database_id: Uuid,
+    pub query_text: &'a str,
     pub remote_client: RemoteSessionClient,
     pub catalog: &'a SessionCatalog,
 }
@@ -527,6 +528,7 @@ impl<'a> PhysicalPlanner for RemotePhysicalPlanner<'a> {
                 let physical = Arc::new(RemoteExecutionExec::new(
                     self.remote_client.clone(),
                     physical,
+                    self.query_text.to_string(),
                 ));
 
                 // Create a wrapper physical plan which drives both the

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -402,12 +402,14 @@ impl Session {
     pub async fn create_physical_plan(
         &self,
         plan: DfLogicalPlan,
+        op: &OperationInfo,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let state = self.ctx.df_ctx().state();
         let plan = state.optimize(&plan)?;
         if let Some(client) = self.ctx.exec_client() {
             let planner = RemotePhysicalPlanner {
                 database_id: self.ctx.get_database_id(),
+                query_text: op.query_text(),
                 remote_client: client,
                 catalog: self.ctx.get_session_catalog(),
             };
@@ -498,6 +500,7 @@ impl Session {
     pub async fn execute_inner(
         &mut self,
         plan: LogicalPlan,
+        op: &OperationInfo,
     ) -> Result<(Arc<dyn ExecutionPlan>, ExecutionResult)> {
         // Note that transaction support is fake, in that we don't currently do
         // anything and do not provide any transactional semantics.
@@ -510,7 +513,7 @@ impl Session {
                 Ok((EMPTY_EXEC_PLAN.clone(), ExecutionResult::EmptyQuery))
             }
             LogicalPlan::Datafusion(plan) => {
-                let physical = self.create_physical_plan(plan).await?;
+                let physical = self.create_physical_plan(plan, op).await?;
                 let stream = self.execute_physical(physical.clone()).await?;
 
                 let stream = ExecutionResult::from_stream(stream).await;
@@ -567,13 +570,18 @@ impl Session {
             None => return Ok(ExecutionResult::EmptyQuery),
         };
 
-        // Create "base" metrics.
-        let mut metrics = QueryMetrics::default();
+        let mut op = OperationInfo::default();
         if let Some(stmt) = &portal.stmt.stmt {
-            metrics.query_text = stmt.to_string();
+            op = op.with_query_text(stmt.to_string());
         }
 
-        let stream = match self.execute_inner(plan).await {
+        // Create "base" metrics.
+        let mut metrics = QueryMetrics {
+            query_text: op.query_text().to_owned(),
+            ..Default::default()
+        };
+
+        let stream = match self.execute_inner(plan, &op).await {
             Ok((plan, result)) => match result {
                 ExecutionResult::Error(e) => {
                     metrics.execution_status = ExecutionStatus::Fail;


### PR DESCRIPTION
```json
{
  "database_id": "00000000-0000-0000-0000-000000000000",
  "connection_id": "00000000-0000-0000-0000-000000000000",
  "query_text": "SELECT * FROM my_pg.public.lineitem WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL '90' LIMIT 5",
  "telemetry_tag": "unknown",
  "execution_status": "success",
  "error_message": null,
  "elapsed_compute_ns": 11627950,
  "output_rows": 5,
  "bytes_read": 15466360,
  "bytes_written": 0
}
```