### PR TITLE
docs: improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,29 @@
 <!-- markdownlint-disable first-line-h1 -->
 <div align="center">
   <a href="https://glaredb.com#gh-light-mode-only">
-    <img src="https://docs.glaredb.com/assets/logo.svg" height="44">
+    <img src="https://docs.glaredb.com/assets/logo.svg" height="60q">
   </a>
   <a href="https://glaredb.com#gh-dark-mode-only">
-    <img src="https://glaredb.com/logo.svg" height="44">
+    <img src="https://glaredb.com/logo.svg" height="60">
   </a>
 </div>
-
-<!-- Adds some spacing between logo and badges. -->
-<p></p>
+<br/>
+<p align="center">
+Data exists everywhere: on laptops, in databases like Postgres and Snowflake, and as files in S3, in various formats including Parquet, CSV, and JSON. Accessing and analyzing this data typically involves multiple steps across different systems.<br/> <br/> <b>GlareDB is designed to query your data wherever it lives using SQL that you
+already know.</b>
+</p>
+<p align="center">
+<a href="https://docs.glaredb.com">Documentation</a> •
+<a href="https://console.glaredb.com>">GlareDB Cloud</a> •
+<a href="https://glaredb.com/blog">Blog</a>
+</p>
 
 <div align="center">
-<a href="https://docs.glaredb.com"><img src="https://img.shields.io/static/v1?label=docs&message=GlareDB%20Reference&color=55A39B&style=flat-square"></img></a>
 <a href="https://github.com/GlareDB/glaredb/releases"><img src="https://img.shields.io/github/v/release/glaredb/glaredb?display_name=tag&style=flat-square"></img></a>
 <a href="https://pypi.org/project/glaredb"><img src="https://img.shields.io/pypi/v/glaredb?style=flat-square"</img></a>
 <a href="https://twitter.com/glaredb"><img src="https://img.shields.io/twitter/follow/glaredb?color=blue&logo=twitter&style=flat-square"></img></a>
 <a href="https://discord.gg/2D7qxC5xkf"><img src="https://img.shields.io/static/v1?label=Chat on Discord&message= &color=360066&style=flat-square"></img></a>
 </div>
-
-## About
-
-Data exists everywhere: your laptop, [Postgres], [Snowflake] and as
-[files in S3]. It exists in various formats such as Parquet, CSV and JSON.
-Regardless, there will always be multiple steps spanning several destinations to
-get the insights you need.
-
-**GlareDB is designed to query your data wherever it lives using SQL that you
-already know.**
 
 ## Install
 
@@ -38,11 +34,12 @@ Install/update `glaredb` in the **current directory**:
 curl https://glaredb.com/install.sh | sh
 ```
 
-It may be helpful to install the binary in a location on your `PATH`. For
-example, `~/.local/bin`.
+> [!TIP]
+> It may be helpful to install the binary in a location on your `PATH`. For example, `~/.local/bin`.
+>
+> If you prefer manual installation, download, extract and run the GlareDB binary
+> from a release in our [releases page].
 
-If you prefer manual installation, download, extract and run the GlareDB binary
-from a release in our [releases page].
 
 ## Getting started
 
@@ -69,12 +66,6 @@ Or, you can execute SQL and immediately return (**try it out!**):
 'https://huggingface.co/datasets/fka/awesome-chatgpt-prompts/raw/main/prompts.csv';"
 ```
 
-To see all options use `--help`:
-
-```sh
-./glaredb --help
-```
-
 ### Hybrid Execution
 
 1. Sign up at <https://console.glaredb.com> for a **free** fully-managed
@@ -94,17 +85,16 @@ Read our [announcement on Hybrid Execution] for more information.
 
 1. Install the official [GlareDB Python library]
 
-     ```shell
-     pip install glaredb
-     ```
+   ```shell
+   pip install glaredb
+   ```
 
 2. Import and use `glaredb`.
 
-     ```python
-     import glaredb
-     con = glaredb.connect()
-     con.sql("select 'hello world';").show()
-     ```
+   ```python
+   import glaredb
+   glaredb.sql("select 'hello world';").show()
+   ```
 
 To use **Hybrid Execution**, sign up at <https://console.glaredb.com> and
 use the connection string for your deployment. For example:
@@ -115,102 +105,45 @@ con = glaredb.connect("glaredb://user:pass@host:port/deployment")
 con.sql("select 'hello hybrid exec';").show()
 ```
 
-GlareDB work with [Pandas] and [Polars] DataFrames out of the box:
+GlareDB also work with [Pandas] and [Polars] DataFrames out of the box:
 
-```python
-import glaredb
-import polars as pl
-
-df = pl.DataFrame(
-    {
-        "A": [1, 2, 3, 4, 5],
-        "fruits": ["banana", "banana", "apple", "apple", "banana"],
-        "B": [5, 4, 3, 2, 1],
-        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-    }
-)
-
-con = glaredb.connect()
-
-df = con.sql("select * from df where fruits = 'banana'").to_polars();
-
-print(df)
+```py
+glaredb.sql("select * from pd_df").to_pandas()
+glaredb.sql("select * from pl_df").to_polars()
 ```
 
 ### Local server
 
-The `server` subcommand can be used to launch a server process for GlareDB:
-
 ```shell
+# The `server` subcommand can be used to launch a server process for GlareDB:
 ./glaredb server
 ```
 
-To see all options for running in server mode, use `--help`:
+> [!NOTE]
+> When launched as a server process, GlareDB can be reached on port `6543` using a
+> Postgres client. The following example uses `psql` to connect to a locally
+> running serve:
 
-```sh
-./glaredb server --help
-```
-
-When launched as a server process, GlareDB can be reached on port `6543` using a
-Postgres client. The following example uses `psql` to connect to a locally
-running server:
 
 ```shell
+# Connect to the server using psql client
 psql "host=localhost user=glaredb dbname=glaredb port=6543"
-```
-
-## Your first data source
-
-A demo Postgres instance is deployed at `pg.demo.glaredb.com`. Adding this
-Postgres instance as data source is as easy as running the following command:
-
-```sql
-CREATE EXTERNAL DATABASE my_pg
-    FROM postgres
-    OPTIONS (
-        host = 'pg.demo.glaredb.com',
-        port = '5432',
-        user = 'demo',
-        password = 'demo',
-        database = 'postgres',
-    );
-```
-
-Once the data source has been added, it can be queried using fully qualified
-table names:
-
-```sql
-SELECT *
-FROM my_pg.public.lineitem
-WHERE l_shipdate <= date '1998-12-01' - INTERVAL '90'
-LIMIT 5;
-```
-
-Check out the docs to learn about all [supported data sources]. Many data
-sources can be connected to the same GlareDB instance.
-
-Done with this data source? Remove it with the following command:
-
-```sql
-DROP DATABASE my_pg;
 ```
 
 ## Building from source
 
-Building GlareDB requires Rust/Cargo to be installed. Check out [rustup](https://rustup.rs/) for
-an easy way to install Rust on your system.
+Requirements
 
-Running the following command will build a release binary:
+- [rust/cargo](https://rustup.rs/)
+- [just](https://just.systems)
 
 ```shell
+git clone https://github.com/GlareDB/glaredb
+cd glaredb
 just build --release
 ```
 
 The compiled release binary can be found in `target/release/glaredb`.
-
-## Docs
-
-Browse GlareDB documentation on our [docs.glaredb.com](https://docs.glaredb.com).
 
 ## Contributing
 


### PR DESCRIPTION
So i think our readme has been getting a bit cluttered. This is an attempt to strip it down a little bit & keep only the most relevant information.

Most importantly, it moves our "about" section to the header, and adds some of the most important links to there as well. 

the `## Your first data source` section was removed as it's already included in our docs. 

Note:
it does use some github markdown specific syntax such as `[!TIP]`, so you should definitely review it with that in mind. 