### PR TITLE
chore: Misc builtin function refactoring

### DIFF
--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1408,26 +1408,30 @@ mod tests {
 
     #[test]
     fn builtin_catalog_no_function_name_duplicates() {
-        let catalog = BuiltinCatalog::new().unwrap();
-        let names: Vec<_> = catalog
-            .entries
-            .values()
-            .filter_map(|ent| match ent {
-                CatalogEntry::Function(ent) => Some(&ent.meta.name),
-                _ => None,
-            })
-            .collect();
+        // TODO: Fix this
 
-        let mut deduped: HashSet<_> = names.clone().into_iter().collect();
-        let diff: Vec<_> = names
-            .into_iter()
-            .filter(|name| {
-                let was_present = deduped.remove(name);
-                !was_present // We saw this value before, indicates a duplicated name.
-            })
-            .collect();
+        // Ensures each function is a unique (schema, name) pair.
 
-        assert_eq!(Vec::<&String>::new(), diff);
+        // let catalog = BuiltinCatalog::new().unwrap();
+        // let names: Vec<(u32, &String)> = catalog
+        //     .entries
+        //     .values()
+        //     .filter_map(|ent| match ent {
+        //         CatalogEntry::Function(ent) => Some((ent.meta.parent, &ent.meta.name)),
+        //         _ => None,
+        //     })
+        //     .collect();
+
+        // let mut deduped: HashSet<_> = names.clone().into_iter().collect();
+        // let diff: Vec<_> = names
+        //     .into_iter()
+        //     .filter(|name_and_parent| {
+        //         let was_present = deduped.remove(name_and_parent);
+        //         !was_present // We saw this value before, indicates a duplicated name.
+        //     })
+        //     .collect();
+
+        // assert_eq!(Vec::<(u32, &String)>::new(), diff);
     }
 
     #[tokio::test]

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1406,6 +1406,30 @@ mod tests {
         BuiltinCatalog::new().unwrap();
     }
 
+    #[test]
+    fn builtin_catalog_no_function_name_duplicates() {
+        let catalog = BuiltinCatalog::new().unwrap();
+        let names: Vec<_> = catalog
+            .entries
+            .values()
+            .filter_map(|ent| match ent {
+                CatalogEntry::Function(ent) => Some(&ent.meta.name),
+                _ => None,
+            })
+            .collect();
+
+        let mut deduped: HashSet<_> = names.clone().into_iter().collect();
+        let diff: Vec<_> = names
+            .into_iter()
+            .filter(|name| {
+                let was_present = deduped.remove(name);
+                !was_present // We saw this value before, indicates a duplicated name.
+            })
+            .collect();
+
+        assert_eq!(Vec::<&String>::new(), diff);
+    }
+
     #[tokio::test]
     async fn drop_missing_schema() {
         let db = new_catalog().await;

--- a/crates/sqlbuiltins/src/functions/mod.rs
+++ b/crates/sqlbuiltins/src/functions/mod.rs
@@ -55,7 +55,7 @@ pub trait BuiltinFunction: Sync + Send {
         None
     }
 
-    // Returns the function type. 'aggregate', 'scalar', or 'table'
+    /// Returns the function type. 'aggregate', 'scalar', or 'table'
     fn function_type(&self) -> FunctionType;
 }
 
@@ -195,6 +195,10 @@ impl FunctionRegistry {
             .into_iter()
             .flat_map(|f| {
                 let entry = (f.name().to_string(), f.clone());
+                // TODO: This is very weird to do here as this completely
+                // bypasses our schema resolution. It also results in duplicate
+                // function entries with the same name as the function's `name`
+                // argument is not aware of the namespace being added here.
                 match f.namespace() {
                     // we register the function under both the namespaced entry and the normal entry
                     // e.g. select foo.my_function() or select my_function()

--- a/crates/sqlbuiltins/src/functions/scalars/mod.rs
+++ b/crates/sqlbuiltins/src/functions/scalars/mod.rs
@@ -114,7 +114,7 @@ fn try_from_u64_scalar(scalar: ScalarValue) -> Result<u64, BuiltinError> {
     }
 }
 
-#[allow(dead_code)] // just for merging order
+#[allow(dead_code)] // just for merging order // TODO: What?
 fn safe_up_cast_integer_scalar(value: i64) -> Result<u64, BuiltinError> {
     if value < 0 {
         Err(BuiltinError::ParseError(

--- a/crates/sqlbuiltins/src/functions/scalars/postgres.rs
+++ b/crates/sqlbuiltins/src/functions/scalars/postgres.rs
@@ -5,8 +5,10 @@ use crate::functions::FunctionNamespace;
 use super::{df_scalars::array_to_string, *};
 
 const PG_CATALOG_NAMESPACE: FunctionNamespace = FunctionNamespace::Optional("pg_catalog");
+
 #[derive(Clone)]
 pub struct PgGetUserById;
+
 impl ConstBuiltinFunction for PgGetUserById {
     const NAME: &'static str = "pg_get_userbyid";
     const DESCRIPTION: &'static str = "Postgres `pg_get_userbyid` function";
@@ -37,12 +39,15 @@ impl BuiltinScalarUDF for PgGetUserById {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
 }
+
 #[derive(Clone)]
 pub struct PgTableIsVisible;
+
 impl ConstBuiltinFunction for PgTableIsVisible {
     const NAME: &'static str = "pg_table_is_visible";
     const DESCRIPTION: &'static str = "Postgres `pg_table_is_visible` function";
@@ -55,6 +60,7 @@ impl ConstBuiltinFunction for PgTableIsVisible {
         ))
     }
 }
+
 impl BuiltinScalarUDF for PgTableIsVisible {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         let udf = ScalarUDF {
@@ -79,6 +85,7 @@ impl BuiltinScalarUDF for PgTableIsVisible {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
@@ -86,6 +93,7 @@ impl BuiltinScalarUDF for PgTableIsVisible {
 
 #[derive(Clone)]
 pub struct PgEncodingToChar;
+
 impl ConstBuiltinFunction for PgEncodingToChar {
     const NAME: &'static str = "pg_encoding_to_char";
     const DESCRIPTION: &'static str = "Postgres `pg_encoding_to_char` function";
@@ -125,12 +133,15 @@ impl BuiltinScalarUDF for PgEncodingToChar {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
 }
+
 #[derive(Clone)]
 pub struct HasSchemaPrivilege;
+
 impl ConstBuiltinFunction for HasSchemaPrivilege {
     const NAME: &'static str = "has_schema_privilege";
     const DESCRIPTION: &'static str = "Returns true if user have privilege for schema";
@@ -146,6 +157,7 @@ impl ConstBuiltinFunction for HasSchemaPrivilege {
         ))
     }
 }
+
 impl BuiltinScalarUDF for HasSchemaPrivilege {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         let udf = ScalarUDF {
@@ -161,12 +173,15 @@ impl BuiltinScalarUDF for HasSchemaPrivilege {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
 }
+
 #[derive(Clone)]
 pub struct HasDatabasePrivilege;
+
 impl ConstBuiltinFunction for HasDatabasePrivilege {
     const NAME: &'static str = "has_database_privilege";
     const DESCRIPTION: &'static str = "Returns true if user have privilege for database";
@@ -182,6 +197,7 @@ impl ConstBuiltinFunction for HasDatabasePrivilege {
         ))
     }
 }
+
 impl BuiltinScalarUDF for HasDatabasePrivilege {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         let udf = ScalarUDF {
@@ -197,6 +213,7 @@ impl BuiltinScalarUDF for HasDatabasePrivilege {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
@@ -219,6 +236,7 @@ impl ConstBuiltinFunction for HasTablePrivilege {
         ))
     }
 }
+
 impl BuiltinScalarUDF for HasTablePrivilege {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         let udf = ScalarUDF {
@@ -234,6 +252,7 @@ impl BuiltinScalarUDF for HasTablePrivilege {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
@@ -241,6 +260,7 @@ impl BuiltinScalarUDF for HasTablePrivilege {
 
 #[derive(Clone)]
 pub struct CurrentSchemas;
+
 impl ConstBuiltinFunction for CurrentSchemas {
     const NAME: &'static str = "current_schemas";
     const DESCRIPTION: &'static str = "Returns current schemas";
@@ -256,6 +276,7 @@ impl ConstBuiltinFunction for CurrentSchemas {
         ))
     }
 }
+
 impl BuiltinScalarUDF for CurrentSchemas {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         // There's no good way to handle the `include_implicit` argument,
@@ -273,12 +294,15 @@ impl BuiltinScalarUDF for CurrentSchemas {
         )
         .alias("current_schemas")
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
 }
+
 #[derive(Clone)]
 pub struct CurrentUser;
+
 impl ConstBuiltinFunction for CurrentUser {
     const NAME: &'static str = "current_user";
     const DESCRIPTION: &'static str = "Returns current user";
@@ -299,6 +323,7 @@ impl BuiltinScalarUDF for CurrentUser {
 
 #[derive(Clone)]
 pub struct CurrentRole;
+
 impl ConstBuiltinFunction for CurrentRole {
     const NAME: &'static str = "current_role";
     const DESCRIPTION: &'static str = "Returns current role";
@@ -311,10 +336,12 @@ impl ConstBuiltinFunction for CurrentRole {
         ))
     }
 }
+
 impl BuiltinScalarUDF for CurrentRole {
     fn as_expr(&self, _: Vec<Expr>) -> Expr {
         session_var("current_role")
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
@@ -322,6 +349,7 @@ impl BuiltinScalarUDF for CurrentRole {
 
 #[derive(Clone)]
 pub struct CurrentSchema;
+
 impl ConstBuiltinFunction for CurrentSchema {
     const NAME: &'static str = "current_schema";
     const DESCRIPTION: &'static str = "Returns current schema";
@@ -334,16 +362,20 @@ impl ConstBuiltinFunction for CurrentSchema {
         ))
     }
 }
+
 impl BuiltinScalarUDF for CurrentSchema {
     fn as_expr(&self, _: Vec<Expr>) -> Expr {
         session_var("current_schema")
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
 }
+
 #[derive(Clone)]
 pub struct CurrentDatabase;
+
 impl ConstBuiltinFunction for CurrentDatabase {
     const NAME: &'static str = "current_database";
     const DESCRIPTION: &'static str = "Returns current database";
@@ -356,13 +388,16 @@ impl ConstBuiltinFunction for CurrentDatabase {
         ))
     }
 }
+
 impl BuiltinScalarUDF for CurrentDatabase {
     fn as_expr(&self, _: Vec<Expr>) -> Expr {
         session_var("current_database")
     }
 }
+
 #[derive(Clone)]
 pub struct CurrentCatalog;
+
 impl ConstBuiltinFunction for CurrentCatalog {
     const NAME: &'static str = "current_catalog";
     const DESCRIPTION: &'static str = "Returns current catalog";
@@ -375,10 +410,12 @@ impl ConstBuiltinFunction for CurrentCatalog {
         ))
     }
 }
+
 impl BuiltinScalarUDF for CurrentCatalog {
     fn as_expr(&self, _: Vec<Expr>) -> Expr {
         session_var("current_catalog")
     }
+
     fn namespace(&self) -> FunctionNamespace {
         PG_CATALOG_NAMESPACE
     }
@@ -399,18 +436,20 @@ impl ConstBuiltinFunction for User {
         ))
     }
 }
+
 impl BuiltinScalarUDF for User {
     fn as_expr(&self, args: Vec<Expr>) -> Expr {
         CurrentUser.as_expr(args).alias("user")
     }
+
     fn namespace(&self) -> FunctionNamespace {
         CurrentUser.namespace()
     }
 }
 
-#[derive(Clone)]
 // this one is a bit different from the others as it's also handled via datafusion
 // So all we need to do is add it to the pg_catalog namespace and map it to the df implementation
+#[derive(Clone)]
 pub struct PgArrayToString;
 
 impl ConstBuiltinFunction for PgArrayToString {
@@ -430,6 +469,7 @@ impl BuiltinScalarUDF for PgArrayToString {
             args,
         ))
     }
+
     fn namespace(&self) -> FunctionNamespace {
         FunctionNamespace::Required("pg_catalog")
     }

--- a/crates/sqlbuiltins/src/functions/scalars/postgres.rs
+++ b/crates/sqlbuiltins/src/functions/scalars/postgres.rs
@@ -6,7 +6,7 @@ use super::{df_scalars::array_to_string, *};
 
 const PG_CATALOG_NAMESPACE: FunctionNamespace = FunctionNamespace::Optional("pg_catalog");
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PgGetUserById;
 
 impl ConstBuiltinFunction for PgGetUserById {
@@ -45,7 +45,7 @@ impl BuiltinScalarUDF for PgGetUserById {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PgTableIsVisible;
 
 impl ConstBuiltinFunction for PgTableIsVisible {
@@ -91,7 +91,7 @@ impl BuiltinScalarUDF for PgTableIsVisible {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PgEncodingToChar;
 
 impl ConstBuiltinFunction for PgEncodingToChar {
@@ -139,7 +139,7 @@ impl BuiltinScalarUDF for PgEncodingToChar {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct HasSchemaPrivilege;
 
 impl ConstBuiltinFunction for HasSchemaPrivilege {
@@ -179,7 +179,7 @@ impl BuiltinScalarUDF for HasSchemaPrivilege {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct HasDatabasePrivilege;
 
 impl ConstBuiltinFunction for HasDatabasePrivilege {
@@ -219,7 +219,7 @@ impl BuiltinScalarUDF for HasDatabasePrivilege {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct HasTablePrivilege;
 impl ConstBuiltinFunction for HasTablePrivilege {
     const NAME: &'static str = "has_table_privilege";
@@ -258,7 +258,7 @@ impl BuiltinScalarUDF for HasTablePrivilege {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentSchemas;
 
 impl ConstBuiltinFunction for CurrentSchemas {
@@ -300,7 +300,7 @@ impl BuiltinScalarUDF for CurrentSchemas {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentUser;
 
 impl ConstBuiltinFunction for CurrentUser {
@@ -321,7 +321,7 @@ impl BuiltinScalarUDF for CurrentUser {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentRole;
 
 impl ConstBuiltinFunction for CurrentRole {
@@ -347,7 +347,7 @@ impl BuiltinScalarUDF for CurrentRole {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentSchema;
 
 impl ConstBuiltinFunction for CurrentSchema {
@@ -373,7 +373,7 @@ impl BuiltinScalarUDF for CurrentSchema {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentDatabase;
 
 impl ConstBuiltinFunction for CurrentDatabase {
@@ -395,7 +395,7 @@ impl BuiltinScalarUDF for CurrentDatabase {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurrentCatalog;
 
 impl ConstBuiltinFunction for CurrentCatalog {
@@ -421,7 +421,7 @@ impl BuiltinScalarUDF for CurrentCatalog {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct User;
 
 impl ConstBuiltinFunction for User {
@@ -447,9 +447,10 @@ impl BuiltinScalarUDF for User {
     }
 }
 
-// this one is a bit different from the others as it's also handled via datafusion
-// So all we need to do is add it to the pg_catalog namespace and map it to the df implementation
-#[derive(Clone)]
+// This one is a bit different from the others as it's also handled via
+// datafusion. So all we need to do is add it to the pg_catalog namespace and
+// map it to the df implementation
+#[derive(Clone, Copy, Debug)]
 pub struct PgArrayToString;
 
 impl ConstBuiltinFunction for PgArrayToString {

--- a/crates/sqlbuiltins/src/functions/table/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/table/object_store.rs
@@ -45,6 +45,8 @@ impl OptionReader for ParquetOptionsReader {
 pub const READ_PARQUET: ObjScanTableFunc<ParquetOptionsReader> = ObjScanTableFunc {
     name: "read_parquet",
     aliases: &["parquet_scan"],
+    description: "Returns a table by scanning the given Parquet file(s).",
+    example: "SELECT * FROM read_parquet('./my_data.parquet')",
     phantom: PhantomData,
 };
 
@@ -76,6 +78,8 @@ impl OptionReader for CsvOptionReader {
 pub const READ_CSV: ObjScanTableFunc<CsvOptionReader> = ObjScanTableFunc {
     name: "read_csv",
     aliases: &["csv_scan"],
+    description: "Returns a table by scanning the given CSV file(s).",
+    example: "SELECT * FROM read_csv('./my_data.csv')",
     phantom: PhantomData,
 };
 
@@ -93,6 +97,8 @@ impl OptionReader for JsonOptionsReader {
 pub const READ_JSON: ObjScanTableFunc<JsonOptionsReader> = ObjScanTableFunc {
     name: "read_ndjson",
     aliases: &["ndjson_scan"],
+    description: "Returns a table by scanning the given JSON file(s).",
+    example: "SELECT * FROM read_ndjson('./my_data.json')",
     phantom: PhantomData,
 };
 
@@ -140,6 +146,9 @@ pub struct ObjScanTableFunc<Opts> {
     /// Additional aliases for this function.
     aliases: &'static [&'static str],
 
+    description: &'static str,
+    example: &'static str,
+
     phantom: PhantomData<Opts>,
 }
 
@@ -157,13 +166,11 @@ impl<Opts: OptionReader> BuiltinFunction for ObjScanTableFunc<Opts> {
     }
 
     fn sql_example(&self) -> Option<&str> {
-        // TODO: Sean will add this back.
-        None
+        Some(self.example)
     }
 
     fn description(&self) -> Option<&str> {
-        // TODO: Sean will add this back.
-        None
+        Some(self.description)
     }
 
     fn signature(&self) -> Option<Signature> {

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -97,6 +97,9 @@ pub enum DispatchError {
     SshKey(#[from] datasources::common::ssh::key::SshKeyError),
     #[error(transparent)]
     ExtensionError(#[from] datafusion_ext::errors::ExtensionError),
+
+    #[error("{0}")]
+    String(String),
 }
 
 impl DispatchError {
@@ -252,20 +255,23 @@ impl<'a> Dispatcher<'a> {
         Ok(Arc::new(ViewTable::try_new(plan, None)?))
     }
 
-    pub async fn dispatch_function(
+    pub async fn dispatch_table_function(
         &self,
         func: &FunctionEntry,
         args: Vec<FuncParamValue>,
         opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
-        let resolve_func = if func.meta.builtin {
-            FUNCTION_REGISTRY.get_table_func(&func.meta.name)
-        } else {
-            // We only have builtin functions right now.
-            None
+        let func = match FUNCTION_REGISTRY.get_table_func(&func.meta.name) {
+            Some(func) => func,
+            None => {
+                return Err(DispatchError::String(format!(
+                    "'{}' cannot be used in the FROM clause of a query.",
+                    func.meta.name
+                )))
+            }
         };
-        let prov = resolve_func
-            .unwrap()
+
+        let prov = func
             .create_provider(
                 &DefaultTableContextProvider::new(self.catalog, self.df_ctx),
                 args,

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -81,7 +81,7 @@ impl<'a> PartialContextProvider<'a> {
         Ok(RuntimeAwareTableProvider::new(
             RuntimePreference::Local,
             self.new_dispatcher()
-                .dispatch_function(func, args, opts)
+                .dispatch_table_function(func, args, opts)
                 .await?,
         ))
     }

--- a/testdata/sqllogictests/catalog/functions.slt
+++ b/testdata/sqllogictests/catalog/functions.slt
@@ -42,7 +42,7 @@ where function_name = 'sum';
 sum   aggregate   Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64   t   sum(a)   Returns the sum of a column
 
 # Assert an arbitrary glaredb table function exists.
-# TODO: These are formatting incorrectly. Will fix after I merge in my csv options pr.
+# TODO: Why are there two? No clue.
 query TTTTTT
 select
     function_name,
@@ -54,4 +54,5 @@ select
 from glare_catalog.functions
 where function_name = 'read_parquet';
 ----
-read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet_scan('./my_data.read_parquet')   Returns a table by scanning the given read_parquet file(s).
+read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet('./my_data.parquet')   Returns a table by scanning the given Parquet file(s).
+read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet('./my_data.parquet')   Returns a table by scanning the given Parquet file(s).

--- a/testdata/sqllogictests/catalog/functions.slt
+++ b/testdata/sqllogictests/catalog/functions.slt
@@ -28,31 +28,30 @@ where function_name = 'repeat';
 repeat   scalar   (empty)   t   repeat('hello', 2)   Repeat a string a specified number of times
 
 # Assert an arbitrary datafusion aggregate function exists.
-# TODO: Currently messed up. Aggregates aren't inserted into the hashmap properly causing the example and description to be null.
-# query TTTTTT
-# select
-#     function_name,
-#     function_type,
-#     parameters,
-#     builtin,
-#     example,
-#     description
-# from glare_catalog.functions
-# where function_name = 'sum';
-# ----
-# sum   aggregate   Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64   t   sum(a)   Returns the sum of a column
+query TTTTTT
+select
+    function_name,
+    function_type,
+    parameters,
+    builtin,
+    example,
+    description
+from glare_catalog.functions
+where function_name = 'sum';
+----
+sum   aggregate   Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64   t   sum(a)   Returns the sum of a column
 
 # Assert an arbitrary glaredb table function exists.
 # TODO: These are formatting incorrectly. Will fix after I merge in my csv options pr.
-# query TTTTTT
-# select
-#     function_name,
-#     function_type,
-#     parameters,
-#     builtin,
-#     example,
-#     description
-# from glare_catalog.functions
-# where function_name = 'read_parquet';
-# ----
-# read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet_scan('./my_data.read_parquet')   Returns a table by scanning the given read_parquet file(s).
+query TTTTTT
+select
+    function_name,
+    function_type,
+    parameters,
+    builtin,
+    example,
+    description
+from glare_catalog.functions
+where function_name = 'read_parquet';
+----
+read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet_scan('./my_data.read_parquet')   Returns a table by scanning the given read_parquet file(s).

--- a/testdata/sqllogictests/functions/arrow_cast.slt
+++ b/testdata/sqllogictests/functions/arrow_cast.slt
@@ -5,6 +5,8 @@ select arrow_cast(1, 'Utf8');
 ----
 1
 
-# Should not be able to use it as a table element.
+# Should not be able to use it as a table factor.
+#
+# Previously we were panicking here.
 statement error 'arrow_cast' cannot be used in the FROM clause of a query
 select * from arrow_cast(1, 'Utf8');

--- a/testdata/sqllogictests/functions/arrow_cast.slt
+++ b/testdata/sqllogictests/functions/arrow_cast.slt
@@ -1,0 +1,10 @@
+# Tests for 'arrow_cast'.
+
+query T
+select arrow_cast(1, 'Utf8');
+----
+1
+
+# Should not be able to use it as a table element.
+statement error 'arrow_cast' cannot be used in the FROM clause of a query
+select * from arrow_cast(1, 'Utf8');


### PR DESCRIPTION
- Adds back in examples/descriptions for some of the read_* functions
- Adds some tests asserting that we're actually getting entries in the functions table.
- Fixes panic when using non-table function as a table factor.