### PR TITLE
fix: add signature for read_excel

### DIFF
--- a/crates/sqlbuiltins/src/functions/table/excel.rs
+++ b/crates/sqlbuiltins/src/functions/table/excel.rs
@@ -10,7 +10,6 @@ use ioutil::resolve_path;
 use protogen::metastore::types::catalog::{FunctionType, RuntimePreference};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::field;
 
 use super::{table_location_and_opts, TableFunc};
 use crate::functions::ConstBuiltinFunction;


### PR DESCRIPTION
closes #2373 

```sql
> select function_name, parameters from glare_catalog.functions WHERE function_name = 'read_excel';
┌───────────────┬─────────────────────────────────────────────────────────────────────────┐
│ function_name │ parameters                                                              │
│ ──            │ ──                                                                      │
│ Utf8          │ List<Utf8>                                                              │
╞═══════════════╪═════════════════════════════════════════════════════════════════════════╡
│ read_excel    │ [Utf8, Utf8, sheet_name: Utf8, infer_rows: UInt64, has_header: Boolean] │
└───────────────┴─────────────────────────────────────────────────────────────────────────┘
```
