### PR TITLE
chore: skip sqlserver+flight combination.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,7 @@ jobs:
             target/
             !target/**/glaredb
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - run: just build
-
       - uses: actions/cache/save@v4
         name: glaredb cache
         with:
@@ -77,6 +75,7 @@ jobs:
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
 
+
   lint:
     name: Lint (clippy)
     runs-on: ubuntu-latest-8-cores
@@ -108,6 +107,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just clippy
 
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest-8-cores
@@ -137,8 +137,8 @@ jobs:
             target/
             !target/**/glaredb
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - run: just unit-tests
+
 
   python-binding-tests:
     name: Python Binding Tests
@@ -171,6 +171,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just python build
       - run: just python test
+
 
   nodejs-bindings-tests:
     name: Node.js Binding Tests
@@ -206,6 +207,7 @@ jobs:
       - run: just js build-debug
       - run: just js test
 
+
   pg-protocol:
     name: PG Protocol Tests
     runs-on: ubuntu-latest
@@ -216,7 +218,7 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -225,40 +227,41 @@ jobs:
           PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
       - run: just slt-bin-debug 'pgproto/*'
 
+
   sql-logic-tests:
     name: SQL Logic Tests
     runs-on: ubuntu-latest
     needs: ["build"]
     strategy:
       matrix:
-        protocol: ["postgres", "flightsql", "rpc"]
+        protocol: 
+          - name: "postgres"
+            basic: just slt-bin --protocol=postgres 'sqllogictests/*'
+            debug: just slt-bin-debug --protocol=postgres 'sqllogictests/*'
+          - name: "flightsql"
+            basic: just slt-bin --protocol=flightsql 'sqllogictests/*'
+            debug: just slt-bin-debug --protocol=flightsql 'sqllogictests/*'
+          - name: "rpc"
+            basic: just rpc-tests
+            debug: just rpc-tests
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
-        run: |
-          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
-            just rpc-tests
-          else
-            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
-          fi
+        run: ${{matrix.protocol.debug}}
       - name: public sql logic tests
         if: ${{ env.ACTIONS_STEP_DEBUG != 'true' }}
-        run: |
-          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
-            just rpc-tests
-          else
-            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
-          fi
+        run: ${{matrix.protocol.basic}}
+
 
   process-integration-tests:
     name: Process Integration Tests (pytest)
@@ -291,6 +294,7 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/Cargo.lock') }}
       - run: just venv
       - run: just pytest
+
 
   service-integration-tests:
     name: Service Integration Tests (SLT)
@@ -401,6 +405,7 @@ jobs:
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/1 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/2 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
 
+
   minio-integration-tests:
     name: MinIO Integration Tests (SLT::MinIO)
     runs-on: ubuntu-latest
@@ -463,6 +468,7 @@ jobs:
               'sqllogictests/*' \
               --protocol=flightsql
 
+
   datasource-integration-tests:
     name: Datasource Integration (${{matrix.settings.name}})
     strategy:
@@ -495,7 +501,6 @@ jobs:
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
-
     runs-on: ubuntu-latest
     needs: ["build"]
     steps:
@@ -516,6 +521,7 @@ jobs:
           just slt-bin ${{matrix.settings.path}}
           just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
           just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+
 
   service-integration-tests-snowflake:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -465,19 +465,16 @@ jobs:
         settings:
           - name: Clickhouse
             path: "sqllogictests_clickhouse/*"
-            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               source ./scripts/ci-install-clickhouse.sh
               export CLICKHOUSE_CONN_STRING=$(./scripts/create-test-clickhouse-db.sh)
           - name: Cassandra
             path: "sqllogictests_cassandra/*"
-            runner: ubuntu-latest
             prepare: |
               export CASSANDRA_CONN_STRING=$(./scripts/create-test-cassandra-db.sh | tail -n 1)
           - name: Mysql
             path: "sqllogictests_mysql/*"
-            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export MYSQL_CONN_STRING=$(./scripts/create-test-mysql-db.sh)
@@ -485,18 +482,16 @@ jobs:
               export MYSQL_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 1p)
           - name: MongoDB
             path: "sqllogictests_mongodb/*"
-            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
           - name: Sqlserver
             path: "sqllogictests_sqlserver/*"
-            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
 
-    runs-on: ${{matrix.runner}}
+    runs-on: ubuntu-latest
     needs: ["build"]
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -570,8 +570,8 @@ jobs:
           ${{matrix.settings.prepare}}
 
           just slt-bin ${{matrix.settings.path}}
-          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-
           # for sqlserver, skip flightsql because the suite takes 4-5
           # minutes, and Sqlserver is the longest/last task to finish
-          if [ "${{matrix.settings.name}}" = "Sqlserver" ]; then; exit 0; fi
+          [ "${{matrix.settings.name}}" = "Sqlserver" ] && exit 0
+
+          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rustfmt.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: workspace cache
         with:
           path: |
@@ -98,7 +98,7 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: workspace cache
         with:
           path: |
@@ -130,7 +130,7 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: workspace cache
         with:
           path: |
@@ -197,7 +197,7 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: workspace cache
         with:
           path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,10 @@ jobs:
       - uses: actions/cache/save@v4
         name: build cache
         with:
-          path: target/
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ github.run_id }}
       - uses: actions/cache/save@v4
         name: glaredb cache
@@ -114,7 +117,10 @@ jobs:
       - uses: actions/cache/restore@v4
         name: build cache
         with:
-          path: target/
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ github.run_id }}
       - run: just clippy
 
@@ -144,7 +150,15 @@ jobs:
       - uses: actions/cache/restore@v4
         name: build cache
         with:
-          path: target/
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
+          key: ${{ github.run_id }}
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
+        with:
+          path: target/debug/glaredb
           key: ${{ github.run_id }}
       - run: just unit-tests
 
@@ -174,7 +188,10 @@ jobs:
       - uses: actions/cache/restore@v4
         name: build cache
         with:
-          path: target/
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ github.run_id }}
       - run: just python build
       - run: just python test
@@ -207,7 +224,10 @@ jobs:
       - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
-          path: target/
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ github.run_id }}
       - run: just js build-debug
       - run: just js test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_queue:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,12 +39,14 @@ jobs:
           path: |
             target/
             !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just build
+      - run: cargo build --bin pgprototest
       - uses: actions/cache/save@v4
         name: glaredb cache
         with:
-          path: target/debug/glaredb
+          path: target/
           key: ${{ github.run_id }}
 
 
@@ -65,12 +67,10 @@ jobs:
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rustfmt.toml') }}
       - uses: actions/cache/restore@v4
-        name: workspace cache
+        name: glaredb cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target/
+          key: ${{ github.run_id }}
       - run: rustup install nightly
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
@@ -99,12 +99,10 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: workspace cache
+        name: glaredb cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target/
+          key: ${{ github.run_id }}
       - run: just clippy
 
 
@@ -131,12 +129,10 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: workspace cache
+        name: glaredb cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target/
+          key: ${{ github.run_id }}
       - run: just unit-tests
 
 
@@ -162,13 +158,11 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: workspace cache
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target/
+          key: ${{ github.run_id }}
       - run: just python build
       - run: just python test
 
@@ -198,12 +192,10 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: workspace cache
+        name: glaredb cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target/
+          key: ${{ github.run_id }}
       - run: just js build-debug
       - run: just js test
 
@@ -221,10 +213,11 @@ jobs:
       - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
-          path: target/debug/glaredb
+          path: |
+            target/debug/glaredb
+            target/debug/pgprototest
           key: ${{ github.run_id }}
-      - run: |
-          PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
+      - run: ./scripts/protocol-test.sh
       - run: just slt-bin-debug 'pgproto/*'
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,12 +48,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
-      - uses: actions/cache/save@v4
-        name: build cache
-        with:
-          path: |
-            target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+
 
   fmt:
     name: Format (rustfmt +nightly)
@@ -65,12 +60,19 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: nightly toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rustfmt.toml') }}
+      - uses: actions/cache@v4
+        name: workspace cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup install nightly
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
@@ -97,6 +99,13 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: workspace cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just clippy
 
   unit-tests:
@@ -121,12 +130,14 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
+      - uses: actions/cache@v4
+        name: workspace cache
         with:
           path: |
             target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - run: just unit-tests
 
   python-binding-tests:
@@ -151,12 +162,13 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
+      - uses: actions/cache@v4
+        name: workspace cache
         with:
           path: |
             target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just python build
       - run: just python test
 
@@ -184,12 +196,13 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
+      - uses: actions/cache@v4
+        name: workspace cache
         with:
           path: |
             target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just js build-debug
       - run: just js test
 
@@ -203,18 +216,11 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: cargo cache
+      - uses: actions/cache/save@v4
+        name: glaredb cache
         with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
-        with:
-          path: |
-            target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
       - run: |
           PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
       - run: just slt-bin-debug 'pgproto/*'
@@ -232,12 +238,11 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: build cache
+      - uses: actions/cache/save@v4
+        name: glaredb cache
         with:
-          path: |
-            target/
-          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  merge_queue:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,12 +50,12 @@ jobs:
           path: target/
           key: ${{ github.run_id }}
       - uses: actions/cache/save@v4
-        name: build cache
+        name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
       - uses: actions/cache/save@v4
-        name: build cache
+        name: pgprototest cache
         with:
           path: target/debug/pgprototest
           key: ${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,21 @@ jobs:
       - run: just build
       - run: cargo build --bin pgprototest
       - uses: actions/cache/save@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: target/
           key: ${{ github.run_id }}
+      - uses: actions/cache/save@v4
+        name: build cache
+        with:
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+      - uses: actions/cache/save@v4
+        name: build cache
+        with:
+          path: target/debug/pgprototest
+          key: ${{ github.run_id }}
+
 
 
   fmt:
@@ -67,7 +78,7 @@ jobs:
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rustfmt.toml') }}
       - uses: actions/cache/restore@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: target/
           key: ${{ github.run_id }}
@@ -78,7 +89,8 @@ jobs:
 
   lint:
     name: Lint (clippy)
-    runs-on: ubuntu-latest-8-cores
+    # emperically runtimes are the same for big/small hosts:
+    runs-on: ubuntu-latest
     needs: ["fmt"]
     steps:
       - name: checkout
@@ -99,7 +111,7 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: target/
           key: ${{ github.run_id }}
@@ -108,7 +120,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: ["build"]
     steps:
       - name: checkout
@@ -129,7 +141,7 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: target/
           key: ${{ github.run_id }}
@@ -138,7 +150,7 @@ jobs:
 
   python-binding-tests:
     name: Python Binding Tests
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: ["build"]
     steps:
       - name: checkout
@@ -159,7 +171,7 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: target/
           key: ${{ github.run_id }}
@@ -213,9 +225,12 @@ jobs:
       - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
-          path: |
-            target/debug/glaredb
-            target/debug/pgprototest
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+      - uses: actions/cache/restore@v4
+        name: pgprototest cache
+        with:
+          path: target/debug/pgprototest
           key: ${{ github.run_id }}
       - run: ./scripts/protocol-test.sh
       - run: just slt-bin-debug 'pgproto/*'
@@ -293,7 +308,7 @@ jobs:
   service-integration-tests:
     name: Service Integration Tests (SLT)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: ["build"]
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,6 +155,14 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache/restore@v4
+        name: workspace cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just python build
       - run: just python test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -34,19 +35,25 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache@v4
-        name: build cache
+        name: workspace cache
         with:
           path: |
             target/
             !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - run: just build
+      - run: cargo build --bin pgprototest
+      - uses: actions/cache/save@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
-      - name: build
-        run: just build
+      - uses: actions/cache/save@v4
+        name: pgprototest cache
+        with:
+          path: target/debug/pgprototest
+          key: ${{ github.run_id }}
 
 
   fmt:
@@ -69,9 +76,11 @@ jobs:
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
 
+
   lint:
     name: Lint (clippy)
-    runs-on: ubuntu-latest-8-cores
+    # emperically runtimes are the same for big/small hosts:
+    runs-on: ubuntu-latest
     needs: ["fmt"]
     steps:
       - name: checkout
@@ -79,21 +88,20 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: just clippy
 
-      - name: clippy
-        run: just clippy
 
   unit-tests:
     name: Unit Tests
@@ -105,25 +113,29 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
+        with:
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+      - run: just unit-tests
 
-      - name: run tests
-        run: just unit-tests
 
   python-binding-tests:
     name: Python Binding Tests
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: ["build"]
     steps:
       - name: checkout
@@ -131,31 +143,29 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: build cache
+      - uses: actions/cache/restore@v4
+        name: workspace cache
         with:
           path: |
             target/
             !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: just python build
+      - run: just python test
 
-      - name: build python bindings
-        run: just python build
-
-      - name: run python binding tests
-        run: just python test
 
   nodejs-bindings-tests:
     name: Node.js Binding Tests
@@ -163,14 +173,13 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
@@ -182,17 +191,17 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: build cache
+      - uses: actions/cache/restore@v4
+        name: workspace cache
         with:
           path: |
             target/
             !target/**/glaredb
+            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: build node.js bindings
-        run: just js build-debug
-      - name: run node.js binding tests
-        run: just js test
+      - run: just js build-debug
+      - run: just js test
+
 
   pg-protocol:
     name: PG Protocol Tests
@@ -204,31 +213,19 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
-        name: toolchain cache
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
         with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
-        name: cargo cache
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+      - uses: actions/cache/restore@v4
+        name: pgprototest cache
         with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: pg protocol test (script)
-        run: |
-          PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
+          path: target/debug/pgprototest
+          key: ${{ github.run_id }}
+      - run: ./scripts/protocol-test.sh
+      - run: just slt-bin-debug 'pgproto/*'
 
-      - name: pg protocol tests (slt runner)
-        run: just slt-bin-debug 'pgproto/*'
 
   sql-logic-tests:
     name: SQL Logic Tests
@@ -237,33 +234,34 @@ jobs:
     strategy:
       matrix:
         protocol: ["postgres", "flightsql", "rpc"]
+        include:
+          - protocol: "postgres"
+            basic: just slt-bin --protocol=postgres 'sqllogictests/*'
+            debug: just slt-bin-debug --protocol=postgres 'sqllogictests/*'
+          - protocol: "flightsql"
+            basic: just slt-bin --protocol=flightsql 'sqllogictests/*'
+            debug: just slt-bin-debug --protocol=flightsql 'sqllogictests/*'
+          - protocol: "rpc"
+            basic: just rpc-tests
+            debug: just rpc-tests
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
-        run: |
-          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
-            just rpc-tests
-          else
-            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
-          fi
+        run: ${{matrix.protocol.debug}}
       - name: public sql logic tests
         if: ${{ env.ACTIONS_STEP_DEBUG != 'true' }}
-        run: |
-          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
-            just rpc-tests
-          else
-            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
-          fi
+        run: ${{matrix.protocol.basic}}
+
 
   process-integration-tests:
     name: Process Integration Tests (pytest)
@@ -283,26 +281,7 @@ jobs:
           python-version: "3.11"
           cache: poetry
           cache-dependency-path: tests/poetry.lock
-      - uses: actions/cache@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
-        name: cargo cache
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -313,23 +292,24 @@ jobs:
           path: |
             tests/.venv/
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/Cargo.lock') }}
-      - name: setup pytest
-        run: just venv
-      - name: run pytest
-        run: just pytest
+      - run: just venv
+      - run: just pytest
+
 
   service-integration-tests:
     name: Service Integration Tests (SLT)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -343,8 +323,7 @@ jobs:
       - name: setup GCP
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: prepare testdata
-        run: ./scripts/prepare-testdata.sh
+      - run: ./scripts/prepare-testdata.sh
 
       - name: run tests (slt)
         env:
@@ -426,17 +405,19 @@ jobs:
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/1 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/2 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
 
+
   minio-integration-tests:
     name: MinIO Integration Tests (SLT::MinIO)
-    runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -487,6 +468,58 @@ jobs:
               'sqllogictests/*' \
               --protocol=flightsql
 
+
+  service-integration-tests-snowflake:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
+    name: Snowflake Integration Tests (SLT::Snowflake)
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
+    concurrency:
+      group: snowflake-integration-tests
+      cancel-in-progress: false
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
+        with:
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+
+      - name: snowflake setup (SnowSQL)
+        run: |
+          curl -o snowsql.bash \
+            https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.24-linux_x86_64.bash
+          mkdir -p ~/bin
+          SNOWSQL_DEST=~/bin SNOWSQL_LOGIN_SHELL=~/.profile bash snowsql.bash
+
+      - run: ./scripts/prepare-testdata.sh
+
+      - name: run tests (slt)
+        env:
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+        run: |
+          # Prepare SLT (Snowflake)
+          export PATH="$HOME/bin:$PATH"
+          if ./scripts/files-changed-in-branch.sh \
+            "scripts/prepare-testdata.sh" \
+            "scripts/create-test-snowflake-db.sh" \
+            "testdata/sqllogictests_datasources_common/data" \
+            "testdata/sqllogictests_snowflake/data"
+          then
+            export SNOWFLAKE_DATABASE=$(./scripts/create-test-snowflake-db.sh)
+          else
+            export SNOWFLAKE_DATABASE=glaredb_test
+          fi
+
+          just slt-bin 'sqllogictests_snowflake/*'
+          just slt-bin --protocol=rpc 'sqllogictests_snowflake/*'
+
+
   datasource-integration-tests:
     name: Datasource Integration (${{matrix.settings.name}})
     strategy:
@@ -519,16 +552,15 @@ jobs:
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
-
-    runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -543,56 +575,3 @@ jobs:
           # for sqlserver, skip flightsql because the suite takes 4-5
           # minutes, and Sqlserver is the longest/last task to finish
           if [ "${{matrix.settings.name}}" = "Sqlserver" ]; then; exit 0; fi
-
-          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-
-  service-integration-tests-snowflake:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    name: Snowflake Service Integration Tests (SLT::Snowflake)
-    runs-on: ubuntu-latest
-    needs: ["service-integration-tests"]
-    concurrency:
-      group: snowflake-integration-tests
-      cancel-in-progress: false
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache@v4
-        name: glaredb cache
-        with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
-
-      - name: snowflake setup (SnowSQL)
-        run: |
-          curl -o snowsql.bash \
-            https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.24-linux_x86_64.bash
-          mkdir -p ~/bin
-          SNOWSQL_DEST=~/bin SNOWSQL_LOGIN_SHELL=~/.profile bash snowsql.bash
-
-      - name: prepare testdata
-        run: ./scripts/prepare-testdata.sh
-
-      - name: run tests (slt)
-        env:
-          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-        run: |
-          # Prepare SLT (Snowflake)
-          export PATH="$HOME/bin:$PATH"
-          if ./scripts/files-changed-in-branch.sh \
-            "scripts/prepare-testdata.sh" \
-            "scripts/create-test-snowflake-db.sh" \
-            "testdata/sqllogictests_datasources_common/data" \
-            "testdata/sqllogictests_snowflake/data"
-          then
-            export SNOWFLAKE_DATABASE=$(./scripts/create-test-snowflake-db.sh)
-          else
-            export SNOWFLAKE_DATABASE=glaredb_test
-          fi
-
-          just slt-bin 'sqllogictests_snowflake/*'
-          just slt-bin --protocol=rpc 'sqllogictests_snowflake/*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,8 +309,8 @@ jobs:
   service-integration-tests:
     name: Service Integration Tests (SLT)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    runs-on: ubuntu-latest-4-cores
-    needs: ["build"]
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -419,7 +419,7 @@ jobs:
   minio-integration-tests:
     name: MinIO Integration Tests (SLT::MinIO)
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["sql-logic-tests"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -479,65 +479,11 @@ jobs:
               --protocol=flightsql
 
 
-  datasource-integration-tests:
-    name: Datasource Integration (${{matrix.settings.name}})
-    strategy:
-      matrix:
-        settings:
-          - name: Clickhouse
-            path: "sqllogictests_clickhouse/*"
-            prepare: |
-              ./scripts/prepare-testdata.sh
-              source ./scripts/ci-install-clickhouse.sh
-              export CLICKHOUSE_CONN_STRING=$(./scripts/create-test-clickhouse-db.sh)
-          - name: Cassandra
-            path: "sqllogictests_cassandra/*"
-            prepare: |
-              export CASSANDRA_CONN_STRING=$(./scripts/create-test-cassandra-db.sh | tail -n 1)
-          - name: Mysql
-            path: "sqllogictests_mysql/*"
-            prepare: |
-              ./scripts/prepare-testdata.sh
-              export MYSQL_CONN_STRING=$(./scripts/create-test-mysql-db.sh)
-              export MYSQL_TUNNEL_SSH_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 2p)
-              export MYSQL_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 1p)
-          - name: MongoDB
-            path: "sqllogictests_mongodb/*"
-            prepare: |
-              ./scripts/prepare-testdata.sh
-              export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
-          - name: Sqlserver
-            path: "sqllogictests_sqlserver/*"
-            prepare: |
-              ./scripts/prepare-testdata.sh
-              export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
-    runs-on: ubuntu-latest
-    needs: ["build"]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: glaredb cache
-        with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
-      - name: run tests (slt)
-        run: |
-          ${{matrix.settings.prepare}}
-
-          just slt-bin ${{matrix.settings.path}}
-          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
-
-
   service-integration-tests-snowflake:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    name: Snowflake Service Integration Tests (SLT::Snowflake)
+    name: Snowflake Integration Tests (SLT::Snowflake)
     runs-on: ubuntu-latest
-    needs: ["service-integration-tests"]
+    needs: ["sql-logic-tests"]
     concurrency:
       group: snowflake-integration-tests
       cancel-in-progress: false
@@ -582,3 +528,57 @@ jobs:
 
           just slt-bin 'sqllogictests_snowflake/*'
           just slt-bin --protocol=rpc 'sqllogictests_snowflake/*'
+
+
+  datasource-integration-tests:
+    name: Datasource Integration (${{matrix.settings.name}})
+    strategy:
+      matrix:
+        settings:
+          - name: Clickhouse
+            path: "sqllogictests_clickhouse/*"
+            prepare: |
+              ./scripts/prepare-testdata.sh
+              source ./scripts/ci-install-clickhouse.sh
+              export CLICKHOUSE_CONN_STRING=$(./scripts/create-test-clickhouse-db.sh)
+          - name: Cassandra
+            path: "sqllogictests_cassandra/*"
+            prepare: |
+              export CASSANDRA_CONN_STRING=$(./scripts/create-test-cassandra-db.sh | tail -n 1)
+          - name: Mysql
+            path: "sqllogictests_mysql/*"
+            prepare: |
+              ./scripts/prepare-testdata.sh
+              export MYSQL_CONN_STRING=$(./scripts/create-test-mysql-db.sh)
+              export MYSQL_TUNNEL_SSH_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 2p)
+              export MYSQL_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 1p)
+          - name: MongoDB
+            path: "sqllogictests_mongodb/*"
+            prepare: |
+              ./scripts/prepare-testdata.sh
+              export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
+          - name: Sqlserver
+            path: "sqllogictests_sqlserver/*"
+            prepare: |
+              ./scripts/prepare-testdata.sh
+              export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
+    runs-on: ubuntu-latest
+    needs: ["sql-logic-tests"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache/restore@v4
+        name: glaredb cache
+        with:
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+      - name: run tests (slt)
+        run: |
+          ${{matrix.settings.prepare}}
+
+          just slt-bin ${{matrix.settings.path}}
+          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
           key: ${{ github.run_id }}
 
 
-
   fmt:
     name: Format (rustfmt +nightly)
     runs-on: ubuntu-latest
@@ -81,11 +80,6 @@ jobs:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rustfmt.toml') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
-        with:
-          path: target/
-          key: ${{ github.run_id }}
       - run: rustup install nightly
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
@@ -179,7 +173,7 @@ jobs:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: cargo cache
         with:
           path: |
@@ -215,14 +209,14 @@ jobs:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: glaredb cache
+        name: build cache
         with:
           path: |
             target/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -570,8 +570,11 @@ jobs:
           ${{matrix.settings.prepare}}
 
           just slt-bin ${{matrix.settings.path}}
+
+          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+
           # for sqlserver, skip flightsql because the suite takes 4-5
           # minutes, and Sqlserver is the longest/last task to finish
           [ "${{matrix.settings.name}}" = "Sqlserver" ] && exit 0
 
-          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,14 +45,6 @@ jobs:
       - run: just build
       - run: cargo build --bin pgprototest
       - uses: actions/cache/save@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ github.run_id }}
-      - uses: actions/cache/save@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -108,14 +100,6 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ github.run_id }}
       - run: just clippy
 
 
@@ -142,14 +126,6 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ github.run_id }}
-      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -173,20 +149,12 @@ jobs:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ github.run_id }}
       - run: just python build
       - run: just python test
 
@@ -216,13 +184,13 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: build cache
+        name: workspace cache
         with:
           path: |
             target/
             !target/**/glaredb
             !target/**/pgprototest
-          key: ${{ github.run_id }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: just js build-debug
       - run: just js test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -35,25 +34,19 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache@v4
-        name: workspace cache
+        name: build cache
         with:
           path: |
             target/
             !target/**/glaredb
-            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: just build
-      - run: cargo build --bin pgprototest
-      - uses: actions/cache/save@v4
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
-      - uses: actions/cache/save@v4
-        name: pgprototest cache
-        with:
-          path: target/debug/pgprototest
-          key: ${{ github.run_id }}
+      - name: build
+        run: just build
 
 
   fmt:
@@ -76,11 +69,9 @@ jobs:
       - run: rustup component add rustfmt --toolchain nightly
       - run: just fmt-check
 
-
   lint:
     name: Lint (clippy)
-    # emperically runtimes are the same for big/small hosts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     needs: ["fmt"]
     steps:
       - name: checkout
@@ -88,98 +79,7 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache/restore@v4
-        name: cargo cache
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: just clippy
-
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache/restore@v4
-        name: cargo cache
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: glaredb cache
-        with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
-      - run: just unit-tests
-
-
-  python-binding-tests:
-    name: Python Binding Tests
-    runs-on: ubuntu-latest-4-cores
-    needs: ["build"]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache/restore@v4
-        name: cargo cache
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: workspace cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: just python build
-      - run: just python test
-
-
-  nodejs-bindings-tests:
-    name: Node.js Binding Tests
-    runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: toolchain cache
         with:
           path: |
@@ -191,17 +91,108 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: workspace cache
+
+      - name: clippy
+        run: just clippy
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache@v4
+        name: toolchain cache
+        with:
+          path: |
+            ~/.rustup/toolchains/
+          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
+      - uses: actions/cache@v4
+        name: cargo cache
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: run tests
+        run: just unit-tests
+
+  python-binding-tests:
+    name: Python Binding Tests
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache@v4
+        name: toolchain cache
+        with:
+          path: |
+            ~/.rustup/toolchains/
+          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
+      - uses: actions/cache@v4
+        name: cargo cache
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
         with:
           path: |
             target/
             !target/**/glaredb
-            !target/**/pgprototest
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: just js build-debug
-      - run: just js test
 
+      - name: build python bindings
+        run: just python build
+
+      - name: run python binding tests
+        run: just python test
+
+  nodejs-bindings-tests:
+    name: Node.js Binding Tests
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache@v4
+        name: toolchain cache
+        with:
+          path: |
+            ~/.rustup/toolchains/
+          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
+      - uses: actions/cache@v4
+        name: cargo cache
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: build node.js bindings
+        run: just js build-debug
+      - name: run node.js binding tests
+        run: just js test
 
   pg-protocol:
     name: PG Protocol Tests
@@ -213,19 +204,31 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: glaredb cache
+      - uses: actions/cache@v4
+        name: toolchain cache
         with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
-      - uses: actions/cache/restore@v4
-        name: pgprototest cache
+          path: |
+            ~/.rustup/toolchains/
+          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
+      - uses: actions/cache@v4
+        name: cargo cache
         with:
-          path: target/debug/pgprototest
-          key: ${{ github.run_id }}
-      - run: ./scripts/protocol-test.sh
-      - run: just slt-bin-debug 'pgproto/*'
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: pg protocol test (script)
+        run: |
+          PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
 
+      - name: pg protocol tests (slt runner)
+        run: just slt-bin-debug 'pgproto/*'
 
   sql-logic-tests:
     name: SQL Logic Tests
@@ -234,34 +237,33 @@ jobs:
     strategy:
       matrix:
         protocol: ["postgres", "flightsql", "rpc"]
-        include:
-          - protocol: "postgres"
-            basic: just slt-bin --protocol=postgres 'sqllogictests/*'
-            debug: just slt-bin-debug --protocol=postgres 'sqllogictests/*'
-          - protocol: "flightsql"
-            basic: just slt-bin --protocol=flightsql 'sqllogictests/*'
-            debug: just slt-bin-debug --protocol=flightsql 'sqllogictests/*'
-          - protocol: "rpc"
-            basic: just rpc-tests
-            debug: just rpc-tests
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
-        run: ${{matrix.protocol.debug}}
+        run: |
+          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
+            just rpc-tests
+          else
+            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
+          fi
       - name: public sql logic tests
         if: ${{ env.ACTIONS_STEP_DEBUG != 'true' }}
-        run: ${{matrix.protocol.basic}}
-
+        run: |
+          if [[ "${{ matrix.protocol }}" == "rpc" ]]; then
+            just rpc-tests
+          else
+            just slt-bin-debug --protocol=${{ matrix.protocol }} 'sqllogictests/*'
+          fi
 
   process-integration-tests:
     name: Process Integration Tests (pytest)
@@ -281,7 +283,26 @@ jobs:
           python-version: "3.11"
           cache: poetry
           cache-dependency-path: tests/poetry.lock
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
+        name: toolchain cache
+        with:
+          path: |
+            ~/.rustup/toolchains/
+          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
+      - uses: actions/cache@v4
+        name: cargo cache
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -292,24 +313,23 @@ jobs:
           path: |
             tests/.venv/
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/Cargo.lock') }}
-      - run: just venv
-      - run: just pytest
-
+      - name: setup pytest
+        run: just venv
+      - name: run pytest
+        run: just pytest
 
   service-integration-tests:
     name: Service Integration Tests (SLT)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    runs-on: ubuntu-latest
-    needs: ["sql-logic-tests"]
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
-
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -323,7 +343,8 @@ jobs:
       - name: setup GCP
         uses: google-github-actions/setup-gcloud@v2
 
-      - run: ./scripts/prepare-testdata.sh
+      - name: prepare testdata
+        run: ./scripts/prepare-testdata.sh
 
       - name: run tests (slt)
         env:
@@ -405,19 +426,17 @@ jobs:
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/1 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/2 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
 
-
   minio-integration-tests:
     name: MinIO Integration Tests (SLT::MinIO)
-    runs-on: ubuntu-latest
-    needs: ["sql-logic-tests"]
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -468,58 +487,6 @@ jobs:
               'sqllogictests/*' \
               --protocol=flightsql
 
-
-  service-integration-tests-snowflake:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
-    name: Snowflake Integration Tests (SLT::Snowflake)
-    runs-on: ubuntu-latest
-    needs: ["sql-logic-tests"]
-    concurrency:
-      group: snowflake-integration-tests
-      cancel-in-progress: false
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-        with:
-          just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
-        name: glaredb cache
-        with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
-
-      - name: snowflake setup (SnowSQL)
-        run: |
-          curl -o snowsql.bash \
-            https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.24-linux_x86_64.bash
-          mkdir -p ~/bin
-          SNOWSQL_DEST=~/bin SNOWSQL_LOGIN_SHELL=~/.profile bash snowsql.bash
-
-      - run: ./scripts/prepare-testdata.sh
-
-      - name: run tests (slt)
-        env:
-          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-        run: |
-          # Prepare SLT (Snowflake)
-          export PATH="$HOME/bin:$PATH"
-          if ./scripts/files-changed-in-branch.sh \
-            "scripts/prepare-testdata.sh" \
-            "scripts/create-test-snowflake-db.sh" \
-            "testdata/sqllogictests_datasources_common/data" \
-            "testdata/sqllogictests_snowflake/data"
-          then
-            export SNOWFLAKE_DATABASE=$(./scripts/create-test-snowflake-db.sh)
-          else
-            export SNOWFLAKE_DATABASE=glaredb_test
-          fi
-
-          just slt-bin 'sqllogictests_snowflake/*'
-          just slt-bin --protocol=rpc 'sqllogictests_snowflake/*'
-
-
   datasource-integration-tests:
     name: Datasource Integration (${{matrix.settings.name}})
     strategy:
@@ -552,15 +519,16 @@ jobs:
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
-    runs-on: ubuntu-latest
-    needs: ["sql-logic-tests"]
+
+    runs-on: ubuntu-latest-8-cores
+    needs: ["build"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -571,4 +539,60 @@ jobs:
 
           just slt-bin ${{matrix.settings.path}}
           just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+
+          # for sqlserver, skip flightsql because the suite takes 4-5
+          # minutes, and Sqlserver is the longest/last task to finish
+          if [ "${{matrix.settings.name}}" = "Sqlserver" ]; then; exit 0; fi
+
           just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+
+  service-integration-tests-snowflake:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'GlareDB'
+    name: Snowflake Service Integration Tests (SLT::Snowflake)
+    runs-on: ubuntu-latest
+    needs: ["service-integration-tests"]
+    concurrency:
+      group: snowflake-integration-tests
+      cancel-in-progress: false
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: "1.23.0"
+      - uses: actions/cache@v4
+        name: glaredb cache
+        with:
+          path: target/debug/glaredb
+          key: ${{ github.run_id }}
+
+      - name: snowflake setup (SnowSQL)
+        run: |
+          curl -o snowsql.bash \
+            https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.24-linux_x86_64.bash
+          mkdir -p ~/bin
+          SNOWSQL_DEST=~/bin SNOWSQL_LOGIN_SHELL=~/.profile bash snowsql.bash
+
+      - name: prepare testdata
+        run: ./scripts/prepare-testdata.sh
+
+      - name: run tests (slt)
+        env:
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+        run: |
+          # Prepare SLT (Snowflake)
+          export PATH="$HOME/bin:$PATH"
+          if ./scripts/files-changed-in-branch.sh \
+            "scripts/prepare-testdata.sh" \
+            "scripts/create-test-snowflake-db.sh" \
+            "testdata/sqllogictests_datasources_common/data" \
+            "testdata/sqllogictests_snowflake/data"
+          then
+            export SNOWFLAKE_DATABASE=$(./scripts/create-test-snowflake-db.sh)
+          else
+            export SNOWFLAKE_DATABASE=glaredb_test
+          fi
+
+          just slt-bin 'sqllogictests_snowflake/*'
+          just slt-bin --protocol=rpc 'sqllogictests_snowflake/*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     needs: ["build"]
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-  merge_queue:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,20 +34,26 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache@v4
-        name: build cache
+        name: workspace cache
         with:
           path: |
             target/
             !target/**/glaredb
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+
+      - run: just build
+
+      - uses: actions/cache/save@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
           key: ${{ github.run_id }}
-      - name: build
-        run: just build
-
+      - uses: actions/cache/save@v4
+        name: build cache
+        with:
+          path: |
+            target/
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
 
   fmt:
     name: Format (rustfmt +nightly)
@@ -59,7 +65,7 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: nightly toolchain cache
         with:
           path: |
@@ -79,21 +85,19 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: clippy
-        run: just clippy
+      - run: just clippy
 
   unit-tests:
     name: Unit Tests
@@ -105,21 +109,25 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: run tests
-        run: just unit-tests
+      - uses: actions/cache/restore@v4
+        name: build cache
+        with:
+          path: |
+            target/
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+      - run: just unit-tests
 
   python-binding-tests:
     name: Python Binding Tests
@@ -131,31 +139,26 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: build cache
         with:
           path: |
             target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: build python bindings
-        run: just python build
-
-      - name: run python binding tests
-        run: just python test
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+      - run: just python build
+      - run: just python test
 
   nodejs-bindings-tests:
     name: Node.js Binding Tests
@@ -163,36 +166,32 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: toolchain cache
         with:
           path: |
             ~/.rustup/toolchains/
           key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: build cache
         with:
           path: |
             target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: build node.js bindings
-        run: just js build-debug
-      - name: run node.js binding tests
-        run: just js test
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+      - run: just js build-debug
+      - run: just js test
 
   pg-protocol:
     name: PG Protocol Tests
@@ -204,31 +203,21 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: cargo cache
         with:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: build cache
         with:
           path: |
             target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: pg protocol test (script)
-        run: |
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
+      - run: |
           PROTOC=`just protoc && just --evaluate PROTOC` ./scripts/protocol-test.sh
-
-      - name: pg protocol tests (slt runner)
-        run: just slt-bin-debug 'pgproto/*'
+      - run: just slt-bin-debug 'pgproto/*'
 
   sql-logic-tests:
     name: SQL Logic Tests
@@ -243,11 +232,12 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
-        name: glaredb cache
+      - uses: actions/cache/restore@v4
+        name: build cache
         with:
-          path: target/debug/glaredb
-          key: ${{ github.run_id }}
+          path: |
+            target/
+          key: ${{ runner.os }}-cargo--target-${{github.sha}}
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
         run: |
@@ -283,26 +273,7 @@ jobs:
           python-version: "3.11"
           cache: poetry
           cache-dependency-path: tests/poetry.lock
-      - uses: actions/cache@v4
-        name: toolchain cache
-        with:
-          path: |
-            ~/.rustup/toolchains/
-          key: ${{ runner.os }}-toolchain-${{ hashFiles('**/rust-toolchain.toml') }}
-      - uses: actions/cache@v4
-        name: cargo cache
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
-        name: build cache
-        with:
-          path: |
-            target/
-            !target/**/glaredb
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -313,10 +284,8 @@ jobs:
           path: |
             tests/.venv/
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/Cargo.lock') }}
-      - name: setup pytest
-        run: just venv
-      - name: run pytest
-        run: just pytest
+      - run: just venv
+      - run: just pytest
 
   service-integration-tests:
     name: Service Integration Tests (SLT)
@@ -326,10 +295,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -343,8 +314,7 @@ jobs:
       - name: setup GCP
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: prepare testdata
-        run: ./scripts/prepare-testdata.sh
+      - run: ./scripts/prepare-testdata.sh
 
       - name: run tests (slt)
         env:
@@ -428,7 +398,7 @@ jobs:
 
   minio-integration-tests:
     name: MinIO Integration Tests (SLT::MinIO)
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     needs: ["build"]
     steps:
       - name: checkout
@@ -436,7 +406,8 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -494,16 +465,19 @@ jobs:
         settings:
           - name: Clickhouse
             path: "sqllogictests_clickhouse/*"
+            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               source ./scripts/ci-install-clickhouse.sh
               export CLICKHOUSE_CONN_STRING=$(./scripts/create-test-clickhouse-db.sh)
           - name: Cassandra
             path: "sqllogictests_cassandra/*"
+            runner: ubuntu-latest
             prepare: |
               export CASSANDRA_CONN_STRING=$(./scripts/create-test-cassandra-db.sh | tail -n 1)
           - name: Mysql
             path: "sqllogictests_mysql/*"
+            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export MYSQL_CONN_STRING=$(./scripts/create-test-mysql-db.sh)
@@ -511,16 +485,18 @@ jobs:
               export MYSQL_CONN_STRING=$(echo "$MYSQL_CONN_STRING" | sed -n 1p)
           - name: MongoDB
             path: "sqllogictests_mongodb/*"
+            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export MONGO_CONN_STRING=$(./scripts/create-test-mongo-db.sh)
           - name: Sqlserver
             path: "sqllogictests_sqlserver/*"
+            runner: ubuntu-latest
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
 
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ${{matrix.runner}}
     needs: ["build"]
     steps:
       - name: checkout
@@ -528,7 +504,7 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -555,7 +531,7 @@ jobs:
       - uses: extractions/setup-just@v1
         with:
           just-version: "1.23.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: glaredb cache
         with:
           path: target/debug/glaredb
@@ -568,8 +544,7 @@ jobs:
           mkdir -p ~/bin
           SNOWSQL_DEST=~/bin SNOWSQL_LOGIN_SHELL=~/.profile bash snowsql.bash
 
-      - name: prepare testdata
-        run: ./scripts/prepare-testdata.sh
+      - run: ./scripts/prepare-testdata.sh
 
       - name: run tests (slt)
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,14 +234,15 @@ jobs:
     needs: ["build"]
     strategy:
       matrix:
-        protocol: 
-          - name: "postgres"
+        protocol: ["postgres", "flightsql", "rpc"]
+        include:
+          - protocol: "postgres"
             basic: just slt-bin --protocol=postgres 'sqllogictests/*'
             debug: just slt-bin-debug --protocol=postgres 'sqllogictests/*'
-          - name: "flightsql"
+          - protocol: "flightsql"
             basic: just slt-bin --protocol=flightsql 'sqllogictests/*'
             debug: just slt-bin-debug --protocol=flightsql 'sqllogictests/*'
-          - name: "rpc"
+          - protocol: "rpc"
             basic: just rpc-tests
             debug: just rpc-tests
     steps:

--- a/scripts/protocol-test.sh
+++ b/scripts/protocol-test.sh
@@ -38,7 +38,7 @@ fi
 
 # Run protocol tests.
 ret=0
-./target/debug/pgprototest -- \
+./target/debug/pgprototest \
     --dir ./testdata/pgprototest \
     --dir ./testdata/pgprototest_glaredb \
     --addr localhost:6543 \

--- a/scripts/protocol-test.sh
+++ b/scripts/protocol-test.sh
@@ -5,28 +5,40 @@
 # This will spin up a GlareDB instance on its default port (6543) and execute
 # the protocol tests against it.
 
-set -e
+set -exo pipefail
 
 export RUST_BACKTRACE=1
 
 run_id=${RANDOM}
 
-# build once...
-just build || true
-
 # Start up GlareDB.
 glaredb_log_file="/tmp/glaredb.log-${run_id}"
-nohup cargo run --bin glaredb -- -v server --user glaredb --password dummy > "${glaredb_log_file}" 2>&1 &
+if [ ! -f ./target/debug/glaredb ]; then
+    just build
+fi
+./target/debug/glaredb -v server --user glaredb --password dummy > "${glaredb_log_file}" 2>&1 &
 
 glaredb_pid=$!
+
+# build the prototest build in the background if needed
+pgproto_test_build=-1
+if [ ! -f ./target/debug/glaredb ]; then
+    cargo build --bin pgprototest &
+    pgproto_test_build=$!
+fi
 
 # Give it some time. Eventually we could wait on a signal or poll system status
 # through an endpoint.
 sleep 5
 
+# wait for the build to be complete, if it was running
+if [ $pgproto_test_build -ne -1 ]; then
+    wait $pgproto_test_build
+fi
+
 # Run protocol tests.
 ret=0
-cargo run --bin pgprototest -- \
+./target/debug/pgprototest -- \
     --dir ./testdata/pgprototest \
     --dir ./testdata/pgprototest_glaredb \
     --addr localhost:6543 \


### PR DESCRIPTION
This (on top of #2518) should get wall clock time to about 10 minutes for an entire PR run, at the same cost. 

It's likely redundant to the other suite. We could also switch datasource integration to just postgres as there's less postgres protocol coverage.