### PR TITLE
add commit-sha to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d17f4d6e4dc36d1a02fbedc2753a096848e7c1b0772f7654eab8e2c927dd53"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3214,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glaredb"
 version = "0.8.0"
 dependencies = [
@@ -3212,6 +3234,7 @@ dependencies = [
  "arrow_util",
  "assert_cmd",
  "atty",
+ "built",
  "clap",
  "colored",
  "console-subscriber",
@@ -4096,6 +4119,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4165,18 @@ dependencies = [
  "clap",
  "termcolor",
  "threadpool",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f526fdd09d99e19742883e43de41e1aa9e36db0c7ab7f935165d611c5cccc66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -8340,6 +8387,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -44,3 +44,6 @@ predicates = "3.0.4"
 assert_cmd = "2.0.12"
 tokio-postgres = "0.7.8"
 tempfile = { workspace = true }
+
+[build-dependencies]
+built = { version = "0.7.1", features = ["git2"] }

--- a/crates/glaredb/build.rs
+++ b/crates/glaredb/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/crates/glaredb/build.rs
+++ b/crates/glaredb/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  built::write_built_file().expect("Failed to acquire build-time information");
+    built::write_built_file().expect("Failed to acquire build-time information");
 }

--- a/crates/glaredb/src/commands.rs
+++ b/crates/glaredb/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::args::server::ServerArgs;
 use crate::args::{LocalArgs, MetastoreArgs, PgProxyArgs, RpcProxyArgs};
+use crate::built_info;
 use crate::local::LocalSession;
 use crate::metastore::Metastore;
 use crate::proxy::{PgProxy, RpcProxy};
@@ -117,7 +118,12 @@ impl RunCommand for LocalArgs {
             };
 
             if query.is_none() {
-                println!("GlareDB (v{})", env!("CARGO_PKG_VERSION"));
+                // git should always be present, but just in case, we'll fall back to the version
+                if let Some(git_version) = built_info::GIT_VERSION {
+                    println!("GlareDB ({git_version})",);
+                } else {
+                    println!("GlareDB (v{})", env!("CARGO_PKG_VERSION"));
+                }
             }
 
             let local = LocalSession::connect(self.opts).await?;

--- a/crates/glaredb/src/lib.rs
+++ b/crates/glaredb/src/lib.rs
@@ -8,8 +8,7 @@ pub mod proxy;
 
 pub mod server;
 
-
 pub mod built_info {
-  // The file has been placed there by the build script.
-  include!(concat!(env!("OUT_DIR"), "/built.rs"));
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }

--- a/crates/glaredb/src/lib.rs
+++ b/crates/glaredb/src/lib.rs
@@ -7,3 +7,9 @@ mod prompt;
 pub mod proxy;
 
 pub mod server;
+
+
+pub mod built_info {
+  // The file has been placed there by the build script.
+  include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2280

now it'll show a nice git version instead of just the pkg version. 
```sh
> ./glaredb
GlareDB (v0.8.0-11-g167702f)
```

you can read more about how the {git_version} is generated [here](https://docs.rs/built/0.7.1/built/#git2). 

TLDR; it uses the head (if its a tag, it uses just that, otherwise it uses a concatonation of the last tag + the commit)


## note for development purposes. 

It does cache this in your `target` dir, so if it's not showing the current commit, it's likely that this generated file is cached. 