### PR TITLE
fix: truncate long floats in cli formatting for display

### DIFF
--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -576,7 +576,7 @@ fn fmt_floats(flt: Option<&f64>) -> String {
     match flt {
         Some(float) => {
             //Change here to configure digits after decimalpoint for long floats
-            let str = format!("{:.4}", float); 
+            let str = format!("{:.5}", float); 
             str
         }
         None => String::from(""),

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -519,7 +519,7 @@ impl ColumnValues {
                         let s = fmt_floats(floats_array.get(idx));
                         Ok(s)
                     })
-                    .collect::<Result<Vec<_>, ArrowError>>()?;
+                    .collect::<Result<Vec<_>, ArrowError>>()?
             }
             _ => {
                 // formatting rest of data types using ArrayFormatter
@@ -531,7 +531,7 @@ impl ColumnValues {
                         }
                         Ok(s)
                     })
-                    .collect::<Result<Vec<_>, ArrowError>>()?;
+                    .collect::<Result<Vec<_>, ArrowError>>()?
             }
         };
 

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -1,7 +1,6 @@
 use comfy_table::{Cell, CellAlignment, ColumnConstraint, ContentArrangement, Table};
 use datafusion::arrow::array::{Array, Float64Array};
-use datafusion::arrow::datatypes::DataType::{self,Float64};
-use datafusion::arrow::datatypes::{Field, Schema, TimeUnit};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
@@ -491,7 +490,7 @@ impl TableFormat {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 struct ColumnValues {
     vals: Vec<String>,
 }
@@ -515,17 +514,16 @@ impl ColumnValues {
                     .unwrap()
                     .values();
 
-                let formatted_floats = (0..floats_array.len())
+                (0..floats_array.len())
                     .map(|idx| {
                         let s = fmt_floats(floats_array.get(idx));
                         Ok(s)
                     })
                     .collect::<Result<Vec<_>, ArrowError>>()?;
-                formatted_floats
             }
             _ => {
                 // formatting rest of data types using ArrayFormatter
-                let formatted_strings = (0..col.len())
+                (0..col.len())
                     .map(|idx| {
                         let mut s = formatter.value(idx).try_to_string()?;
                         if let Some(trunc) = trunc {
@@ -534,7 +532,6 @@ impl ColumnValues {
                         Ok(s)
                     })
                     .collect::<Result<Vec<_>, ArrowError>>()?;
-                formatted_strings
             }
         };
 
@@ -576,7 +573,7 @@ fn fmt_floats(flt: Option<&f64>) -> String {
     match flt {
         Some(float) => {
             //Change here to configure digits after decimalpoint for long floats
-            let str = format!("{:.5}", float); 
+            let str = format!("{:.5}", float);
             str
         }
         None => String::from(""),
@@ -681,8 +678,8 @@ mod tests {
             assert_eq!(tc.expected, &s, "test case: {tc:?}");
         }
     }
-    
-     #[test]
+
+    #[test]
     fn test_truncate_floats() {
         #[derive(Debug)]
         struct TestCase<'a> {
@@ -730,7 +727,7 @@ mod tests {
         }
 
         for tc in test_cases {
-            let tc_result = try_new_from_array(tc.input, tc.truncate);
+            let tc_result = ColumnValues::try_new_from_array(tc.input, tc.truncate);
 
             let result: ColumnValues = match tc_result {
                 Ok(x) => x,

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -516,8 +516,7 @@ impl ColumnValues {
 
                 (0..floats_array.len())
                     .map(|idx| {
-                        let s = fmt_floats(floats_array.get(idx));
-                        Ok(s)
+                        Ok(fmt_floats(floats_array.get(idx)))
                     })
                     .collect::<Result<Vec<_>, ArrowError>>()?
             }
@@ -573,8 +572,7 @@ fn fmt_floats(flt: Option<&f64>) -> String {
     match flt {
         Some(float) => {
             //Change here to configure digits after decimalpoint for long floats
-            let str = format!("{:.5}", float);
-            str
+            format!("{:.5}", float)
         }
         None => String::from(""),
     }

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -515,9 +515,7 @@ impl ColumnValues {
                     .values();
 
                 (0..floats_array.len())
-                    .map(|idx| {
-                        Ok(fmt_floats(floats_array.get(idx)))
-                    })
+                    .map(|idx| Ok(fmt_floats(floats_array.get(idx))))
                     .collect::<Result<Vec<_>, ArrowError>>()?
             }
             _ => {

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -237,6 +237,8 @@ fn truncate_or_wrap_string(s: &mut String, width: usize) {
         return;
     }
 
+    fmt_float(s); //Truncating long floats to have 4 digits after decimal point.
+
     if display_width(s) <= width {
         return;
     }
@@ -251,6 +253,51 @@ fn truncate_or_wrap_string(s: &mut String, width: usize) {
     }
 
     // I don't believe it's possible for us to actually get here...
+}
+
+fn fmt_float(s: &mut String) {
+    const DIGITS_AFTER_DECIMAL: usize = 4;
+    let x = s.as_mut_str();
+    let mut is_float: bool = false;
+    let p = x.parse::<f64>();
+
+    match p {
+        Ok(_) => {
+            let mut index_of_decimal: usize;
+            let m = x.chars().enumerate();
+            let mut length: usize = 0;
+
+            for a in m {
+                //Checking if its a floating number else its an integer
+                if a.1 == '.' {
+                    index_of_decimal = a.0; //Noting index of decimalpoint
+                    length = index_of_decimal + DIGITS_AFTER_DECIMAL;
+                    is_float = true;
+                }
+            }
+            if is_float {
+                if x.len() > length + 1 {
+                    let mut u = x.len() - (length + 1);
+                    while u > 0 {
+                        s.pop();
+                        u -= 1;
+                    }
+                } else {
+                    let mut add_zeros: usize = (length + 1) - x.len();
+                    while add_zeros > 0 {
+                        s.push('0');
+                        add_zeros -= 1;
+                    }
+                }
+            } else {
+                //Ignoring values which are integers without decimal point.
+                //We can add code if needed.
+            }
+        }
+        Err(_) => {
+            //ignoring values which are not both (float or integer)
+        }
+    }
 }
 
 fn fmt_timeunit(tu: &TimeUnit) -> String {


### PR DESCRIPTION
Fixes the issue #1807 
Tried to truncate long floats to have 5 digits after decimal point.
Added Unit Test for a batch of floats. 
@universalmind303 I abandoned the previous logic of having a config parameter to control number of digits after decimal point, instead hardcoded it. Please suggest any corrections.

Thanks in advance.