### PR TITLE
chore: populate shareable cache on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,7 +226,49 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - run: just unit-tests
+
+
+  cache:
+    # when we change the Cargo.lock we should copy the branch cache
+    # from this build to the expected cache location to better
+    # populate caches.
+    name: Cache Maintenance
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    # parent branches can't use caches from child branches, so no need
+    # to update this cache _except_ on main.
+    # if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/cache@v4
+        name: cache check
+        id: target-for-cargo-hash
+        with:
+          lookup-only: true
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
+          key: ${{ runner.os }}-cargo-pkg-build-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache/restore@v4
+        name: cache check
+        if: ${{ steps.target-for-cargo-hash.cache-hit != 'true' }}
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
+          key: ${{ runner.os }}-cargo-glaredb-build-${{ github.ref_name }}
+      - uses: actions/cache/save@v4
+        name: cache check
+        if: ${{ steps.target-for-cargo-hash.cache-hit != 'true' }}
+        with:
+          path: |
+            target/
+            !target/**/glaredb
+            !target/**/pgprototest
+          key: ${{ runner.os }}-cargo-pkg-build-${{ hashFiles('**/Cargo.lock') }}
 
 
   pg-protocol:
@@ -244,11 +286,13 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - uses: actions/cache/restore@v4
         name: pgprototest cache
         with:
           path: target/debug/pgprototest
           key: ${{ runner.os }}-pgprototest-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - run: ./scripts/protocol-test.sh
       - run: just slt-bin-debug 'pgproto/*'
 
@@ -281,6 +325,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: public sql logic tests DEBUG
         if: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
         run: ${{matrix.protocol.debug}}
@@ -312,6 +357,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - run: just venv
       - run: just pytest
 
@@ -334,6 +380,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: GCP authenticate
         uses: google-github-actions/auth@v2
@@ -442,6 +489,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: run tests (slt)
         env:
@@ -508,6 +556,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: snowflake setup (SnowSQL)
         run: |
@@ -585,6 +634,7 @@ jobs:
         with:
           path: target/debug/glaredb
           key: ${{ runner.os }}-glaredb-bin-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: run tests (slt)
         run: |
           ${{matrix.settings.prepare}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,7 +239,7 @@ jobs:
     needs: ["build"]
     # parent branches can't use caches from child branches, so no need
     # to update this cache _except_ on main.
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/cache@v4
         name: cache check
@@ -252,7 +252,7 @@ jobs:
             !target/**/pgprototest
           key: ${{ runner.os }}-cargo-pkg-build-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/cache/restore@v4
-        name: cache check
+        name: build cache restore
         if: ${{ steps.target-for-cargo-hash.cache-hit != 'true' }}
         with:
           path: |
@@ -261,7 +261,7 @@ jobs:
             !target/**/pgprototest
           key: ${{ runner.os }}-cargo-glaredb-build-${{ github.ref_name }}
       - uses: actions/cache/save@v4
-        name: cache check
+        name: cache update
         if: ${{ steps.target-for-cargo-hash.cache-hit != 'true' }}
         with:
           path: |


### PR DESCRIPTION
(this has a restriction commented out for testing, which I'll remove before merging.)

Basically this helps us populate a shareable cache (so that PRs can
get access to relatively fresh base caches and avoid slow first
builds.)