### PR TITLE
fix: Hacky fix for running the experimental scheduler when spawning task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Adding something new? It's probably good to add to .dockerignore too.
 
 .pre-commit-config.yaml
-# nix build results
-/target
+# Cargo target directories.
+/*target
 /result
 glaredb_image
 pgsrv_image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
+name = "console-api"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,6 +3161,7 @@ dependencies = [
  "atty",
  "clap",
  "colored",
+ "console-subscriber",
  "datafusion",
  "datafusion_ext",
  "futures",
@@ -3225,6 +3263,19 @@ checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
  "ahash 0.8.6",
  "allocator-api2",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.5",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -7432,6 +7483,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
+ "tracing",
  "windows-sys",
 ]
 

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -36,6 +36,7 @@ reedline = "0.27.1"
 nu-ansi-term = "0.49.0"
 url.workspace = true
 atty = "0.2.14"
+console-subscriber = "0.2.0"
 
 [dev-dependencies]
 predicates = "3.0.4"

--- a/crates/glaredb/src/args/local.rs
+++ b/crates/glaredb/src/args/local.rs
@@ -21,6 +21,10 @@ pub struct LocalArgs {
     /// File for logs to be written to
     #[arg(long, value_parser)]
     pub log_file: Option<PathBuf>,
+
+    /// Start the tokio console subscriber to debug runtime.
+    #[arg(long, value_parser, hide = true)]
+    pub debug_tokio: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/glaredb/src/args/local.rs
+++ b/crates/glaredb/src/args/local.rs
@@ -23,6 +23,7 @@ pub struct LocalArgs {
     pub log_file: Option<PathBuf>,
 
     /// Start the tokio console subscriber to debug runtime.
+    #[cfg(not(release))]
     #[arg(long, value_parser, hide = true)]
     pub debug_tokio: bool,
 }

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -52,12 +52,20 @@ trait RunCommand {
     fn run(self) -> Result<()>;
 }
 
-impl RunCommand for LocalArgs {
-    fn run(self) -> Result<()> {
+impl LocalArgs {
+    #[cfg(not(release))]
+    fn start_tokio_debugger(&self) {
         if self.debug_tokio {
             eprintln!("> Starting tokio debugger");
             console_subscriber::init();
         }
+    }
+}
+
+impl RunCommand for LocalArgs {
+    fn run(self) -> Result<()> {
+        #[cfg(not(release))]
+        self.start_tokio_debugger();
 
         let runtime = build_runtime("local")?;
         runtime.block_on(async move {

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -54,6 +54,11 @@ trait RunCommand {
 
 impl RunCommand for LocalArgs {
     fn run(self) -> Result<()> {
+        if self.debug_tokio {
+            eprintln!("> Starting tokio debugger");
+            console_subscriber::init();
+        }
+
         let runtime = build_runtime("local")?;
         runtime.block_on(async move {
             let query = match (self.file, self.query) {

--- a/justfile
+++ b/justfile
@@ -29,6 +29,14 @@ run *args: protoc
 build *args: protoc
   cargo build --bin glaredb {{args}}
 
+# Build glaredb with unstable_tokio flag.
+#
+# Need to run the local command with `--debug-tokio` argument.
+build-debug-tokio *args:
+  RUSTFLAGS="--cfg tokio_unstable" CARGO_TARGET_DIR=tokio-unstable-target just build {{args}}
+
+run-debug-tokio *args:
+  RUSTFLAGS="--cfg tokio_unstable" CARGO_TARGET_DIR=tokio-unstable-target just run {{args}}
 
 # A zip archive will be placed in `target/dist` containing the release binary.
 


### PR DESCRIPTION
Until I figure out the best solution (which hopefully is close).

Pushing just to benchmark and test stuff successfully.

To run the tokio console debugger:

1. Download the CLI:
   ```
   cargo --locked tokio-console
   ```
2. Build/Run local with new just commands (along with `--debug-tokio` flag):
   ```
   just run-debug-tokio local --debug-tokio
   ```

**NOTE:** This builds in a new `target` directory: `unstable-tokio-target` so as to not mess up with existing target directory (which can cause issues with LSP etc.).