### PR TITLE
Revert "chore: enable ci for merge queue events"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  merge_queue:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Reverts GlareDB/glaredb#2495