### PR TITLE
fix: filter unknown oids for Postgres types

### DIFF
--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -410,6 +410,20 @@ ORDER BY attnum;
             type_oids.push(row.try_get(1)?);
         }
 
+        let mut unknown_type_oids: Vec<i32> = Vec::new();
+
+        type_oids.iter().for_each(|oid| {
+            if let None = PostgresType::from_oid(*oid) {
+                unknown_type_oids.push(*oid);
+            }
+        });
+
+        if !unknown_type_oids.is_empty() {
+            return Err(PostgresError::UnknownPostgresOids(unknown_type_oids));
+        }
+
+        //will Proceed here ONLY if types are known for all oids else returns error with unknown_type_oids
+        
         let pg_types = type_oids
             .iter()
             .map(|oid| PostgresType::from_oid(*oid))

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -410,7 +410,7 @@ ORDER BY attnum;
             type_oids.push(row.try_get(1)?);
         }
 
-        let mut unknown_type_oids: Vec<i32> = Vec::new();
+        let mut unknown_type_oids: Vec<u32> = Vec::new();
 
         type_oids.iter().for_each(|oid| {
             if let None = PostgresType::from_oid(*oid) {
@@ -423,7 +423,7 @@ ORDER BY attnum;
         }
 
         //will Proceed here ONLY if types are known for all oids else returns error with unknown_type_oids
-        
+
         let pg_types = type_oids
             .iter()
             .map(|oid| PostgresType::from_oid(*oid))

--- a/crates/datasources/src/postgres/mod.rs
+++ b/crates/datasources/src/postgres/mod.rs
@@ -413,7 +413,7 @@ ORDER BY attnum;
         let mut unknown_type_oids: Vec<u32> = Vec::new();
 
         type_oids.iter().for_each(|oid| {
-            if let None = PostgresType::from_oid(*oid) {
+            if PostgresType::from_oid(*oid).is_none() {
                 unknown_type_oids.push(*oid);
             }
         });


### PR DESCRIPTION
Fixes issue : #2025 
Filters out unknown type - oids and returns them in error log.
@scsmithr  Please correct me if needed.

Thanks.
