### PR TITLE
chore: (ci) split cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Lint (clippy)
     # emperically runtimes are the same for big/small hosts:
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["fmt"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -56,8 +56,12 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-clippy-${{ github.ref_name }}
       - run: just clippy
-
 
   build:
     name: Build
@@ -82,13 +86,13 @@ jobs:
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache@v4
-        name: workspace cache
+        name: build cache
         with:
           path: |
             target/
             !target/**/glaredb
             !target/**/pgprototest
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-glaredb-${{ github.ref_name }}
       - run: just build
       - run: cargo build --bin pgprototest
       - uses: actions/cache/save@v4
@@ -125,21 +129,18 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: workspace cache
+      - uses: actions/cache@v4
+        name: build cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target
+          key: ${{ runner.os }}-cargo-build-python-${{ github.ref_name }}
       - run: just python build
       - run: just python test
 
 
   nodejs-bindings-tests:
     name: Node.js Binding Tests
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: ["fmt"]
     steps:
       - uses: actions/checkout@v4
@@ -161,14 +162,11 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache/restore@v4
-        name: workspace cache
+      - uses: actions/cache@v4
+        name: build cache
         with:
-          path: |
-            target/
-            !target/**/glaredb
-            !target/**/pgprototest
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: target
+          key: ${{ runner.os }}-cargo-build-nodejs-${{ github.ref_name }}
       - run: just js build-debug
       - run: just js test
 
@@ -176,7 +174,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest-8-cores
-    needs: ["build"]
+    needs: ["fmt"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -195,6 +193,13 @@ jobs:
           path: |
             ~/.cargo/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v4
+        name: build cache
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+          key: ${{ runner.os }}-cargo-unit-tests-${{ github.ref_name }}
       - uses: actions/cache/restore@v4
         name: glaredb cache
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
 
   nodejs-bindings-tests:
     name: Node.js Binding Tests
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     needs: ["fmt"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As discussed out of band this PR: 
- creates a separate set of caches for each branch. This means that the first build of any PR will be a bit slower than it is today, but that every push after that will be (quite) quick.
- splits the caches between uinttests/glaredb/python/nodejs/clippy: all of these compile the world, and can't share each other's cache because they have different flags.