### PR TITLE
chore: Remove timeouts from CLI tests that don't need them

### DIFF
--- a/crates/glaredb/tests/iss_2309.rs
+++ b/crates/glaredb/tests/iss_2309.rs
@@ -1,17 +1,12 @@
 mod setup;
 
-use setup::DEFAULT_TIMEOUT;
-
 use crate::setup::make_cli;
 
 #[test]
 fn test_special_characters() {
     let mut cmd = make_cli();
 
-    let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
-        .args(&["-q", r#"select ';'"#])
-        .assert();
+    let assert = cmd.args(&["-q", r#"select ';'"#]).assert();
     assert.success().stdout(predicates::str::contains(
         r#"
 ┌───────────┐
@@ -29,10 +24,7 @@ fn test_special_characters() {
 fn test_special_characters_2() {
     let mut cmd = make_cli();
 
-    let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
-        .args(&["-q", r#"select ";""#])
-        .assert();
+    let assert = cmd.args(&["-q", r#"select ";""#]).assert();
     assert.failure().stderr(predicates::str::contains(
         "Schema error: No field named \";\".",
     ));

--- a/crates/glaredb/tests/local_args_test.rs
+++ b/crates/glaredb/tests/local_args_test.rs
@@ -1,7 +1,6 @@
 mod setup;
 
 use predicates::boolean::PredicateBooleanExt;
-use setup::DEFAULT_TIMEOUT;
 
 use crate::setup::make_cli;
 
@@ -11,10 +10,7 @@ use crate::setup::make_cli;
 fn test_query_or_file() {
     let mut cmd = make_cli();
 
-    let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
-        .args(&["-q", "SELECT * FROM foo", "foo.sql"])
-        .assert();
+    let assert = cmd.args(&["-q", "SELECT * FROM foo", "foo.sql"]).assert();
     assert.failure().stderr(predicates::str::contains(
         "the argument '--query <QUERY>' cannot be used with '[FILE]'",
     ));
@@ -26,10 +22,7 @@ fn test_query_or_file() {
 fn test_storage_config_require_location() {
     let mut cmd = make_cli();
 
-    let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
-        .args(&["-o", "foo=bar"])
-        .assert();
+    let assert = cmd.args(&["-o", "foo=bar"]).assert();
     assert.failure().stderr(
         predicates::str::contains("error: the following required arguments were not provided:")
             .and(predicates::str::contains("--location <LOCATION>")),
@@ -42,10 +35,7 @@ fn test_storage_config_require_location() {
 fn test_parse_storage_options_not_ok() {
     let mut cmd = make_cli();
 
-    let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
-        .args(&["-l", "foo", "-o", "foobar"])
-        .assert();
+    let assert = cmd.args(&["-l", "foo", "-o", "foobar"]).assert();
     assert.failure().stderr(predicates::str::contains(
         "Expected key-value pair delimited by an equals sign, got",
     ));
@@ -60,7 +50,6 @@ fn test_parse_storage_options_ok() {
     let temp_dir = temp_dir.path().to_str().unwrap();
 
     let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
         .args(&["-l", temp_dir, "-o", "foo=bar", "-q", "select 1"])
         .assert();
     assert.success();
@@ -76,7 +65,6 @@ fn test_data_dir() {
     let path = data_dir.to_str().unwrap();
 
     let assert = cmd
-        .timeout(DEFAULT_TIMEOUT)
         .args(&["-f", path, "-q", "create table test as select 1"])
         .assert();
     assert.success();

--- a/crates/glaredb/tests/log_file_test.rs
+++ b/crates/glaredb/tests/log_file_test.rs
@@ -7,7 +7,7 @@ use std::{
 
 use tempfile::NamedTempFile;
 
-use crate::setup::{make_cli, DEFAULT_TIMEOUT};
+use crate::setup::make_cli;
 
 #[test]
 fn test_log_file() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,8 +17,7 @@ fn test_log_file() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = file_path.canonicalize().unwrap();
     let file_path = file_path.as_os_str().to_str().unwrap();
 
-    cmd.timeout(DEFAULT_TIMEOUT)
-        .arg("--log-file")
+    cmd.arg("--log-file")
         .arg(file_path)
         .arg("-q")
         .arg("select 1;")
@@ -49,8 +48,7 @@ fn test_log_file_verbosity_level() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = file_path.canonicalize().unwrap();
     let file_path = file_path.as_os_str().to_str().unwrap();
 
-    cmd.timeout(DEFAULT_TIMEOUT)
-        .arg("-v")
+    cmd.arg("-v")
         .arg("--log-file")
         .arg(file_path)
         .arg("-q")

--- a/crates/glaredb/tests/output_mode_test.rs
+++ b/crates/glaredb/tests/output_mode_test.rs
@@ -1,15 +1,11 @@
 mod setup;
 
-use crate::setup::{make_cli, DEFAULT_TIMEOUT};
+use crate::setup::make_cli;
 
 fn test_output_mode(mode: &str, expected: &str) {
     let mut cmd = make_cli();
 
-    cmd.timeout(DEFAULT_TIMEOUT)
-        .arg("--mode")
-        .arg(mode)
-        .arg("-q")
-        .arg("select 1;");
+    cmd.arg("--mode").arg(mode).arg("-q").arg("select 1;");
     let output = cmd.output().expect("Failed to run command");
     let stdout_str = String::from_utf8(output.stdout).expect("Failed to read stdout");
 
@@ -22,7 +18,7 @@ fn test_output_mode(mode: &str, expected: &str) {
 fn test_output_mode_default() {
     let mut cmd = make_cli();
 
-    cmd.timeout(DEFAULT_TIMEOUT).arg("-q").arg("select 1;");
+    cmd.arg("-q").arg("select 1;");
     let output = cmd.output().expect("Failed to run command");
     let stdout_str = String::from_utf8(output.stdout).expect("Failed to read stdout");
     let expected = r#"

--- a/crates/glaredb/tests/server_args_test.rs
+++ b/crates/glaredb/tests/server_args_test.rs
@@ -34,8 +34,8 @@ fn test_server_bind_addr_conflict() {
         .arg("--disable-postgres-api")
         .assert();
 
-    assert.failure(/* We expect a timeout here */).stderr(contains(
-      "the argument '--bind <PORT>' cannot be used with '--disable-postgres-api'",
+    assert.failure().stderr(contains(
+        "the argument '--bind <PORT>' cannot be used with '--disable-postgres-api'",
     ));
 }
 
@@ -52,11 +52,10 @@ fn test_user_requires_password() {
         .args(&["-u", "test"])
         .assert();
 
-    assert.failure(/* We expect a timeout here */).stderr(contains(
-      "the following required arguments were not provided:",
-    ).and(contains(
-      "--password <PASSWORD>",
-    )));
+    assert.failure().stderr(
+        contains("the following required arguments were not provided:")
+            .and(contains("--password <PASSWORD>")),
+    );
 }
 
 #[test]

--- a/crates/glaredb/tests/setup.rs
+++ b/crates/glaredb/tests/setup.rs
@@ -7,4 +7,4 @@ pub fn make_cli() -> Command {
 }
 
 #[allow(dead_code)] // Used in the tests. IDK why clippy is complaining about it.
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(2500);
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(5_000);


### PR DESCRIPTION
Partially addresses https://github.com/GlareDB/glaredb/issues/2467