### PR TITLE
fix: parquet over http 

### DIFF
--- a/crates/datasources/src/object_store/http.rs
+++ b/crates/datasources/src/object_store/http.rs
@@ -91,9 +91,11 @@ impl ObjStoreAccess for HttpStoreAccess {
                 status, self.url
             )));
         }
+        // reqwest doesn't check the content length header, instead looks at the contents
+        // See: https://github.com/seanmonstar/reqwest/issues/843
         let len: u64 = res
             .headers()
-            .get("Content-Length") // reqwest uses case sensitive headers, so we need to explicitly check for "Content-Length"
+            .get("Content-Length") 
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse().ok())
             .unwrap_or_else(|| res.content_length().unwrap_or(0));

--- a/crates/datasources/src/object_store/http.rs
+++ b/crates/datasources/src/object_store/http.rs
@@ -95,7 +95,7 @@ impl ObjStoreAccess for HttpStoreAccess {
         // See: https://github.com/seanmonstar/reqwest/issues/843
         let len: u64 = res
             .headers()
-            .get("Content-Length") 
+            .get("Content-Length")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse().ok())
             .unwrap_or_else(|| res.content_length().unwrap_or(0));

--- a/crates/datasources/src/object_store/http.rs
+++ b/crates/datasources/src/object_store/http.rs
@@ -91,10 +91,18 @@ impl ObjStoreAccess for HttpStoreAccess {
                 status, self.url
             )));
         }
+        let len: u64 = res
+            .headers()
+            .get("Content-Length") // reqwest uses case sensitive headers, so we need to explicitly check for "Content-Length"
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| res.content_length().unwrap_or(0));
+        if len == 0 {
+            return Err(ObjectStoreSourceError::Static(
+                "Missing content-length header",
+            ));
+        }
 
-        let len = res.content_length().ok_or(ObjectStoreSourceError::Static(
-            "Missing content-length header",
-        ))?;
 
         Ok(ObjectMeta {
             location: location.clone(),
@@ -119,7 +127,6 @@ impl ObjStoreAccess for HttpStoreAccess {
         let next = locations
             .next()
             .ok_or(ObjectStoreSourceError::Static("No locations provided"))?;
-
         let objects = self
             .list_globbed(&store, &next.path())
             .await


### PR DESCRIPTION
reqwest's `content_length` method apparantly doesnt check for the casing of "Content-Length". This seems like a bug in reqwest to me. 

https://github.com/seanmonstar/reqwest/issues/843


```rust

#[tokio::main]
async fn main() {
    let client = reqwest::Client::new();
    let head_res = client.head("https://clickhouse-public-datasets.s3.eu-central-1.amazonaws.com/hits_compatible/athena/hits.parquet").send().await.unwrap();
    let content_length = head_res.content_length();
    assert_eq!(content_length, Some(14779976446))
}

```

closes https://github.com/GlareDB/glaredb/issues/2561