### PR TITLE
chore: Default to compact logs

### DIFF
--- a/crates/glaredb/src/bin/main.rs
+++ b/crates/glaredb/src/bin/main.rs
@@ -2,11 +2,12 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use glaredb::args::LocalArgs;
 use glaredb::commands::Commands;
+
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
 enum LoggingMode {
-    #[default]
     Full,
     Json,
+    #[default]
     Compact,
 }
 

--- a/crates/glaredb/src/server.rs
+++ b/crates/glaredb/src/server.rs
@@ -351,14 +351,14 @@ impl ComputeServer {
     /// Serve using the provided config.
     pub async fn serve(self) -> Result<()> {
         let rpc_msg = if let Some(listener) = &self.rpc_listener {
-            format!("\nConnect via RPC: grpc://{}\n", listener.local_addr()?)
+            format!("Connect via RPC: grpc://{}", listener.local_addr()?)
         } else {
             "".to_string()
         };
 
         let pg_msg = if let Some(PostgresProtocolConfig { ref listener, .. }) = &self.pg_config {
             format!(
-                "\nConnect via Postgres: postgresql://{}",
+                "Connect via Postgres protocol: postgresql://{}",
                 listener.local_addr()?,
             )
         } else {
@@ -366,10 +366,9 @@ impl ComputeServer {
         };
 
         info!(
-            "Starting GlareDB {}{}{}\n",
+            "Starting GlareDB {}\n{}",
             env!("CARGO_PKG_VERSION"),
-            pg_msg,
-            rpc_msg
+            vec![rpc_msg, pg_msg].join("\n"),
         );
 
         // Shutdown handler.

--- a/crates/glaredb/src/server.rs
+++ b/crates/glaredb/src/server.rs
@@ -368,7 +368,7 @@ impl ComputeServer {
         info!(
             "Starting GlareDB {}\n{}",
             env!("CARGO_PKG_VERSION"),
-            vec![rpc_msg, pg_msg].join("\n"),
+            [rpc_msg, pg_msg].join("\n"),
         );
 
         // Shutdown handler.

--- a/crates/glaredb/tests/server_args_test.rs
+++ b/crates/glaredb/tests/server_args_test.rs
@@ -17,7 +17,7 @@ fn test_server_bind_addr() {
         .assert();
 
     assert.interrupted(/* We expect a timeout here */).stdout(contains(
-        "Connect via Postgres: postgresql://",
+        "Connect via Postgres protocol: postgresql://",
     ));
 }
 

--- a/crates/glaredb/tests/server_args_test.rs
+++ b/crates/glaredb/tests/server_args_test.rs
@@ -111,7 +111,7 @@ fn test_pg_enabled_by_default() {
         .assert();
 
     assert.interrupted(/* We expect a timeout here */).stdout(contains(
-        "Connect via Postgres: postgresql://"
+        "Connect via Postgres protocol: postgresql://"
     ));
 }
 
@@ -127,6 +127,6 @@ fn test_pg_disable() {
         .assert();
 
     assert.interrupted(/* We expect a timeout here */).stdout(contains(
-        "Connect via Postgres: postgresql"
+        "Connect via Postgres protocol: postgresql"
     ).not());
 }

--- a/crates/logutil/src/lib.rs
+++ b/crates/logutil/src/lib.rs
@@ -38,9 +38,8 @@ impl From<Verbosity> for Level {
         }
     }
 }
-#[derive(Default)]
+
 pub enum LoggingMode {
-    #[default]
     Full,
     Json,
     Compact,


### PR DESCRIPTION
Easier to read when running Cloud+GlareDB in the same terminal.