### PR TITLE
fix: rename "pg_table" to "pg_tables"

### DIFF
--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -613,9 +613,9 @@ FROM glare_catalog.databases;
 ",
 });
 
-pub static PG_TABLE: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
+pub static PG_TABLES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     schema: POSTGRES_SCHEMA,
-    name: "pg_table",
+    name: "pg_tables",
     sql: "
 SELECT
     schema_name as schemaname,
@@ -642,6 +642,7 @@ SELECT
 FROM glare_catalog.views;
 ",
 });
+
 pub static PG_TYPE: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     schema: POSTGRES_SCHEMA,
     name: "pg_type",
@@ -687,6 +688,8 @@ FROM (VALUES (NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL)) WHERE false",
 });
+
+
 impl BuiltinView {
     pub fn builtins() -> Vec<&'static BuiltinView> {
         vec![
@@ -700,7 +703,7 @@ impl BuiltinView {
             &PG_NAMESPACE,
             &PG_DESCRIPTION,
             &PG_DATABASE,
-            &PG_TABLE,
+            &PG_TABLES,
             &PG_VIEWS,
             &PG_TYPE,
         ]

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -689,7 +689,6 @@ FROM (VALUES (NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL)) WHERE false",
 });
 
-
 impl BuiltinView {
     pub fn builtins() -> Vec<&'static BuiltinView> {
         vec![

--- a/testdata/sqllogictests/pg_catalog.slt
+++ b/testdata/sqllogictests/pg_catalog.slt
@@ -21,7 +21,7 @@ statement ok
 select * from pg_catalog.pg_database;
 
 statement ok
-select * from pg_catalog.pg_table;
+select * from pg_catalog.pg_tables; 
 
 statement ok
 select * from pg_catalog.pg_views;
@@ -48,7 +48,7 @@ statement ok
 select * from pg_database;
 
 statement ok
-select * from pg_table;
+select * from pg_tables;
 
 statement ok
 select * from pg_views;
@@ -117,3 +117,48 @@ AND c.relkind IN ('r', 'S', 'v', 'm', 'f', 'p')
 AND (c.relname) LIKE '%' 
 AND n.nspname = 'pg_catalog' 
 LIMIT 1000;
+
+
+# https://github.com/GlareDB/glaredb/issues/2475
+statement ok
+WITH table_privileges AS (
+  SELECT
+    NULL AS role,
+    t.schemaname AS schema,
+    t.tablename AS table,
+    pg_catalog.has_table_privilege(
+      current_user,
+      concat( '"', t.schemaname, '"', '.', '"', t.tablename, '"' ),
+      'SELECT'
+    ) AS select ,
+    pg_catalog.has_table_privilege(
+      current_user,
+      concat( '"', t.schemaname, '"', '.', '"', t.tablename, '"' ),
+      'UPDATE'
+    ) AS update ,
+    pg_catalog.has_table_privilege(
+      current_user,
+      concat( '"', t.schemaname, '"', '.', '"', t.tablename, '"' ),
+      'INSERT'
+    ) AS insert ,
+    pg_catalog.has_table_privilege(
+      current_user,
+      concat( '"', t.schemaname, '"', '.', '"', t.tablename, '"' ),
+      'DELETE'
+    ) AS delete 
+  FROM
+    pg_catalog.pg_tables AS t
+  WHERE
+    t.schemaname !~ '^pg_'
+    AND t.schemaname <> 'information_schema'
+    AND pg_catalog.has_schema_privilege(current_user, t.schemaname, 'USAGE')
+)
+SELECT
+  t.*
+FROM
+  table_privileges AS t
+WHERE
+  t.select
+  OR t.update
+  OR t.insert
+  OR t.delete


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2475

We were incorrectly calling the table `pg_table` when it is supposed to be `pg_tables`