### PR TITLE
feat: cli highlighting improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
  "proxyutil",
  "reedline",
  "rpcsrv",
+ "sqlbuiltins",
  "sqlexec",
  "telemetry",
  "tempfile",

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -36,6 +36,7 @@ reedline = "0.27.1"
 nu-ansi-term = "0.49.0"
 url.workspace = true
 atty = "0.2.14"
+sqlbuiltins = { path = "../sqlbuiltins" }
 
 [dev-dependencies]
 predicates = "3.0.4"

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -63,7 +63,7 @@ fn colorize_sql(query: &str, st: &mut StyledText, is_hint: bool) {
     }
     let tokens = tokens.unwrap();
 
-    for (idx, token) in tokens.iter().enumerate() {
+    for token in tokens {
         match token {
             // Symbols
             token @ (Token::LParen

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -1,6 +1,5 @@
 use std::io::{self};
 
-use datafusion::sql::sqlparser::tokenizer::Word;
 use nu_ansi_term::{Color, Style};
 
 use crate::local::is_client_cmd;

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -92,29 +92,6 @@ fn colorize_sql(query: &str, st: &mut StyledText, is_hint: bool) {
                 st.push((new_style().fg(Color::Yellow).italic(), format!("\"{}\"", s)))
             }
             Token::Word(w) => match w.keyword {
-                Keyword::TABLES => {
-                    let expected_whitespace = tokens.get(idx - 1);
-                    let expected_show = tokens.get(idx - 2);
-
-                    // match against SHOW TABLES, but not "tables"
-                    // SHOW TABLES -> highlighted
-                    // select * from tables -> not highlighted
-                    if matches!(
-                        (expected_show, expected_whitespace),
-                        (
-                            Some(Token::Word(Word {
-                                keyword: Keyword::SHOW,
-                                ..
-                            })),
-                            Some(Token::Whitespace(_))
-                        )
-                    ) {
-                        st.push((new_style().fg(Color::LightGreen), format!("{w}")));
-                    } else {
-                        st.push((new_style(), format!("{w}")));
-                    }
-                }
-
                 // Keywords
                 Keyword::SELECT
                 | Keyword::FROM
@@ -137,7 +114,6 @@ fn colorize_sql(query: &str, st: &mut StyledText, is_hint: bool) {
                 | Keyword::CREATE
                 | Keyword::EXTERNAL
                 | Keyword::TABLE
-                | Keyword::SHOW
                 | Keyword::ASC
                 | Keyword::DESC
                 | Keyword::NULL

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -143,7 +143,6 @@ impl LocalSession {
             .with_validator(Box::new(SQLValidator));
 
         let prompt = SQLPrompt {};
-        let mut scratch = String::with_capacity(1024);
 
         loop {
             let sig = line_editor.read_line(&prompt);
@@ -157,26 +156,14 @@ impl LocalSession {
                         }
                     },
                     _ => {
-                        let mut parts = buffer.splitn(2, ';');
-                        let first = parts.next().unwrap();
-                        scratch.push_str(first);
-
-                        let second = parts.next();
-                        if second.is_some() {
-                            match self.execute(&scratch).await {
-                                Ok(_) => {}
-                                Err(e) => println!("Error: {e}"),
-                            };
-                            scratch.clear();
-                        } else {
-                            scratch.push(' ');
-                        }
+                        match self.execute(&buffer).await {
+                            Ok(_) => {}
+                            Err(e) => println!("Error: {e}"),
+                        };
                     }
                 },
                 Ok(Signal::CtrlD) => break,
-                Ok(Signal::CtrlC) => {
-                    scratch.clear();
-                }
+                Ok(Signal::CtrlC) => {}
                 Err(e) => {
                     return Err(anyhow!("Unable to read from prompt: {e}"));
                 }

--- a/crates/glaredb/tests/iss_2309.rs
+++ b/crates/glaredb/tests/iss_2309.rs
@@ -1,0 +1,39 @@
+mod setup;
+
+use setup::DEFAULT_TIMEOUT;
+
+use crate::setup::make_cli;
+
+#[test]
+fn test_special_characters() {
+    let mut cmd = make_cli();
+
+    let assert = cmd
+        .timeout(DEFAULT_TIMEOUT)
+        .args(&["-q", r#"select ';'"#])
+        .assert();
+    assert.success().stdout(predicates::str::contains(
+        r#"
+┌───────────┐
+│ Utf8(";") │
+│ ──        │
+│ Utf8      │
+╞═══════════╡
+│ ;         │
+└───────────┘"#
+            .trim_start(),
+    ));
+}
+
+#[test]
+fn test_special_characters_2() {
+    let mut cmd = make_cli();
+
+    let assert = cmd
+        .timeout(DEFAULT_TIMEOUT)
+        .args(&["-q", r#"select ";""#])
+        .assert();
+    assert.failure().stderr(predicates::str::contains(
+        "Schema error: No field named \";\".",
+    ));
+}

--- a/crates/sqlbuiltins/src/functions/mod.rs
+++ b/crates/sqlbuiltins/src/functions/mod.rs
@@ -226,6 +226,14 @@ impl FunctionRegistry {
         FunctionRegistry { funcs, udfs }
     }
 
+    pub fn contains(&self, name: impl AsRef<str>) -> bool {
+        self.funcs
+            .keys()
+            .chain(self.udfs.keys())
+            .chain(BUILTIN_TABLE_FUNCS.keys())
+            .any(|k| k.to_lowercase() == name.as_ref().to_lowercase())
+    }
+
     pub fn find_function(&self, name: &str) -> Option<Arc<dyn BuiltinFunction>> {
         self.funcs.get(name).cloned()
     }

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -123,6 +123,9 @@ impl BuiltinTableFuncs {
     pub fn iter_funcs(&self) -> impl Iterator<Item = &Arc<dyn TableFunc>> {
         self.funcs.values()
     }
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.funcs.keys()
+    }
 }
 
 impl Default for BuiltinTableFuncs {

--- a/testdata/sqllogictests/special_characters.slt
+++ b/testdata/sqllogictests/special_characters.slt
@@ -1,0 +1,9 @@
+# https://github.com/GlareDB/glaredb/issues/2309
+statement ok
+select ';';
+
+statement ok
+select ';"';
+
+statement error Schema error: No field named ";".
+select ";";

--- a/testdata/sqllogictests/special_characters.slt
+++ b/testdata/sqllogictests/special_characters.slt
@@ -5,5 +5,5 @@ select ';';
 statement ok
 select ';"';
 
-statement error Schema error: No field named ";".
+statement error Schema error
 select ";";


### PR DESCRIPTION
a number of improvements to the cli highlighter. 

- better support for types
- more support for various symbols `&|+-/%` 
- function highlighting!

![demo](https://github.com/GlareDB/glaredb/assets/21327470/39024a73-5aec-46c8-8e96-532568b36cdc)


