### PR TITLE
chore: Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/crates/protogen/proto/common/arrow.proto
+++ b/crates/protogen/proto/common/arrow.proto
@@ -8,7 +8,9 @@ package common.arrow;
 
 option go_package = "github.com/glaredb/cloud/pkg/protogen/common";
 
-message Schema { repeated Field columns = 1; }
+message Schema {
+  repeated Field columns = 1;
+}
 
 message Field {
   // Name of the field.
@@ -19,7 +21,9 @@ message Field {
   repeated Field children = 4;
 }
 
-message FixedSizeBinary { int32 length = 1; }
+message FixedSizeBinary {
+  int32 length = 1;
+}
 
 message Timestamp {
   TimeUnit time_unit = 1;
@@ -50,7 +54,9 @@ message Decimal {
   int32 scale = 4;
 }
 
-message List { Field field_type = 1; }
+message List {
+  Field field_type = 1;
+}
 
 message FixedSizeList {
   Field field_type = 1;
@@ -62,7 +68,9 @@ message Dictionary {
   ArrowType value = 2;
 }
 
-message Struct { repeated Field sub_field_types = 1; }
+message Struct {
+  repeated Field sub_field_types = 1;
+}
 
 enum UnionMode {
   sparse = 0;

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -156,7 +156,7 @@ message SchemaEntry {
 message TableEntry {
   EntryMeta meta = 1;
 
-  reserved 2; // Column fields
+  reserved 2;  // Column fields
 
   options.TableOptions options = 3;
   optional uint32 tunnel_id = 4;
@@ -202,7 +202,7 @@ message FunctionEntry {
 
   EntryMeta meta = 1;
   FunctionType func_type = 2;
-  reserved 3; // Function runtime preference (static)
+  reserved 3;  // Function runtime preference (static)
   Signature signature = 4;
 }
 

--- a/crates/protogen/proto/metastore/options.proto
+++ b/crates/protogen/proto/metastore/options.proto
@@ -54,18 +54,26 @@ message DatabaseOptionsInternal {}
 
 message DatabaseOptionsDebug {}
 
-message DatabaseOptionsPostgres { string connection_string = 1; }
+message DatabaseOptionsPostgres {
+  string connection_string = 1;
+}
 
 message DatabaseOptionsBigQuery {
   string service_account_key = 1;
   string project_id = 2;
 }
 
-message DatabaseOptionsMysql { string connection_string = 1; }
+message DatabaseOptionsMysql {
+  string connection_string = 1;
+}
 
-message DatabaseOptionsMongo { string connection_string = 1; }
+message DatabaseOptionsMongo {
+  string connection_string = 1;
+}
 
-message DatabaseOptionsSqlServer { string connection_string = 1; }
+message DatabaseOptionsSqlServer {
+  string connection_string = 1;
+}
 
 message DatabaseOptionsSnowflake {
   string account_name = 1;
@@ -77,7 +85,9 @@ message DatabaseOptionsSnowflake {
 }
 
 message DatabaseOptionsDeltaLake {
-  oneof catalog { DeltaLakeUnityCatalog unity = 1; }
+  oneof catalog {
+    DeltaLakeUnityCatalog unity = 1;
+  }
   StorageOptions storage_options = 2;
 }
 
@@ -88,7 +98,9 @@ message DeltaLakeUnityCatalog {
   string workspace_url = 3;
 }
 
-message StorageOptions { map<string, string> inner = 1; }
+message StorageOptions {
+  map<string, string> inner = 1;
+}
 
 // Table options
 
@@ -119,7 +131,9 @@ message TableOptionsInternal {
   repeated InternalColumnDefinition columns = 1;
 }
 
-message TableOptionsDebug { string table_type = 1; }
+message TableOptionsDebug {
+  string table_type = 1;
+}
 
 message TableOptionsPostgres {
   string connection_string = 1;
@@ -234,9 +248,13 @@ message CredentialsOptions {
   }
 }
 
-message CredentialsOptionsDebug { string table_type = 1; }
+message CredentialsOptionsDebug {
+  string table_type = 1;
+}
 
-message CredentialsOptionsGcp { string service_account_key = 1; }
+message CredentialsOptionsGcp {
+  string service_account_key = 1;
+}
 
 message CredentialsOptionsAws {
   string access_key_id = 1;

--- a/crates/protogen/proto/metastore/service.proto
+++ b/crates/protogen/proto/metastore/service.proto
@@ -14,7 +14,9 @@ message FetchCatalogRequest {
   bytes db_id = 1;
 }
 
-message FetchCatalogResponse { catalog.CatalogState catalog = 1; }
+message FetchCatalogResponse {
+  catalog.CatalogState catalog = 1;
+}
 
 // Possible mutations to make.
 message Mutation {
@@ -129,7 +131,8 @@ message AlterDatabaseOperationSetAccessMode {
 message AlterDatabaseOperation {
   oneof operation {
     AlterDatabaseOperationRename alter_database_operation_rename = 1;
-    AlterDatabaseOperationSetAccessMode alter_database_operation_set_access_mode = 2;
+    AlterDatabaseOperationSetAccessMode
+        alter_database_operation_set_access_mode = 2;
   };
 }
 
@@ -176,7 +179,9 @@ message DropCredentials {
   bool if_exists = 2;
 }
 
-message UpdateDeploymentStorage { uint64 new_storage_size = 1; }
+message UpdateDeploymentStorage {
+  uint64 new_storage_size = 1;
+}
 
 message MutateRequest {
   // Mutate the catalog for this database.

--- a/crates/protogen/proto/rpcsrv/common.proto
+++ b/crates/protogen/proto/rpcsrv/common.proto
@@ -10,7 +10,9 @@ package rpcsrv.common;
 option go_package = "github.com/glaredb/cloud/pkg/protogen/rpcsrv";
 
 // Storage config for the session.
-message SessionStorageConfig { optional string gcs_bucket = 1; }
+message SessionStorageConfig {
+  optional string gcs_bucket = 1;
+}
 
 /// A single batch as the result of query execution.
 message ExecutionResultBatch {

--- a/crates/protogen/proto/rpcsrv/service.proto
+++ b/crates/protogen/proto/rpcsrv/service.proto
@@ -88,9 +88,13 @@ message InitializeSessionResponse {
   bytes user_id = 3;
 }
 
-message FetchCatalogRequest { bytes database_id = 1; }
+message FetchCatalogRequest {
+  bytes database_id = 1;
+}
 
-message FetchCatalogResponse { metastore.catalog.CatalogState catalog = 1; }
+message FetchCatalogResponse {
+  metastore.catalog.CatalogState catalog = 1;
+}
 
 // Dispatch the table access on remote server.
 message DispatchAccessRequest {


### PR DESCRIPTION
Adds a `.clang-format` file for configuring `clang-format` (I use it for auto-formatting protobufs).

My motivation for adding this in is by default clang-format will collapse a protobuf message with a single field and no comments into a single line.

For example, it will format this:

```protobuf
message Schema {
  repeated Field columns = 1;
}
```

Into this:

```protobuf
message Schema { repeated Field columns = 1; }
```

I don't like that way of formatting, and the only reason we had it in the code base was because I was using a unconfigured clang-format.

Unfortunately I was not able to find a specific option for this (there's a ton, so I might've just missed it:
https://clang.llvm.org/docs/ClangFormatStyleOptions.html), so instead I just enabled the Google style. This seems to do mostly what I want.