### PR TITLE
fix: bson type inference fixes

### DIFF
--- a/crates/datasources/src/bson/table.rs
+++ b/crates/datasources/src/bson/table.rs
@@ -120,7 +120,7 @@ pub async fn bson_streaming_table(
     let schema = Arc::new(merge_schemas(
         sample
             .iter()
-            .map(|doc| schema_from_document(doc.to_document()?)),
+            .map(|doc| schema_from_document(&doc.to_raw_document_buf())),
     )?);
 
     let mut streams = Vec::<Arc<(dyn PartitionStream + 'static)>>::with_capacity(readers.len() + 1);

--- a/crates/datasources/src/mongodb/infer.rs
+++ b/crates/datasources/src/mongodb/infer.rs
@@ -1,4 +1,5 @@
 use super::errors::Result;
+use bson::RawDocumentBuf;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
 use futures::TryStreamExt;
 
@@ -41,7 +42,7 @@ impl TableSampler {
 
         let mut schemas = Vec::with_capacity(sample_count as usize);
         while let Some(doc) = cursor.try_next().await? {
-            let schema = schema_from_document(doc);
+            let schema = schema_from_document(&RawDocumentBuf::from_document(&doc)?);
             schemas.push(schema);
         }
 

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -29,13 +29,6 @@ bikeshare_stations
 query TTT rowsort
 SELECT column_name, data_type, nullable
 	FROM list_columns(external_db, test, bikeshare_stations)
-	WHERE data_type = 'Float64';
-----
-footprint_width		Float64	t
-
-query TTT rowsort
-SELECT column_name, data_type, nullable
-	FROM list_columns(external_db, test, bikeshare_stations)
 	WHERE data_type = 'Int32';
 ----
 city_asset_number Int32 t

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -31,12 +31,17 @@ SELECT column_name, data_type, nullable
 	FROM list_columns(external_db, test, bikeshare_stations)
 	WHERE data_type = 'Float64';
 ----
-city_asset_number	Float64	t
-council_district	Float64	t
-footprint_length	Float64	t
 footprint_width		Float64	t
-number_of_docks		Float64	t
-station_id			Float64	t
+
+query TTT rowsort
+SELECT column_name, data_type, nullable
+	FROM list_columns(external_db, test, bikeshare_stations)
+	WHERE data_type = 'Int32';
+----
+city_asset_number	Int32	t
+council_district	Int32	t
+number_of_docks		Int32	t
+station_id		Int32	t
 
 statement ok
 DROP DATABASE external_db;

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -26,17 +26,27 @@ SELECT table_name FROM list_tables(external_db, test)
 ----
 bikeshare_stations
 
-query TTT rowsort
-SELECT column_name, data_type, nullable
+query T
+SELECT data_type, nullable
 	FROM list_columns(external_db, test, bikeshare_stations)
-	WHERE data_type = 'Int32';
+	WHERE column_name = 'station_id';
 ----
-city_asset_number Int32 t
-council_district Int32 t
-footprint_length Int32 t
-footprint_width Int32 t
-number_of_docks Int32 t
-station_id Int32 t
+Int32 t
+
+query T
+SELECT data_type, nullable
+	FROM list_columns(external_db, test, bikeshare_stations)
+	WHERE column_name = 'name';
+----
+Utf8 t
+
+query T
+SELECT data_type, nullable
+	FROM list_columns(external_db, test, bikeshare_stations)
+	WHERE column_name = 'modified_date';
+----
+Date64 t
+
 
 statement ok
 DROP DATABASE external_db;

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -40,13 +40,5 @@ SELECT data_type, nullable
 ----
 Utf8 t
 
-query T
-SELECT data_type, nullable
-	FROM list_columns(external_db, test, bikeshare_stations)
-	WHERE column_name = 'modified_date';
-----
-Date64 t
-
-
 statement ok
 DROP DATABASE external_db;

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -38,9 +38,10 @@ SELECT column_name, data_type, nullable
 	FROM list_columns(external_db, test, bikeshare_stations)
 	WHERE data_type = 'Int32';
 ----
-city_asset_number Int32	t
+city_asset_number Int32 t
 council_district Int32 t
 footprint_length Int32 t
+footprint_width Int32 t
 number_of_docks Int32 t
 station_id Int32 t
 

--- a/testdata/sqllogictests_mongodb/external_database.slt
+++ b/testdata/sqllogictests_mongodb/external_database.slt
@@ -38,10 +38,11 @@ SELECT column_name, data_type, nullable
 	FROM list_columns(external_db, test, bikeshare_stations)
 	WHERE data_type = 'Int32';
 ----
-city_asset_number	Int32	t
-council_district	Int32	t
-number_of_docks		Int32	t
-station_id		Int32	t
+city_asset_number Int32	t
+council_district Int32 t
+footprint_length Int32 t
+number_of_docks Int32 t
+station_id Int32 t
 
 statement ok
 DROP DATABASE external_db;


### PR DESCRIPTION
This pulls out the fix from #2318 for the fact that all numbers get
pushed into floats.

I also bundled a fix that does some more lazy parsing of the bson. 

This should definitely go into the next release whereas #2318 probably
won't make the cut.