### PR TITLE
fix: Hybrid planning when the root plan has local preference

### DIFF
--- a/crates/datafusion_ext/src/transform.rs
+++ b/crates/datafusion_ext/src/transform.rs
@@ -15,6 +15,16 @@ pub trait TreeNodeExt: TreeNode {
         let new_node = op(after_op_children)?.into();
         Ok(new_node)
     }
+
+    /// Like `transform_down`, but allows providing a closure with mutable access
+    /// to the environment.
+    fn transform_down_mut<F>(self, op: &mut F) -> Result<Self>
+    where
+        F: FnMut(Self) -> Result<Transformed<Self>>,
+    {
+        let after_op = op(self)?.into();
+        after_op.map_children(|node| node.transform_down_mut(op))
+    }
 }
 
 impl<T: DynTreeNode + ?Sized> TreeNodeExt for Arc<T> {}


### PR DESCRIPTION
Push down "remote" exec as far down as possible and replace any "local"
execs that are found (children to the remote). Finally, pack the
remote exec in a [`SendRecvJoinExec`] so the plan transformation looks
something like:
    
### Original plan:
    
```txt
                 +-----------+
                 | A (Local) |
                 +-----+-----+
                       |
                       v
              +-----------------+
      +-------+ B (Unspecified) +-------+
      |       +--------+--------+       |
      v                |                v
+------------+         |          +-----------+
| C (Remote) |         |          | F (Local) |
+-----+------+         v          +-----------+
      |          +------------+
      v          | E (Remote) |
+-----------+    +------------+
| D (Local) |
+-----------+
```
    
 ### Transformed plan:

```txt
                          +-----------+
                          | A (Local) |
                          +-----+-----+
                                |
                                v
                       +-----------------+
         +-------------+ B (Unspecified) +-------+
         |             +--------+--------+       |
         |                      |                v
         v                      |          +-----------+
+------------------+            |          | F (Local) |
| SendRecvJoinExec |            v          +-----------+
|                  |   +------------------+
|        C         |   | SendRecvJoinExec |
|        |         |   |                  |
|        v         |   |        E         |
|   D (Send-Recv)  |   +------------------+
+------------------+
```
    
> **Note:** All nodes shown in the graphs above (except `B`) are
> [`RuntimeGroupExec`]s. Other nodes are omitted for simplicity.
    
We don't "pull-up" the remote exec as much as possible because we want
to stop pulling once a "local" node is met but there's no certain way of
knowing that the node is to be run locally (since that information lies
with its n'th parent, i.e., [`RuntimeGroupExec`]).
    
For example, take the following plan in consideration which tries to
copy contents from a remote table in a local file:
    
```txt
RuntimeExec (local)
        |
    CopyToExec
        |
      Limit
        |
RuntimeExec (remote)
        |
    TableScan
```
    
If we were to pull "remote" up until the "local", we would end up with
something like:
    
```txt
RuntimeExec (local)
        |
RuntimeExec (remote)
        |
    CopyToExec
        |
      Limit
        |
    TableScan
```
    
This ends up running the `CopyToExec` on remote which is completely
incorrect.

Fixes: #2104