### PR TITLE
fix: Error instead of panic when converting pg timestamps to arrow

### DIFF
--- a/crates/datasources/src/postgres/errors.rs
+++ b/crates/datasources/src/postgres/errors.rs
@@ -27,6 +27,9 @@ pub enum PostgresError {
     #[error("Unsupported tunnel '{0}' for Postgres")]
     UnsupportedTunnel(String),
 
+    #[error("Overflow converting '{0}' to {1}")]
+    DataOverflow(String, datafusion::arrow::datatypes::DataType),
+
     #[error(transparent)]
     Arrow(#[from] datafusion::arrow::error::ArrowError),
 


### PR DESCRIPTION
```
> select * from pg.public.comments;
Error: External error: External error: Overflow converting '0001-01-01 00:00:00 UTC' to Timestamp(Nanosecond, Some("UTC"))
```

Fixes: #2412