### PR TITLE
feat: Notices on transactions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,7 +369,16 @@ and asserts that we receive the appropriate backend messages. These tests ensure
 postgres protocol compatability as well as allowing us to assert the contents of
 error and notice messages.
 
-Test cases can be found in `./testdata/pgprototest`.
+Test cases can be found in `./testdata/pgprototest` and
+`./testdata/pgprototest_glaredb`.
+
+The `pgprototest` directory is for test cases to assert that GlareDB matches
+Postgres exactly, and the expected output should be generated from an actual
+Postgres instance.
+
+The `pgprototest_glaredb` directory contains test cases that do match Postgres
+output exactly either because of an incomplete feature, or differing behavior.
+The expected output for these tests need to be hand-crafted.
 
 Tests can be ran with the `pgprototest` command:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "paste",
+ "pgrepr",
  "protogen",
  "rand",
  "regex",

--- a/crates/datafusion_ext/Cargo.toml
+++ b/crates/datafusion_ext/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { workspace = true }
 thiserror.workspace = true
 decimal = { path = "../decimal" }
 protogen = { path = "../protogen" }
+pgrepr = { path = "../pgrepr" }
 futures = { workspace = true }
 parking_lot = "0.12.1"
 bson = "2.7.0"

--- a/crates/datafusion_ext/src/vars.rs
+++ b/crates/datafusion_ext/src/vars.rs
@@ -8,6 +8,7 @@ use constants::*;
 use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion::config::{ConfigExtension, ExtensionOptions};
 use datafusion::scalar::ScalarValue;
+use pgrepr::notice::NoticeSeverity;
 use utils::*;
 
 use datafusion::variable::{VarProvider, VarType};
@@ -79,6 +80,7 @@ impl SessionVars {
      datestyle: String,
      transaction_isolation: String,
      search_path: Vec<String>,
+     client_min_messages: NoticeSeverity,
      enable_debug_datasources: bool,
      force_catalog_refresh: bool,
      glaredb_version: String,

--- a/crates/datafusion_ext/src/vars/constants.rs
+++ b/crates/datafusion_ext/src/vars/constants.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use pgrepr::notice::NoticeSeverity;
+
 // TODO: Decide proper postgres version to spoof/support
 pub(super) const SERVER_VERSION: ServerVar<str> = ServerVar {
     name: "server_version",
@@ -73,6 +75,14 @@ pub(super) static SEARCH_PATH: Lazy<ServerVar<[String]>> = Lazy::new(|| ServerVa
     user_configurable: true,
     description: "Search path for schemas",
 });
+
+pub(super) const CLIENT_MIN_MESSAGES: ServerVar<NoticeSeverity> = ServerVar {
+    name: "client_min_messages",
+    value: &NoticeSeverity::Notice,
+    group: "postgres",
+    user_configurable: true,
+    description: "Controls which messages are sent to the client, defaults NOTICE",
+};
 
 pub(super) static GLAREDB_VERSION_OWNED: Lazy<String> =
     Lazy::new(|| format!("v{}", env!("CARGO_PKG_VERSION")));

--- a/crates/datafusion_ext/src/vars/inner.rs
+++ b/crates/datafusion_ext/src/vars/inner.rs
@@ -4,6 +4,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::config::ConfigEntry;
 use datafusion::error::Result;
 use datafusion::variable::VarType;
+use pgrepr::notice::NoticeSeverity;
 use std::borrow::Borrow;
 
 use super::constants::*;
@@ -32,6 +33,7 @@ pub struct SessionVarsInner {
     pub datestyle: SessionVar<str>,
     pub transaction_isolation: SessionVar<str>,
     pub search_path: SessionVar<[String]>,
+    pub client_min_messages: SessionVar<NoticeSeverity>,
     pub enable_debug_datasources: SessionVar<bool>,
     pub force_catalog_refresh: SessionVar<bool>,
     pub glaredb_version: SessionVar<str>,
@@ -82,6 +84,8 @@ impl SessionVarsInner {
             Ok(&self.transaction_isolation)
         } else if name.eq_ignore_ascii_case(SEARCH_PATH.name) {
             Ok(&self.search_path)
+        } else if name.eq_ignore_ascii_case(CLIENT_MIN_MESSAGES.name) {
+            Ok(&self.client_min_messages)
         } else if name.eq_ignore_ascii_case(ENABLE_DEBUG_DATASOURCES.name) {
             Ok(&self.enable_debug_datasources)
         } else if name.eq_ignore_ascii_case(FORCE_CATALOG_REFRESH.name) {
@@ -139,6 +143,8 @@ impl SessionVarsInner {
             self.transaction_isolation.set_from_str(val, setter)
         } else if name.eq_ignore_ascii_case(SEARCH_PATH.name) {
             self.search_path.set_from_str(val, setter)
+        } else if name.eq_ignore_ascii_case(CLIENT_MIN_MESSAGES.name) {
+            self.client_min_messages.set_from_str(val, setter)
         } else if name.eq_ignore_ascii_case(ENABLE_DEBUG_DATASOURCES.name) {
             self.enable_debug_datasources.set_from_str(val, setter)
         } else if name.eq_ignore_ascii_case(FORCE_CATALOG_REFRESH.name) {
@@ -214,6 +220,7 @@ impl Default for SessionVarsInner {
             datestyle: SessionVar::new(&DATESTYLE),
             transaction_isolation: SessionVar::new(&TRANSACTION_ISOLATION),
             search_path: SessionVar::new(&SEARCH_PATH),
+            client_min_messages: SessionVar::new(&CLIENT_MIN_MESSAGES),
             enable_debug_datasources: SessionVar::new(&ENABLE_DEBUG_DATASOURCES),
             force_catalog_refresh: SessionVar::new(&FORCE_CATALOG_REFRESH),
             glaredb_version: SessionVar::new(&GLAREDB_VERSION),

--- a/crates/datafusion_ext/src/vars/value.rs
+++ b/crates/datafusion_ext/src/vars/value.rs
@@ -1,4 +1,7 @@
+use pgrepr::notice::NoticeSeverity;
+
 use super::*;
+
 pub trait Value: ToOwned + std::fmt::Debug {
     fn try_parse(s: &str) -> Option<Self::Owned>;
     fn format(&self) -> String;
@@ -109,5 +112,15 @@ impl Value for Dialect {
             Dialect::Sql => "sql".to_string(),
             Dialect::Prql => "prql".to_string(),
         }
+    }
+}
+
+impl Value for NoticeSeverity {
+    fn try_parse(s: &str) -> Option<NoticeSeverity> {
+        NoticeSeverity::from_str(s).ok()
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
     }
 }

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -169,7 +169,7 @@ impl LocalSession {
                         // non-interactive fashion which and having notice
                         // messages interspersed with the output would be
                         // annoying.
-                        for notice in self.sess.drain_notices() {
+                        for notice in self.sess.take_notices() {
                             eprintln!(
                                 "{}: {}",
                                 match notice.severity {

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -170,7 +170,7 @@ impl LocalSession {
                         // messages interspersed with the output would be
                         // annoying.
                         for notice in self.sess.drain_notices() {
-                            println!(
+                            eprintln!(
                                 "{}: {}",
                                 match notice.severity {
                                     s @ (NoticeSeverity::Warning | NoticeSeverity::Error) =>

--- a/crates/pgprototest/src/main.rs
+++ b/crates/pgprototest/src/main.rs
@@ -9,8 +9,10 @@ mod proto;
 #[clap(about = "Data driven postgres protocol testing", long_about = None)]
 struct Cli {
     /// The directory containing the test files.
+    ///
+    /// Maybe specified multiple times to run tests from multiple directories.
     #[clap(long)]
-    dir: String,
+    dir: Vec<String>,
     /// Address of the postgres compatible server.
     #[clap(long)]
     addr: String,

--- a/crates/pgprototest/src/messages.rs
+++ b/crates/pgprototest/src/messages.rs
@@ -83,9 +83,15 @@ impl TryFrom<(char, Message)> for SerializedMessage {
                         .collect()?,
                 })?,
             ),
-            Message::NoticeResponse(_msg) => {
-                ("NoticeResponse", serde_json::to_string(&NoticeResponse {})?)
-            }
+            Message::NoticeResponse(msg) => (
+                "NoticeResponse",
+                serde_json::to_string(&ErrorResponse {
+                    fields: msg
+                        .fields()
+                        .map(|field| Ok(field.value().to_string()))
+                        .collect()?,
+                })?,
+            ),
             _ => return Err(anyhow!("unhandle message, type identifier: {}", id)),
         };
         Ok(SerializedMessage {
@@ -177,5 +183,5 @@ pub struct ErrorResponse {
 
 #[derive(Serialize)]
 pub struct NoticeResponse {
-    // TODO: Fill me in. Currently we don't assert notices.
+    pub fields: Vec<String>,
 }

--- a/crates/pgrepr/src/error.rs
+++ b/crates/pgrepr/src/error.rs
@@ -32,6 +32,9 @@ pub enum PgReprError {
 
     #[error("Internal error: {0}")]
     InternalError(String),
+
+    #[error("{0}")]
+    String(String),
 }
 
 pub type Result<T, E = PgReprError> = std::result::Result<T, E>;

--- a/crates/pgrepr/src/lib.rs
+++ b/crates/pgrepr/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod format;
+pub mod notice;
 pub mod oid;
 pub mod reader;
 pub mod scalar;

--- a/crates/pgrepr/src/notice.rs
+++ b/crates/pgrepr/src/notice.rs
@@ -1,0 +1,143 @@
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::PgReprError;
+
+/// 'SQLSTATE' error codes.
+///
+/// See a complete list here: https://www.postgresql.org/docs/current/errcodes-appendix.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlState {
+    // Class 00 — Successful Completion
+    Successful,
+
+    // Class 01 — Warning
+    Warning,
+
+    // Class 0A — Feature Not Supported
+    FeatureNotSupported,
+
+    // Class 42 — Syntax Error or Access Rule Violation
+    SyntaxError,
+
+    // Class XX — Internal Error
+    InternalError,
+}
+
+impl SqlState {
+    pub fn as_code_str(&self) -> &'static str {
+        match self {
+            SqlState::Successful => "00000",
+            SqlState::Warning => "01000",
+            SqlState::FeatureNotSupported => "0A000",
+            SqlState::SyntaxError => "42601",
+            SqlState::InternalError => "XX000",
+        }
+    }
+}
+
+/// Indicates severity of notice.
+///
+/// These must remain in order to allow us to easily test if a message should be
+/// sent back to the client based on a configured session var. For example, if
+/// someone sets that var to WARNING, we can just check severity >= WARNING.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NoticeSeverity {
+    Debug5,
+    Debug4,
+    Debug3,
+    Debug2,
+    Debug1,
+    Log,
+    Notice,
+    Warning,
+    Error,
+    Info,
+}
+
+impl NoticeSeverity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            NoticeSeverity::Debug5 => "DEBUG5",
+            NoticeSeverity::Debug4 => "DEBUG4",
+            NoticeSeverity::Debug3 => "DEBUG3",
+            NoticeSeverity::Debug2 => "DEBUG2",
+            NoticeSeverity::Debug1 => "DEBUG1",
+            NoticeSeverity::Log => "LOG",
+            NoticeSeverity::Notice => "NOTICE",
+            NoticeSeverity::Warning => "WARNING",
+            NoticeSeverity::Error => "ERROR",
+            NoticeSeverity::Info => "INFO",
+        }
+    }
+}
+
+impl FromStr for NoticeSeverity {
+    type Err = PgReprError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "DEBUG5" => Self::Debug5,
+            "DEBUG4" => Self::Debug4,
+            "DEBUG3" => Self::Debug3,
+            "DEBUG2" => Self::Debug2,
+            "DEBUG1" => Self::Debug1,
+            "LOG" => Self::Log,
+            "NOTICE" => Self::Notice,
+            "WARNING" => Self::Warning,
+            "ERROR" => Self::Error,
+            "INFO" => Self::Info,
+            other => {
+                return Err(PgReprError::String(format!(
+                    "unknown notice severity: {other}"
+                )))
+            }
+        })
+    }
+}
+
+impl fmt::Display for NoticeSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// A notice that should be displayed to the user.
+#[derive(Debug, Clone)]
+pub struct Notice {
+    pub severity: NoticeSeverity,
+    pub code: SqlState,
+    pub message: String,
+}
+
+impl Notice {
+    pub fn info(msg: impl Into<String>) -> Notice {
+        Notice {
+            severity: NoticeSeverity::Info,
+            code: SqlState::Successful,
+            message: msg.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notice_severity_to_from_string() {
+        fn assert_to_from(sev: NoticeSeverity) {
+            assert_eq!(sev, NoticeSeverity::from_str(sev.as_str()).unwrap())
+        }
+
+        assert_to_from(NoticeSeverity::Debug5);
+        assert_to_from(NoticeSeverity::Debug4);
+        assert_to_from(NoticeSeverity::Debug3);
+        assert_to_from(NoticeSeverity::Debug2);
+        assert_to_from(NoticeSeverity::Debug1);
+        assert_to_from(NoticeSeverity::Log);
+        assert_to_from(NoticeSeverity::Notice);
+        assert_to_from(NoticeSeverity::Warning);
+        assert_to_from(NoticeSeverity::Error);
+        assert_to_from(NoticeSeverity::Info);
+    }
+}

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -430,7 +430,7 @@ where
         // query. The pg protocol does not presribe a specific flow for notice
         // messages, and so frontends should be capable of handling notices at
         // any point in the message flow.
-        for notice in self.session.drain_notices() {
+        for notice in self.session.take_notices() {
             self.conn
                 .send(BackendMessage::NoticeResponse(notice))
                 .await?;

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -432,7 +432,7 @@ where
         // any point in the message flow.
         for notice in self.session.drain_notices() {
             self.conn
-                .send(BackendMessage::NoticeResponse(notice.into()))
+                .send(BackendMessage::NoticeResponse(notice))
                 .await?;
         }
 

--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -3,7 +3,7 @@ use crate::codec::server::{FramedConn, PgCodec};
 use crate::errors::{PgSrvError, Result};
 use crate::messages::{
     BackendMessage, DescribeObjectType, ErrorResponse, FieldDescriptionBuilder, FrontendMessage,
-    SqlState, StartupMessage, TransactionStatus,
+    StartupMessage, TransactionStatus,
 };
 use crate::proxy::{
     ProxyKey, GLAREDB_DATABASE_ID_KEY, GLAREDB_GCS_STORAGE_BUCKET_KEY,
@@ -784,8 +784,14 @@ where
             let batch = match result {
                 Ok(r) => r,
                 Err(e) => {
-                    conn.send(ErrorResponse::error(SqlState::InternalError, e.to_string()).into())
-                        .await?;
+                    conn.send(
+                        ErrorResponse::error(
+                            pgrepr::notice::SqlState::InternalError,
+                            e.to_string(),
+                        )
+                        .into(),
+                    )
+                    .await?;
                     return Ok(None);
                 }
             };
@@ -814,7 +820,7 @@ fn parse_sql(
         Dialect::Prql => parser::parse_prql(sql),
         Dialect::Sql => parser::parse_sql(sql),
     }
-    .map_err(|e| ErrorResponse::error(SqlState::SyntaxError, e.to_string()))
+    .map_err(|e| ErrorResponse::error(pgrepr::notice::SqlState::SyntaxError, e.to_string()))
 }
 
 /// Decodes inputs for a prepared query into the appropriate scalar values.

--- a/crates/pgsrv/src/messages.rs
+++ b/crates/pgsrv/src/messages.rs
@@ -214,6 +214,16 @@ impl SqlState {
     }
 }
 
+impl From<sqlexec::context::local::NoticeCondition> for SqlState {
+    fn from(value: sqlexec::context::local::NoticeCondition) -> Self {
+        match value {
+            sqlexec::context::local::NoticeCondition::FeatureNotSupported => {
+                SqlState::FeatureNotSupported
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ErrorResponse {
     pub severity: ErrorSeverity,
@@ -289,6 +299,15 @@ impl NoticeSeverity {
     }
 }
 
+impl From<sqlexec::context::local::NoticeSeverity> for NoticeSeverity {
+    fn from(value: sqlexec::context::local::NoticeSeverity) -> Self {
+        match value {
+            sqlexec::context::local::NoticeSeverity::Warning => Self::Warning,
+            sqlexec::context::local::NoticeSeverity::Info => Self::Info,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct NoticeResponse {
     pub severity: NoticeSeverity,
@@ -302,6 +321,16 @@ impl NoticeResponse {
             severity: NoticeSeverity::Info,
             code: SqlState::Successful,
             message: msg.into(),
+        }
+    }
+}
+
+impl From<sqlexec::context::local::Notice> for NoticeResponse {
+    fn from(value: sqlexec::context::local::Notice) -> Self {
+        NoticeResponse {
+            severity: value.severity.into(),
+            code: value.condition.into(),
+            message: value.message,
         }
     }
 }

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -323,6 +323,10 @@ impl LocalSessionContext {
         self.portals.remove(name);
     }
 
+    pub(crate) fn push_notice(&mut self, notice: Notice) {
+        self.notices.push(notice)
+    }
+
     /// Drain all notices from the session.
     pub(crate) fn drain_notices(&mut self) -> impl Iterator<Item = Notice> + '_ {
         self.notices.drain(..)

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -328,11 +328,11 @@ impl LocalSessionContext {
         self.notices.push(notice)
     }
 
-    /// Drain all notices from the session.
+    /// Take all notices from the session.
     ///
     /// This will take into account the 'client_min_messages' session var to
     /// filter out notices that shouldn't be sent to the client.
-    pub(crate) fn drain_notices(&mut self) -> Vec<Notice> {
+    pub(crate) fn take_notices(&mut self) -> Vec<Notice> {
         // Behind an if since this is called every query, and session vars is behind  a lock :)
         // Let's get rid of the lock.
         if !self.notices.is_empty() {

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -543,8 +543,8 @@ impl Session {
         self.ctx.remove_portal(name);
     }
 
-    pub fn drain_notices(&mut self) -> Vec<Notice> {
-        self.ctx.drain_notices()
+    pub fn take_notices(&mut self) -> Vec<Notice> {
+        self.ctx.take_notices()
     }
 
     /// Bind the parameters of a prepared statement to the given values.

--- a/scripts/protocol-test.sh
+++ b/scripts/protocol-test.sh
@@ -28,6 +28,7 @@ sleep 5
 ret=0
 cargo run --bin pgprototest -- \
     --dir ./testdata/pgprototest \
+    --dir ./testdata/pgprototest_glaredb \
     --addr localhost:6543 \
     --user glaredb \
     --password dummy \

--- a/testdata/pgprototest_glaredb/transactions.pt
+++ b/testdata/pgprototest_glaredb/transactions.pt
@@ -1,0 +1,43 @@
+# Check that we send back the proper notice about transaction support.
+#
+# These are hand-crafted as they don't align with what postgres would returns.
+#
+# Notable differences:
+# - Status is always 'I' for us (should be 'T' when inside a transaction)
+# - We return a notice (at the warning level) on transaction commands
+
+# Basic begin
+
+send
+Query {"query": "begin"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+NoticeResponse {"fields":["WARNING","WARNING","0A000","GlareDB does not support proper transactional semantics. Do not rely on transactions for correctness. Transactions are stubbed out to enable compatability with existing Postgres tools."]}
+ReadyForQuery {"status":"I"}
+
+
+# Check that we can disable the warning message with 'client_min_messages'
+
+send
+Query {"query": "set client_min_messages to ERROR"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "begin"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"I"}

--- a/testdata/pgprototest_glaredb/transactions.pt
+++ b/testdata/pgprototest_glaredb/transactions.pt
@@ -41,3 +41,34 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"I"}
+
+
+# Sanity checks to ensure we send back correct tags for COMMIT and ROLLBACK.
+
+send
+Query {"query": "begin; select 1; commit"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+RowDescription {"fields":[{"name":"Int64(1)"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "begin; select 1; rollback"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+RowDescription {"fields":[{"name":"Int64(1)"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}

--- a/testdata/sqllogictests/functions/postgres.slt
+++ b/testdata/sqllogictests/functions/postgres.slt
@@ -10,7 +10,6 @@
 statement ok
 set search_path = public;
 
-
 query T
 select current_schema();
 ----
@@ -18,7 +17,6 @@ public
 
 skipif glaredb_flight
 query T
-
 select current_user;
 ----
 glaredb

--- a/testdata/sqllogictests/transactions.slt
+++ b/testdata/sqllogictests/transactions.slt
@@ -1,0 +1,16 @@
+# Transaction statement support
+#
+# While we don't support proper semantics yet, we should be allowing these
+# statements through.
+
+statement ok
+begin;
+
+statement ok
+commit;
+
+statement ok
+begin;
+
+statement ok
+rollback;

--- a/testdata/sqllogictests/transactions.slt
+++ b/testdata/sqllogictests/transactions.slt
@@ -3,14 +3,18 @@
 # While we don't support proper semantics yet, we should be allowing these
 # statements through.
 
+skipif glaredb_flight
 statement ok
 begin;
 
+skipif glaredb_flight
 statement ok
 commit;
 
+skipif glaredb_flight
 statement ok
 begin;
 
+skipif glaredb_flight
 statement ok
 rollback;

--- a/testdata/sqllogictests/vars.slt
+++ b/testdata/sqllogictests/vars.slt
@@ -94,3 +94,18 @@ set timezone = 'UTC';
 
 statement ok
 set TIMEZONE = 'UTC';
+
+# client_min_messages
+
+query T
+show client_min_messages;
+----
+NOTICE
+
+statement ok
+set client_min_messages to WARNING;
+
+query T
+show client_min_messages;
+----
+WARNING


### PR DESCRIPTION
Emit notices on transaction commands warning about our incomplete transaction support.

psql:
```
sean@Seans-Air glaredb % psql postgres://localhost:6543
psql (15.4, server 15.1)
Type "help" for help.

sean=> begin;
WARNING:  GlareDB does not support proper transactional semantics. Do not rely on transactions for correctness. Transactions are stubbed out to enable compatability with existing Postgres tools.
BEGIN
sean=> 
```

CLI (colorful):
<img width="871" alt="Screenshot 2024-01-18 at 2 26 37 PM" src="https://github.com/GlareDB/glaredb/assets/4040560/a6e590b4-8fbb-456f-a9a5-34aea29b1143">


Some pg protocol tests added to assert the notices.