### PR TITLE
chore: Remove openssh from slt crate cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7187,7 +7187,6 @@ dependencies = [
  "logutil",
  "metastore",
  "object_store",
- "openssh",
  "pgrepr",
  "pgsrv",
  "regex",

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -73,7 +73,6 @@ bson = "2.7.0"
 scylla = { version = "0.11.1" }
 glob = "0.3.1"
 
-
 # SSH tunnels
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 openssh = "0.10.2"

--- a/crates/slt/Cargo.toml
+++ b/crates/slt/Cargo.toml
@@ -26,7 +26,6 @@ sqlexec = { path = "../sqlexec" }
 telemetry = { path = "../telemetry" }
 tokio-postgres = "0.7.8"
 glob = "0.3.1"
-openssh = "0.10.2"
 regex = "1.8.1"
 sqllogictest = "0.19.1"
 uuid = { version = "1.6", features = ["v4", "fast-rng", "macro-diagnostics"] }


### PR DESCRIPTION
Was causing build failures on windows. Didn't seem to be used anyways.

Note that we conditionally use openssh in the datasources crate to get around this:

```
[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
openssh = "0.10.2"
```