### PR TITLE
chore: Split out term width function into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,6 @@ name = "arrow_util"
 version = "0.8.1"
 dependencies = [
  "comfy-table",
- "crossterm",
  "datafusion",
  "once_cell",
  "textwrap",
@@ -1614,7 +1613,6 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
- "crossterm",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "unicode-width",
@@ -3254,6 +3252,7 @@ dependencies = [
  "sqlexec",
  "telemetry",
  "tempfile",
+ "terminal_util",
  "tokio",
  "tokio-postgres",
  "tonic",
@@ -3736,6 +3735,7 @@ dependencies = [
  "serde_json",
  "sqlexec",
  "telemetry",
+ "terminal_util",
  "thiserror",
  "url",
 ]
@@ -5804,6 +5804,7 @@ dependencies = [
  "pyo3",
  "sqlexec",
  "telemetry",
+ "terminal_util",
  "thiserror",
  "tokio",
  "url",
@@ -7705,6 +7706,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_util"
+version = "0.8.1"
+dependencies = [
+ "crossterm",
 ]
 
 [[package]]

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -19,6 +19,7 @@ pgrepr = { path = "../../crates/pgrepr" }
 datafusion_ext = { path = "../../crates/datafusion_ext" }
 arrow_util = { path = "../../crates/arrow_util" }
 glaredb = { path = "../../crates/glaredb" }
+terminal_util = { path = "../../crates/terminal_util" }
 futures = { workspace = true }
 datafusion.workspace = true
 thiserror = { workspace = true }

--- a/bindings/nodejs/src/execution_result.rs
+++ b/bindings/nodejs/src/execution_result.rs
@@ -63,9 +63,13 @@ async fn print_batch(result: &mut ExecutionResult) -> napi::Result<()> {
                 .collect::<Result<Vec<RecordBatch>, _>>()
                 .map_err(JsGlareDbError::from)?;
 
-            let disp =
-                pretty::pretty_format_batches(&schema, &batches, Some(pretty::term_width()), None)
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            let disp = pretty::pretty_format_batches(
+                &schema,
+                &batches,
+                Some(terminal_util::term_width()),
+                None,
+            )
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
             println!("{}", disp);
             Ok(())

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,6 +25,7 @@ pgrepr = { path = "../../crates/pgrepr" }
 datafusion_ext = { path = "../../crates/datafusion_ext" }
 arrow_util = { path = "../../crates/arrow_util" }
 glaredb = { path = "../../crates/glaredb" }
+terminal_util = { path = "../../crates/terminal_util" }
 futures = { workspace = true }
 uuid = "1.7.0"
 async-trait = { workspace = true }

--- a/bindings/python/src/execution_result.rs
+++ b/bindings/python/src/execution_result.rs
@@ -129,9 +129,13 @@ fn print_batch(result: &mut ExecutionResult, py: Python<'_>) -> PyResult<()> {
                     .collect::<Result<Vec<RecordBatch>, _>>()
             })?;
 
-            let disp =
-                pretty::pretty_format_batches(&schema, &batches, Some(pretty::term_width()), None)
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            let disp = pretty::pretty_format_batches(
+                &schema,
+                &batches,
+                Some(terminal_util::term_width()),
+                None,
+            )
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
             pyprint(disp, py)
         }

--- a/crates/README.md
+++ b/crates/README.md
@@ -8,7 +8,7 @@ Leaf crates are crates that live on the end of the dependency tree. Leaf crates
 should never import an integration crate, and should strive to import a minimal
 amount of other leaf crates.
 
-- `arrow_util`: Utilities around detecting terminal features
+- `arrow_util`: Extra utilies for arrow
   - WASM: not yet (datafusion, tokio, parquet)
 - `terminal_util`: Utilities around detecting terminal features
   - WASM: no

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,19 @@
+# Crate structure
+
+Overview of crates.
+
+## Leaf crates
+
+Leaf crates are crates that live on the end of the dependency tree. Leaf crates
+should never import an integration crate, and should strive to import a minimal
+amount of other leaf crates.
+
+- `arrow_util`: Utilities around detecting terminal features
+  - WASM: not yet (datafusion, tokio, parquet)
+- `terminal_util`: Utilities around detecting terminal features
+  - WASM: no
+
+## Integration crates
+
+Integration crates are crates that import a bunch of leaf crates. Integration
+crates should strive to import a minimal amount of other integration crates.

--- a/crates/arrow_util/Cargo.toml
+++ b/crates/arrow_util/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 
 [dependencies]
 datafusion = { workspace = true }
-comfy-table = "7.1.0"
+comfy-table = { version = "7.1.0", default-features = false }
 once_cell = "1.19.0"
 textwrap = { version = "0.16.0", default-features = false, features = ["unicode-width"] }
-crossterm = "0.27.0"

--- a/crates/arrow_util/src/pretty.rs
+++ b/crates/arrow_util/src/pretty.rs
@@ -32,19 +32,6 @@ pub fn pretty_format_batches(
     PrettyTable::try_new(schema, batches, max_width, max_rows)
 }
 
-/// Get the terminal's width in characters.
-///
-/// This can be used as the `max_width` argument when pretty formatting to
-/// ensure the formatted table doesn't exceed the width of the terminal.
-///
-/// If the width can't be determine or is unreasonable (0), then a default width
-/// of 80 is used.
-pub fn term_width() -> usize {
-    crossterm::terminal::size()
-        .map(|(width, _)| if width == 0 { 80 } else { width as usize })
-        .unwrap_or(80)
-}
-
 #[derive(Debug)]
 struct PrettyTable {
     table: Table,

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -34,6 +34,7 @@ sqlexec = { path = "../sqlexec" }
 telemetry = { path = "../telemetry" }
 sqlbuiltins = { path = "../sqlbuiltins" }
 arrow_util = { path = "../arrow_util" }
+terminal_util = { path = "../terminal_util" }
 
 num_cpus = "1.16.0"
 colored = "2.1.0"

--- a/crates/glaredb/src/local.rs
+++ b/crates/glaredb/src/local.rs
@@ -328,7 +328,7 @@ async fn print_stream(
         OutputMode::Table => {
             // If width not explicitly set by the user, try to get the width of ther
             // terminal.
-            let width = max_width.unwrap_or(pretty::term_width());
+            let width = max_width.unwrap_or(terminal_util::term_width());
             let disp = pretty::pretty_format_batches(&schema, &batches, Some(width), max_rows)?;
             println!("{disp}");
         }

--- a/crates/terminal_util/Cargo.toml
+++ b/crates/terminal_util/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "terminal_util"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+crossterm = "0.27.0"

--- a/crates/terminal_util/src/lib.rs
+++ b/crates/terminal_util/src/lib.rs
@@ -1,0 +1,12 @@
+/// Get the terminal's width in characters.
+//
+/// This can be used as the `max_width` argument when pretty formatting to
+/// ensure the formatted table doesn't exceed the width of the terminal.
+///
+/// If the width can't be determined or is unreasonable (0), then a default
+/// width of 80 is used.
+pub fn term_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(width, _)| if width == 0 { 80 } else { width as usize })
+        .unwrap_or(80)
+}


### PR DESCRIPTION
Ensures crossterm isn't a dependency of arrow_util. Also disables default features for `comfy_term` since we're not using their terminal detection stuff (which uses crossterm).