### PR TITLE
fix(metastore): make builtin schemas readonly

### DIFF
--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -73,7 +73,7 @@ static BUILTIN_CATALOG: Lazy<BuiltinCatalog> = Lazy::new(|| BuiltinCatalog::new(
 pub struct DatabaseCatalog {
     db_id: Uuid,
 
-    /// Reference to underlying persistant storage.
+    /// Reference to underlying persistent storage.
     storage: Arc<Storage>,
 
     /// A cached catalog state for a single database.

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1977,7 +1977,7 @@ mod tests {
         let db = new_catalog().await;
         version(&db).await;
 
-        // Add view.
+        // Add internal table on 'glare_catalog'
         db.try_mutate(
             version(&db).await,
             vec![Mutation::CreateTable(CreateTable {
@@ -2003,7 +2003,7 @@ mod tests {
         let db = new_catalog().await;
         version(&db).await;
 
-        // Add view.
+        // Add internal table on 'public' schema
         db.try_mutate(
             version(&db).await,
             vec![Mutation::CreateTable(CreateTable {

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -278,7 +278,7 @@ impl DatabaseEntries {
 
         for builtin in BuiltinSchema::builtins() {
             if builtin.oid == SCHEMA_DEFAULT.oid {
-                continue
+                continue;
             }
             if builtin.oid == ent.get_meta().parent {
                 return Err(MetastoreError::CannotModifyBuiltin(ent.clone()));
@@ -1378,12 +1378,24 @@ impl BuiltinCatalog {
 mod tests {
     use std::collections::HashSet;
 
-    use object_store::memory::InMemory;
-    use protogen::metastore::types::options::{DatabaseOptionsDebug, InternalColumnDefinition, TableOptionsDebug, TableOptionsInternal};
-    use protogen::metastore::types::service::{
-        AlterDatabase, CreateExternalDatabase, CreateExternalTable, CreateSchema, CreateTable, CreateView, DropDatabase, DropSchema
-    };
     use datafusion::arrow::datatypes::DataType;
+    use object_store::memory::InMemory;
+    use protogen::metastore::types::options::{
+        DatabaseOptionsDebug,
+        InternalColumnDefinition,
+        TableOptionsDebug,
+        TableOptionsInternal,
+    };
+    use protogen::metastore::types::service::{
+        AlterDatabase,
+        CreateExternalDatabase,
+        CreateExternalTable,
+        CreateSchema,
+        CreateTable,
+        CreateView,
+        DropDatabase,
+        DropSchema,
+    };
     use sqlbuiltins::builtins::{DEFAULT_CATALOG, INTERNAL_SCHEMA};
 
     use super::*;
@@ -1973,19 +1985,19 @@ mod tests {
                 name: "peach".to_string(),
                 if_not_exists: true,
                 or_replace: false,
-                options: TableOptionsInternal{
-                    columns: vec![InternalColumnDefinition{
+                options: TableOptionsInternal {
+                    columns: vec![InternalColumnDefinition {
                         name: "luigi".to_string(),
                         nullable: true,
                         arrow_type: DataType::Utf8,
                     }],
-                }
+                },
             })],
         )
         .await
         .unwrap_err();
     }
-    
+
     #[tokio::test]
     async fn allow_modify_default_schema() {
         let db = new_catalog().await;
@@ -1999,13 +2011,13 @@ mod tests {
                 name: "peach".to_string(),
                 if_not_exists: true,
                 or_replace: false,
-                options: TableOptionsInternal{
-                    columns: vec![InternalColumnDefinition{
+                options: TableOptionsInternal {
+                    columns: vec![InternalColumnDefinition {
                         name: "luigi".to_string(),
                         nullable: true,
                         arrow_type: DataType::Utf8,
                     }],
-                }
+                },
             })],
         )
         .await

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -36,6 +36,7 @@ use sqlbuiltins::builtins::{
     DATABASE_DEFAULT,
     DEFAULT_SCHEMA,
     FIRST_NON_STATIC_OID,
+    SCHEMA_DEFAULT,
 };
 use sqlbuiltins::functions::{BuiltinFunction, FUNCTION_REGISTRY};
 use sqlbuiltins::validation::{
@@ -271,6 +272,15 @@ impl DatabaseEntries {
 
         if let Some(ent) = self.0.get(&oid) {
             if ent.get_meta().builtin {
+                return Err(MetastoreError::CannotModifyBuiltin(ent.clone()));
+            }
+        }
+
+        for builtin in BuiltinSchema::builtins() {
+            if builtin.oid == SCHEMA_DEFAULT.oid {
+                continue
+            }
+            if builtin.oid == ent.get_meta().parent {
                 return Err(MetastoreError::CannotModifyBuiltin(ent.clone()));
             }
         }
@@ -1369,17 +1379,12 @@ mod tests {
     use std::collections::HashSet;
 
     use object_store::memory::InMemory;
-    use protogen::metastore::types::options::{DatabaseOptionsDebug, TableOptionsDebug};
+    use protogen::metastore::types::options::{DatabaseOptionsDebug, InternalColumnDefinition, TableOptionsDebug, TableOptionsInternal};
     use protogen::metastore::types::service::{
-        AlterDatabase,
-        CreateExternalDatabase,
-        CreateExternalTable,
-        CreateSchema,
-        CreateView,
-        DropDatabase,
-        DropSchema,
+        AlterDatabase, CreateExternalDatabase, CreateExternalTable, CreateSchema, CreateTable, CreateView, DropDatabase, DropSchema
     };
-    use sqlbuiltins::builtins::DEFAULT_CATALOG;
+    use datafusion::arrow::datatypes::DataType;
+    use sqlbuiltins::builtins::{DEFAULT_CATALOG, INTERNAL_SCHEMA};
 
     use super::*;
     use crate::storage::persist::Storage;
@@ -1953,5 +1958,57 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn try_modify_internal_schema() {
+        let db = new_catalog().await;
+        version(&db).await;
+
+        // Add view.
+        db.try_mutate(
+            version(&db).await,
+            vec![Mutation::CreateTable(CreateTable {
+                schema: INTERNAL_SCHEMA.to_string(),
+                name: "peach".to_string(),
+                if_not_exists: true,
+                or_replace: false,
+                options: TableOptionsInternal{
+                    columns: vec![InternalColumnDefinition{
+                        name: "luigi".to_string(),
+                        nullable: true,
+                        arrow_type: DataType::Utf8,
+                    }],
+                }
+            })],
+        )
+        .await
+        .unwrap_err();
+    }
+    
+    #[tokio::test]
+    async fn allow_modify_default_schema() {
+        let db = new_catalog().await;
+        version(&db).await;
+
+        // Add view.
+        db.try_mutate(
+            version(&db).await,
+            vec![Mutation::CreateTable(CreateTable {
+                schema: DEFAULT_SCHEMA.to_string(),
+                name: "peach".to_string(),
+                if_not_exists: true,
+                or_replace: false,
+                options: TableOptionsInternal{
+                    columns: vec![InternalColumnDefinition{
+                        name: "luigi".to_string(),
+                        nullable: true,
+                        arrow_type: DataType::Utf8,
+                    }],
+                }
+            })],
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/metastore/src/lib.rs
+++ b/crates/metastore/src/lib.rs
@@ -2,7 +2,7 @@
 pub mod errors;
 pub mod local;
 pub mod srv;
+pub mod util;
 
 mod database;
 mod storage;
-pub mod util;

--- a/crates/metastore/src/storage/lease.rs
+++ b/crates/metastore/src/storage/lease.rs
@@ -10,9 +10,9 @@
 //! to `SystemTime` during deserialization. `SystemTime` does not guarantee
 //! monotonicity, but since we're working with remote system, this doesn't
 //! matter. We're making the assumption that every system we're interacting with
-//! for locking is has a reasonably accurate clock. Since we should be updating
+//! for locking has a reasonably accurate clock. Since we should be updating
 //! the expiration time with plenty of time spare before the lease actually
-//! exprires, a little bit of clock drift doesn't matter. We should only be
+//! expires, a little bit of clock drift doesn't matter. We should only be
 //! concerned if it's on the order of tens of seconds.
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/metastore/src/storage/persist.rs
+++ b/crates/metastore/src/storage/persist.rs
@@ -63,7 +63,7 @@ impl Storage {
         {
             Ok(_) => return Ok(()),                       // Nothing to do.
             Err(ObjectStoreError::NotFound { .. }) => (), // Continue on creating new catalog.
-            Err(e) => return Err(e.into()),        // Something else happened...
+            Err(e) => return Err(e.into()),               // Something else happened...
         }
 
         debug!(%db_id, "initializing new catalog for database");

--- a/crates/metastore/src/storage/persist.rs
+++ b/crates/metastore/src/storage/persist.rs
@@ -63,7 +63,7 @@ impl Storage {
         {
             Ok(_) => return Ok(()),                       // Nothing to do.
             Err(ObjectStoreError::NotFound { .. }) => (), // Continue on creating new catalog.
-            Err(e) => return Err(e.into()),               // Something else happened...
+            Err(e) => return Err(e.into()),        // Something else happened...
         }
 
         debug!(%db_id, "initializing new catalog for database");

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -27,9 +27,6 @@ pub const DEFAULT_CATALOG: &str = "default";
 /// Default schema that's created on every startup.
 pub const DEFAULT_SCHEMA: &str = "public";
 
-/// Schema to store uploaded files
-pub const UPLOADS_SCHEMA: &str = "glare_uploads";
-
 /// Internal schema for system tables.
 pub const INTERNAL_SCHEMA: &str = "glare_catalog";
 
@@ -60,7 +57,6 @@ pub const CURRENT_SESSION_SCHEMA: &str = "current_session";
 ///
 /// General OID ranges:
 /// Builtin schemas: 16385 - 16400 (16 OIDs)
-///         Note (2024-02-08): We are at 16390
 /// Builtin tables: 16401 - 16500 (100 OIDs)
 ///
 /// Constructing the builtin catalog happens in metastore, and errors on
@@ -324,11 +320,6 @@ pub static SCHEMA_CURRENT_SESSION: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSch
     oid: 16389,
 });
 
-pub static SCHEMA_UPLOADS: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
-    name: UPLOADS_SCHEMA,
-    oid: 16390,
-});
-
 impl BuiltinSchema {
     pub fn builtins() -> Vec<&'static BuiltinSchema> {
         vec![
@@ -337,7 +328,6 @@ impl BuiltinSchema {
             &SCHEMA_INFORMATION,
             &SCHEMA_POSTGRES,
             &SCHEMA_CURRENT_SESSION,
-            &SCHEMA_UPLOADS,
         ]
     }
 }

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -324,7 +324,7 @@ pub static SCHEMA_CURRENT_SESSION: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSch
     oid: 16389,
 });
 
-pub static SCHEMA_USER_FILES: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
+pub static SCHEMA_UPLOADS: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
     name: UPLOADS_SCHEMA,
     oid: 16390,
 });
@@ -337,7 +337,7 @@ impl BuiltinSchema {
             &SCHEMA_INFORMATION,
             &SCHEMA_POSTGRES,
             &SCHEMA_CURRENT_SESSION,
-            &SCHEMA_USER_FILES,
+            &SCHEMA_UPLOADS,
         ]
     }
 }

--- a/crates/sqlbuiltins/src/builtins.rs
+++ b/crates/sqlbuiltins/src/builtins.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_CATALOG: &str = "default";
 pub const DEFAULT_SCHEMA: &str = "public";
 
 /// Schema to store uploaded files
-pub const USER_FILES_SCHEMA: &str = "user_files"; // REVIEW(stage/upload(s) etc)
+pub const UPLOADS_SCHEMA: &str = "glare_uploads";
 
 /// Internal schema for system tables.
 pub const INTERNAL_SCHEMA: &str = "glare_catalog";
@@ -325,7 +325,7 @@ pub static SCHEMA_CURRENT_SESSION: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSch
 });
 
 pub static SCHEMA_USER_FILES: Lazy<BuiltinSchema> = Lazy::new(|| BuiltinSchema {
-    name: USER_FILES_SCHEMA,
+    name: UPLOADS_SCHEMA,
     oid: 16390,
 });
 

--- a/crates/sqlbuiltins/src/validation.rs
+++ b/crates/sqlbuiltins/src/validation.rs
@@ -26,7 +26,7 @@ pub enum ValidationError {
 
 type Result<T> = std::result::Result<T, ValidationError>;
 
-/// Validate idents as per postgres identifier
+/// Validate identifiers as per [postgres identifier
 /// syntax](https://www.postgresql.org/docs/11/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)
 pub fn validate_object_name(name: &str) -> Result<()> {
     const POSTGRES_IDENT_MAX_LENGTH: usize = 63;

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -256,7 +256,7 @@ impl LocalSessionContext {
         // being used again.
         if !name.is_empty() && self.prepared.contains_key(&name) {
             return Err(internal!(
-                "named prepared statments must be deallocated before reuse, name: {}",
+                "named prepared statements must be deallocated before reuse, name: {}",
                 name
             ));
         }

--- a/crates/sqlexec/src/planner/context_builder.rs
+++ b/crates/sqlexec/src/planner/context_builder.rs
@@ -87,7 +87,7 @@ impl<'a> PartialContextProvider<'a> {
         Ok(provider)
     }
 
-    /// Find a table provider the given reference, taking into account the
+    /// Find a table provider for the given reference, taking into account the
     /// session's search path.
     ///
     /// This will attempt to resolve either a table, or a table returning
@@ -104,7 +104,7 @@ impl<'a> PartialContextProvider<'a> {
     ) -> Result<RuntimeAwareTableProvider, PlanError> {
         // Try to read from the environment first.
         //
-        // TODO: Determine if this is a behavior we want. This was move to the
+        // TODO: Determine if this is a behavior we want. This was moved to the
         // top to preempt reading from a remote session.
         if let TableReference::Bare { table } = &reference {
             if let Some(reader) = self.ctx.get_env_reader() {


### PR DESCRIPTION
Summary
---

This adds a restriction in metastore for creating entries on builtin schemas, other than the default schema (`public`).

<details><summary>Details</summary>
<p>

Initially, this added a builtin schema `glare_uploads` (#2614), but we later decided to remove it and instead use a table funcition.
At the time, `glare_uploads` was chosen because prefixing internal schemas with `glare_` reduces collision chance, and is what pg does.

<details><summary>Read more on pg_</summary>
<p>

From https://www.postgresql.org/docs/current/ddl-schemas.html

> Since system table names begin with pg_, it is best to avoid such names to ensure that you won't suffer a conflict if some future version defines a system table named the same as your table. (With the default search path, an unqualified reference to your table name would then be resolved as the system table instead.) System tables will continue to follow the convention of having names beginning with pg_, so that they will not conflict with unqualified user-table names so long as users avoid the pg_ prefix.

</p>
</details> 

<details><summary>Progress</summary>
<p>

- [x] Add `glare_uploads` schema
- [x] Make schema read-only
- [x] Add test(s) 

</p>
</details> 
</p>
</details> 