### PR TITLE
fix: Execute clickhouse query in stream (during execution)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -526,13 +526,7 @@ jobs:
 
           just slt-bin ${{matrix.settings.path}}
           just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-
-          # Run flight SLTs for everything except clickhouse.
-          #
-          # <https://github.com/GlareDB/glaredb/issues/2389>
-          if [[ "${{ matrix.settings.name }}" != 'Clickhouse' ]]; then
-             just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-          fi
+          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
 
   service-integration-tests-snowflake:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'

--- a/crates/rpcsrv/src/flight/handler.rs
+++ b/crates/rpcsrv/src/flight/handler.rs
@@ -194,7 +194,7 @@ impl FlightSqlService for FlightSessionHandler {
                 let ctx = self.get_or_create_ctx(&req).await?;
                 let mut ctx = ctx.lock().await;
 
-                match ctx.execute_sql(sql, None).await {
+                match ctx.execute_sql(sql).await {
                     Ok(stream) => {
                         let schema = stream.schema();
 

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -782,15 +782,11 @@ impl Session {
 
     /// Execute a SQL query.
     /// if the query doesn't contain exactly one statement, an error is returned.
-    pub async fn execute_sql(
-        &mut self,
-        query: &str,
-        op_info: Option<OperationInfo>,
-    ) -> Result<SendableRecordBatchStream> {
+    pub async fn execute_sql(&mut self, query: &str) -> Result<SendableRecordBatchStream> {
         let plan = self.create_logical_plan(query).await?;
         let plan = plan.try_into_datafusion_plan()?;
         let plan = self
-            .create_physical_plan(plan, &op_info.unwrap_or_default())
+            .create_physical_plan(plan, &OperationInfo::new().with_query_text(query))
             .await?;
         let stream = self.execute_physical_plan(plan).await?;
 


### PR DESCRIPTION
TBH, I am not sure exactly what fixed this but during my investigation I realized, something in flight + clickhouse implementation messes up the stream and eats it up even before it's executed. This is "technically" correct and works!

Fixes: #2389