### PR TITLE
fix: add pg_rewrite and pg_depend tables

### DIFF
--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -704,6 +704,35 @@ pub static PG_MATVIEWS: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     ",
 });
 
+pub static PG_REWRITE: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
+    schema: POSTGRES_SCHEMA,
+    name: "pg_rewrite",
+    sql: "
+    SELECT 0 as oid,
+    '' as rulename,
+    0 as ev_class,
+    1 as ev_type,
+    'D' as ev_enabled,
+    false as is_instead,
+    null as ev_qual,
+    null as ev_action
+    ",
+});
+
+pub static PG_DEPEND: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
+    schema: POSTGRES_SCHEMA,
+    name: "pg_depend",
+    sql: "
+    SELECT 0 as classid,
+    0 as objid,
+    0 as objsubid,
+    0 as refclassid,
+    0 as refobjid,
+    0 as refobjdubid,
+    'a' as deptype,
+    ",
+});
+
 impl BuiltinView {
     pub fn builtins() -> Vec<&'static BuiltinView> {
         vec![
@@ -721,6 +750,8 @@ impl BuiltinView {
             &PG_VIEWS,
             &PG_TYPE,
             &PG_MATVIEWS,
+            &PG_REWRITE,
+            &PG_DEPEND
         ]
     }
 }

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -751,7 +751,7 @@ impl BuiltinView {
             &PG_TYPE,
             &PG_MATVIEWS,
             &PG_REWRITE,
-            &PG_DEPEND
+            &PG_DEPEND,
         ]
     }
 }

--- a/testdata/sqllogictests/pg_catalog.slt
+++ b/testdata/sqllogictests/pg_catalog.slt
@@ -121,6 +121,12 @@ LIMIT 1000;
 statement ok
 select * from pg_matviews;
 
+statement ok
+select * from pg_rewrite;
+
+statement ok
+select * from pg_depend;
+
 # https://github.com/GlareDB/glaredb/issues/2475
 statement ok
 WITH table_privileges AS (


### PR DESCRIPTION
These are to make another step toward fixing #2436. 

I built the definitions off of https://www.postgresql.org/docs/16/catalog-pg-depend.html and https://www.postgresql.org/docs/16/catalog-pg-rewrite.html, but please double-check that I did this correctly.