### PR TITLE
chore: Add alias map for functions

### DIFF
--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1408,30 +1408,28 @@ mod tests {
 
     #[test]
     fn builtin_catalog_no_function_name_duplicates() {
-        // TODO: Fix this
-
         // Ensures each function is a unique (schema, name) pair.
 
-        // let catalog = BuiltinCatalog::new().unwrap();
-        // let names: Vec<(u32, &String)> = catalog
-        //     .entries
-        //     .values()
-        //     .filter_map(|ent| match ent {
-        //         CatalogEntry::Function(ent) => Some((ent.meta.parent, &ent.meta.name)),
-        //         _ => None,
-        //     })
-        //     .collect();
+        let catalog = BuiltinCatalog::new().unwrap();
+        let names: Vec<(u32, &String)> = catalog
+            .entries
+            .values()
+            .filter_map(|ent| match ent {
+                CatalogEntry::Function(ent) => Some((ent.meta.parent, &ent.meta.name)),
+                _ => None,
+            })
+            .collect();
 
-        // let mut deduped: HashSet<_> = names.clone().into_iter().collect();
-        // let diff: Vec<_> = names
-        //     .into_iter()
-        //     .filter(|name_and_parent| {
-        //         let was_present = deduped.remove(name_and_parent);
-        //         !was_present // We saw this value before, indicates a duplicated name.
-        //     })
-        //     .collect();
+        let mut deduped: HashSet<_> = names.clone().into_iter().collect();
+        let diff: Vec<_> = names
+            .into_iter()
+            .filter(|name_and_parent| {
+                let was_present = deduped.remove(name_and_parent);
+                !was_present // We saw this value before, indicates a duplicated name.
+            })
+            .collect();
 
-        // assert_eq!(Vec::<(u32, &String)>::new(), diff);
+        assert_eq!(Vec::<(u32, &String)>::new(), diff);
     }
 
     #[tokio::test]

--- a/crates/sqlbuiltins/src/functions/alias_map.rs
+++ b/crates/sqlbuiltins/src/functions/alias_map.rs
@@ -1,0 +1,181 @@
+use std::borrow::Borrow;
+use std::collections::{hash_map, HashMap};
+use std::hash::Hash;
+use std::iter::FromIterator;
+
+/// A map allowing for multiple keys to point to the same value.
+#[derive(Debug, Clone)]
+pub struct AliasMap<K, V> {
+    /// All values in the map.
+    values: Vec<V>,
+
+    /// Points keys to the index of the value.
+    keys_to_index: HashMap<K, usize>,
+}
+
+impl<K, V> AliasMap<K, V> {
+    pub fn new() -> Self {
+        Self {
+            values: Vec::new(),
+            keys_to_index: HashMap::new(),
+        }
+    }
+
+    /// Return an iterator over all entries in the map.
+    ///
+    /// All aliases will be iterated over, and will result in a value being
+    /// returned multiple times if it has multiple aliases.
+    pub fn iter(&self) -> AliasMapIter<K, V> {
+        AliasMapIter {
+            values: &self.values,
+            key_iter: self.keys_to_index.iter(),
+        }
+    }
+
+    /// Return an iterator over all values.
+    ///
+    /// Values will only be returned once, even if there's multiple keys
+    /// pointing to it.
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.values.iter()
+    }
+}
+
+impl<K: Hash + Eq, V> AliasMap<K, V> {
+    /// Get a value by key from the map.
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let idx = self.keys_to_index.get(key)?;
+        self.values.get(*idx)
+    }
+
+    /// Insert a value with all provided keys pointing to that value.
+    pub fn insert_aliases(&mut self, keys: impl IntoIterator<Item = K>, value: V) {
+        let idx = self.values.len();
+        self.values.push(value);
+
+        for key in keys {
+            self.keys_to_index.insert(key, idx);
+        }
+    }
+}
+
+impl<'a, K: Hash + Eq, V> FromIterator<(Vec<K>, V)> for AliasMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = (Vec<K>, V)>>(iter: T) -> Self {
+        let mut m = AliasMap::new();
+        for (keys, value) in iter {
+            m.insert_aliases(keys, value);
+        }
+        m
+    }
+}
+
+impl<K, V> Default for AliasMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Iterator over an alias map.
+///
+/// A value may be returned more than once if is has more than one alias.
+#[derive(Debug)]
+pub struct AliasMapIter<'a, K, V> {
+    values: &'a Vec<V>,
+    key_iter: hash_map::Iter<'a, K, usize>,
+}
+
+impl<'a, K, V> Iterator for AliasMapIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (k, idx) = self.key_iter.next()?;
+        let v = self.values.get(*idx).expect("value should exist");
+        Some((k, v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.key_iter.size_hint()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert() {
+        let mut m = AliasMap::new();
+        m.insert_aliases(vec!["hello", "world"], 1);
+        m.insert_aliases(vec!["mario", "luigi"], 2);
+        m.insert_aliases(vec!["peach"], 3);
+
+        assert_eq!(Some(&1), m.get(&"hello"));
+        assert_eq!(Some(&1), m.get(&"world"));
+        assert_eq!(Some(&2), m.get(&"mario"));
+        assert_eq!(Some(&2), m.get(&"luigi"));
+        assert_eq!(Some(&3), m.get(&"peach"));
+        assert_eq!(None, m.get(&"bowser"));
+    }
+
+    #[test]
+    fn from_iter() {
+        let m = [
+            (vec!["hello", "world"], 1),
+            (vec!["mario", "luigi"], 2),
+            (vec!["peach"], 3),
+        ]
+        .into_iter()
+        .collect::<AliasMap<_, _>>();
+
+        assert_eq!(Some(&1), m.get(&"hello"));
+        assert_eq!(Some(&1), m.get(&"world"));
+        assert_eq!(Some(&2), m.get(&"mario"));
+        assert_eq!(Some(&2), m.get(&"luigi"));
+        assert_eq!(Some(&3), m.get(&"peach"));
+        assert_eq!(None, m.get(&"bowser"));
+    }
+
+    #[test]
+    fn aliases_iter() {
+        let m = [
+            (vec!["hello", "world"], 1),
+            (vec!["mario", "luigi"], 2),
+            (vec!["peach"], 3),
+        ]
+        .into_iter()
+        .collect::<AliasMap<_, _>>();
+
+        let mut collected = m.iter().collect::<Vec<_>>();
+        collected.sort(); // Lexicographical
+
+        let expected = vec![
+            (&"hello", &1),
+            (&"luigi", &2),
+            (&"mario", &2),
+            (&"peach", &3),
+            (&"world", &1),
+        ];
+
+        assert_eq!(expected, collected);
+    }
+
+    #[test]
+    fn values_iter() {
+        let m = [
+            (vec!["hello", "world"], 1),
+            (vec!["mario", "luigi"], 2),
+            (vec!["peach"], 3),
+        ]
+        .into_iter()
+        .collect::<AliasMap<_, _>>();
+
+        let mut collected = m.values().collect::<Vec<_>>();
+        collected.sort();
+
+        assert_eq!(vec![&1, &2, &3], collected);
+    }
+}

--- a/crates/sqlbuiltins/src/functions/alias_map.rs
+++ b/crates/sqlbuiltins/src/functions/alias_map.rs
@@ -25,6 +25,7 @@ impl<K, V> AliasMap<K, V> {
     ///
     /// All aliases will be iterated over, and will result in a value being
     /// returned multiple times if it has multiple aliases.
+    #[allow(dead_code)]
     pub fn iter(&self) -> AliasMapIter<K, V> {
         AliasMapIter {
             values: &self.values,
@@ -63,7 +64,7 @@ impl<K: Hash + Eq, V> AliasMap<K, V> {
     }
 }
 
-impl<'a, K: Hash + Eq, V> FromIterator<(Vec<K>, V)> for AliasMap<K, V> {
+impl<K: Hash + Eq, V> FromIterator<(Vec<K>, V)> for AliasMap<K, V> {
     fn from_iter<T: IntoIterator<Item = (Vec<K>, V)>>(iter: T) -> Self {
         let mut m = AliasMap::new();
         for (keys, value) in iter {

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -127,14 +127,6 @@ impl BuiltinTableFuncs {
 
         BuiltinTableFuncs { funcs }
     }
-
-    pub fn find_function(&self, name: &str) -> Option<&Arc<dyn TableFunc>> {
-        self.funcs.get(name)
-    }
-
-    pub fn iter_funcs(&self) -> impl Iterator<Item = &Arc<dyn TableFunc>> {
-        self.funcs.values()
-    }
 }
 
 impl Default for BuiltinTableFuncs {
@@ -257,11 +249,12 @@ mod tests {
             "parquet_scan",
         ];
 
-        let funcs = BuiltinTableFuncs::new();
+        let builtin = BuiltinTableFuncs::new();
 
         for name in names_and_aliases {
-            funcs
-                .find_function(name)
+            builtin
+                .funcs
+                .get(name)
                 .expect(&format!("function with name '{name}' should exist"));
         }
     }

--- a/testdata/sqllogictests/catalog/functions.slt
+++ b/testdata/sqllogictests/catalog/functions.slt
@@ -42,7 +42,6 @@ where function_name = 'sum';
 sum   aggregate   Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64   t   sum(a)   Returns the sum of a column
 
 # Assert an arbitrary glaredb table function exists.
-# TODO: Why are there two? No clue.
 query TTTTTT
 select
     function_name,
@@ -55,4 +54,35 @@ from glare_catalog.functions
 where function_name = 'read_parquet';
 ----
 read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet('./my_data.parquet')   Returns a table by scanning the given Parquet file(s).
-read_parquet   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet('./my_data.parquet')   Returns a table by scanning the given Parquet file(s).
+
+# Assert an arbitrary glaredb table function exists (using an alias).
+query TTTTTT
+select
+    function_name,
+    function_type,
+    parameters,
+    builtin,
+    example,
+    description
+from glare_catalog.functions
+where function_name = 'parquet_scan';
+----
+parquet_scan   table   Utf8/List<Utf8>   t   SELECT * FROM read_parquet('./my_data.parquet')   Returns a table by scanning the given Parquet file(s).
+
+# 'array_to_string' is a tricky one since we're aliasing 'array_to_string' to
+# 'pg_catalog.array_to_string'. A more correct implementation would return two
+# entries, one for the default schema, and one for pg_catalog.
+#
+# See https://github.com/GlareDB/glaredb/issues/2371
+query TTTTTT
+select
+    function_name,
+    function_type,
+    parameters,
+    builtin,
+    example,
+    description
+from glare_catalog.functions
+where function_name = 'array_to_string';
+----
+array_to_string   scalar   (empty)   t   array_to_string([1, 2, 3], ',')   Convert an array to a string with a separator


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/2368

Futzing around with function aliases. This replaces `HashMap` with `AliasMap` to allow multiple keys to point to the same object. Also adds some tests.

I needed to add a workaround for 'array_to_string' for one of the iterators, see https://github.com/GlareDB/glaredb/issues/2371.