### PR TITLE
chore: Remote `fn runtime_preference()` from `TableFunc` trait.

### DIFF
--- a/crates/datafusion_ext/src/errors.rs
+++ b/crates/datafusion_ext/src/errors.rs
@@ -4,10 +4,7 @@ pub enum ExtensionError {
     InvalidNumArgs,
 
     #[error("Expected argument at index {index}: {what}")]
-    ExpectedIndexedArgument {
-        index: usize,
-        what: String,
-    },
+    ExpectedIndexedArgument { index: usize, what: String },
 
     #[error("{0}")]
     String(String),

--- a/crates/datafusion_ext/src/errors.rs
+++ b/crates/datafusion_ext/src/errors.rs
@@ -3,6 +3,12 @@ pub enum ExtensionError {
     #[error("Invalid number of arguments.")]
     InvalidNumArgs,
 
+    #[error("Expected argument at index {index}: {what}")]
+    ExpectedIndexedArgument {
+        index: usize,
+        what: String,
+    },
+
     #[error("{0}")]
     String(String),
 

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1302,10 +1302,10 @@ impl BuiltinCatalog {
             let schema_id = schema_names
                 .get(DEFAULT_SCHEMA)
                 .ok_or_else(|| MetastoreError::MissingNamedSchema(DEFAULT_SCHEMA.to_string()))?;
-            let mut entry = func.as_function_entry(oid, *schema_id);
-            entry.runtime_preference = func.runtime_preference();
 
+            let entry = func.as_function_entry(oid, *schema_id);
             insert_entry(oid, CatalogEntry::Function(entry))?;
+
             schema_objects
                 .get_mut(schema_id)
                 .unwrap()

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -199,9 +199,10 @@ message FunctionEntry {
     LOCAL = 1;
     REMOTE = 2;
   }
+
   EntryMeta meta = 1;
   FunctionType func_type = 2;
-  RuntimePreference runtime_preference = 3;
+  reserved 3;
   Signature signature = 4;
 }
 

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -202,7 +202,7 @@ message FunctionEntry {
 
   EntryMeta meta = 1;
   FunctionType func_type = 2;
-  reserved 3;
+  reserved 3; // Function runtime preference (static)
   Signature signature = 4;
 }
 

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -644,7 +644,6 @@ impl From<RuntimePreference> for catalog::function_entry::RuntimePreference {
 pub struct FunctionEntry {
     pub meta: EntryMeta,
     pub func_type: FunctionType,
-    pub runtime_preference: RuntimePreference,
     pub signature: Option<Signature>,
 }
 
@@ -655,7 +654,6 @@ impl TryFrom<catalog::FunctionEntry> for FunctionEntry {
         Ok(FunctionEntry {
             meta,
             func_type: value.func_type.try_into()?,
-            runtime_preference: value.runtime_preference.try_into()?,
             signature: value.signature.map(|s| s.try_into()).transpose()?,
         })
     }
@@ -803,12 +801,9 @@ impl TryFrom<catalog::Signature> for Signature {
 impl From<FunctionEntry> for catalog::FunctionEntry {
     fn from(value: FunctionEntry) -> Self {
         let func_type: catalog::function_entry::FunctionType = value.func_type.into();
-        let runtime_preference: catalog::function_entry::RuntimePreference =
-            value.runtime_preference.into();
         catalog::FunctionEntry {
             meta: Some(value.meta.into()),
             func_type: func_type as i32,
-            runtime_preference: runtime_preference as i32,
             signature: value.signature.map(|s| s.into()),
         }
     }

--- a/crates/sqlbuiltins/src/functions/mod.rs
+++ b/crates/sqlbuiltins/src/functions/mod.rs
@@ -10,9 +10,7 @@ use self::table::{BuiltinTableFuncs, TableFunc};
 
 use datafusion::logical_expr::{AggregateFunction, BuiltinScalarFunction, Expr, Signature};
 use once_cell::sync::Lazy;
-use protogen::metastore::types::catalog::{
-    EntryMeta, EntryType, FunctionEntry, FunctionType, RuntimePreference,
-};
+use protogen::metastore::types::catalog::{EntryMeta, EntryType, FunctionEntry, FunctionType};
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -73,7 +71,6 @@ pub trait BuiltinFunction: Sync + Send {
         FunctionEntry {
             meta,
             func_type: self.function_type(),
-            runtime_preference: RuntimePreference::Unspecified,
             signature: self.signature(),
         }
     }

--- a/crates/sqlbuiltins/src/functions/table/bigquery.rs
+++ b/crates/sqlbuiltins/src/functions/table/bigquery.rs
@@ -34,9 +34,14 @@ impl ConstBuiltinFunction for ReadBigQuery {
 
 #[async_trait]
 impl TableFunc for ReadBigQuery {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,

--- a/crates/sqlbuiltins/src/functions/table/delta.rs
+++ b/crates/sqlbuiltins/src/functions/table/delta.rs
@@ -32,10 +32,15 @@ impl ConstBuiltinFunction for DeltaScan {
 
 #[async_trait]
 impl TableFunc for DeltaScan {
-    fn runtime_preference(&self) -> RuntimePreference {
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
         // TODO: Detect runtime.
-        RuntimePreference::Remote
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,

--- a/crates/sqlbuiltins/src/functions/table/excel.rs
+++ b/crates/sqlbuiltins/src/functions/table/excel.rs
@@ -25,8 +25,12 @@ impl ConstBuiltinFunction for ExcelScan {
 
 #[async_trait]
 impl TableFunc for ExcelScan {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Local
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Local)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/generate_series.rs
+++ b/crates/sqlbuiltins/src/functions/table/generate_series.rs
@@ -47,18 +47,15 @@ impl ConstBuiltinFunction for GenerateSeries {
 
 #[async_trait]
 impl TableFunc for GenerateSeries {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Unspecified
-    }
     fn detect_runtime(
         &self,
         _: &[FuncParamValue],
         parent: RuntimePreference,
     ) -> Result<RuntimePreference> {
-        match parent {
-            RuntimePreference::Unspecified => Ok(RuntimePreference::Local),
-            other => Ok(other),
-        }
+        Ok(match parent {
+            RuntimePreference::Unspecified => RuntimePreference::Local,
+            other => other,
+        })
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/iceberg/data_files.rs
+++ b/crates/sqlbuiltins/src/functions/table/iceberg/data_files.rs
@@ -35,8 +35,12 @@ impl ConstBuiltinFunction for IcebergDataFiles {
 
 #[async_trait]
 impl TableFunc for IcebergDataFiles {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/iceberg/data_files.rs
+++ b/crates/sqlbuiltins/src/functions/table/iceberg/data_files.rs
@@ -40,6 +40,7 @@ impl TableFunc for IcebergDataFiles {
         _args: &[FuncParamValue],
         _parent: RuntimePreference,
     ) -> Result<RuntimePreference> {
+        // TODO: Check URL path to detect runtime dynamically.
         Ok(RuntimePreference::Remote)
     }
 

--- a/crates/sqlbuiltins/src/functions/table/iceberg/scan.rs
+++ b/crates/sqlbuiltins/src/functions/table/iceberg/scan.rs
@@ -27,9 +27,13 @@ impl ConstBuiltinFunction for IcebergScan {
 
 #[async_trait]
 impl TableFunc for IcebergScan {
-    fn runtime_preference(&self) -> RuntimePreference {
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
         // TODO: Detect runtime
-        RuntimePreference::Remote
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/iceberg/snapshots.rs
+++ b/crates/sqlbuiltins/src/functions/table/iceberg/snapshots.rs
@@ -35,8 +35,12 @@ impl ConstBuiltinFunction for IcebergSnapshots {
 
 #[async_trait]
 impl TableFunc for IcebergSnapshots {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/lance.rs
+++ b/crates/sqlbuiltins/src/functions/table/lance.rs
@@ -30,9 +30,13 @@ impl ConstBuiltinFunction for LanceScan {
 
 #[async_trait]
 impl TableFunc for LanceScan {
-    fn runtime_preference(&self) -> RuntimePreference {
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
         // TODO: Detect runtime.
-        RuntimePreference::Remote
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -134,8 +134,13 @@ pub fn table_location_and_opts(
     opts: &mut HashMap<String, FuncParamValue>,
 ) -> Result<(DatasourceUrl, StorageOptions)> {
     let mut args = args.into_iter();
-    let first = args.next().ok_or_else(|| ExtensionError::ExpectedIndexedArgument { index: 0, what: "location for the table".to_string() })?;
-    
+    let first = args
+        .next()
+        .ok_or_else(|| ExtensionError::ExpectedIndexedArgument {
+            index: 0,
+            what: "location for the table".to_string(),
+        })?;
+
     let url: String = first.try_into()?;
     let source_url =
         DatasourceUrl::try_new(url).map_err(|e| ExtensionError::Access(Box::new(e)))?;

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -134,7 +134,8 @@ pub fn table_location_and_opts(
     opts: &mut HashMap<String, FuncParamValue>,
 ) -> Result<(DatasourceUrl, StorageOptions)> {
     let mut args = args.into_iter();
-    let first = args.next().unwrap();
+    let first = args.next().ok_or_else(|| ExtensionError::ExpectedIndexedArgument { index: 0, what: "location for the table".to_string() })?;
+    
     let url: String = first.try_into()?;
     let source_url =
         DatasourceUrl::try_new(url).map_err(|e| ExtensionError::Access(Box::new(e)))?;

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -47,17 +47,13 @@ use super::BuiltinFunction;
 /// e.g. `SELECT * FROM my_table_func(...)`
 #[async_trait]
 pub trait TableFunc: BuiltinFunction {
-    /// Get the preference for where a function should run.
-    fn runtime_preference(&self) -> RuntimePreference;
-
-    /// Determine the runtime from the arguments to the function.
+    /// Determine the runtime preference for the function from the passed-on
+    /// arguments.
     fn detect_runtime(
         &self,
         _args: &[FuncParamValue],
         _parent: RuntimePreference,
-    ) -> Result<RuntimePreference> {
-        Ok(self.runtime_preference())
-    }
+    ) -> Result<RuntimePreference>;
 
     /// Return a table provider using the provided args.
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/mongo.rs
+++ b/crates/sqlbuiltins/src/functions/table/mongo.rs
@@ -34,8 +34,12 @@ impl ConstBuiltinFunction for ReadMongoDb {
 
 #[async_trait]
 impl TableFunc for ReadMongoDb {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/mysql.rs
+++ b/crates/sqlbuiltins/src/functions/table/mysql.rs
@@ -33,8 +33,12 @@ impl ConstBuiltinFunction for ReadMysql {
 
 #[async_trait]
 impl TableFunc for ReadMysql {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/table/object_store.rs
@@ -80,14 +80,10 @@ impl BuiltinFunction for ObjScanTableFunc {
 
 #[async_trait]
 impl TableFunc for ObjScanTableFunc {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Unspecified
-    }
-
     fn detect_runtime(
         &self,
         args: &[FuncParamValue],
-        _: RuntimePreference,
+        _parent: RuntimePreference,
     ) -> Result<RuntimePreference> {
         let mut args = args.iter();
         let url_arg = args.next().unwrap().to_owned();

--- a/crates/sqlbuiltins/src/functions/table/postgres.rs
+++ b/crates/sqlbuiltins/src/functions/table/postgres.rs
@@ -33,9 +33,14 @@ impl ConstBuiltinFunction for ReadPostgres {
 
 #[async_trait]
 impl TableFunc for ReadPostgres {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,

--- a/crates/sqlbuiltins/src/functions/table/snowflake.rs
+++ b/crates/sqlbuiltins/src/functions/table/snowflake.rs
@@ -34,9 +34,14 @@ impl ConstBuiltinFunction for ReadSnowflake {
 
 #[async_trait]
 impl TableFunc for ReadSnowflake {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         _: &dyn TableFuncContextProvider,

--- a/crates/sqlbuiltins/src/functions/table/system/cache_external_tables.rs
+++ b/crates/sqlbuiltins/src/functions/table/system/cache_external_tables.rs
@@ -41,8 +41,12 @@ impl ConstBuiltinFunction for CacheExternalDatabaseTables {
 
 #[async_trait]
 impl TableFunc for CacheExternalDatabaseTables {
-    fn runtime_preference(&self) -> RuntimePreference {
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(

--- a/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
+++ b/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
@@ -37,10 +37,16 @@ impl ConstBuiltinFunction for ListSchemas {
 
 #[async_trait]
 impl TableFunc for ListSchemas {
-    fn runtime_preference(&self) -> RuntimePreference {
-        // Currently all of our db's are "external"  it'd never be preferred to run this locally.
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        // Currently all of our db's are "external" so it'd never be preferred
+        // to run this locally.
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,
@@ -93,9 +99,14 @@ impl ConstBuiltinFunction for ListTables {
 
 #[async_trait]
 impl TableFunc for ListTables {
-    fn runtime_preference(&self) -> RuntimePreference {
-        // Currently all of our db's are "external" so it'd never be preferred to run this locally.
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        // Currently all of our db's are "external" so it'd never be preferred
+        // to run this locally.
+        Ok(RuntimePreference::Remote)
     }
 
     async fn create_provider(
@@ -152,10 +163,16 @@ impl ConstBuiltinFunction for ListColumns {
 
 #[async_trait]
 impl TableFunc for ListColumns {
-    fn runtime_preference(&self) -> RuntimePreference {
-        // Currently all of our db's are "external" so it'd never be preferred to run this locally.
-        RuntimePreference::Remote
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference> {
+        // Currently all of our db's are "external" so it'd never be preferred
+        // to run this locally.
+        Ok(RuntimePreference::Remote)
     }
+
     async fn create_provider(
         &self,
         ctx: &dyn TableFuncContextProvider,


### PR DESCRIPTION
We should only have 1 source of truth for runtime preference for the functions. Here, `runtime_preference` method is removed so the runtime is always calculated from `detect_runtime`.

Fixes #2165