### PR TITLE
chore(cloudauth): remove unused fields

### DIFF
--- a/crates/proxyutil/src/cloudauth.rs
+++ b/crates/proxyutil/src/cloudauth.rs
@@ -173,7 +173,7 @@ mod tests {
               "ip": "1.2.3.4",
               "port": "5432",
               "memory_limit_bytes": 268435456,
-              "gcs_storage_bucket": "",
+              "gcs_storage_bucket": ""
             }
             "#;
 
@@ -202,7 +202,7 @@ mod tests {
               "port": "5432",
               "nodes":[{"ip":"1.2.3.4","port":"5432"}],
               "memory_limit_bytes": 268435456,
-              "gcs_storage_bucket": "",
+              "gcs_storage_bucket": ""
             }
             "#;
 

--- a/crates/proxyutil/src/cloudauth.rs
+++ b/crates/proxyutil/src/cloudauth.rs
@@ -174,8 +174,6 @@ mod tests {
               "port": "5432",
               "memory_limit_bytes": 268435456,
               "gcs_storage_bucket": "",
-              "storage_size_bytes": 0,
-              "max_storage_bytes": 0
             }
             "#;
 
@@ -205,8 +203,6 @@ mod tests {
               "nodes":[{"ip":"1.2.3.4","port":"5432"}],
               "memory_limit_bytes": 268435456,
               "gcs_storage_bucket": "",
-              "storage_size_bytes": 0,
-              "max_storage_bytes": 0
             }
             "#;
 


### PR DESCRIPTION
These are harmless to have around in the tests, but don't add value and may mislead someone in the future into expecting they exist on the actual response