### PR TITLE
chore(ci): move postgres tests and simplify tunnels testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,7 +625,7 @@ jobs:
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 
-          just slt-bin --protocol=rpc ${{matrix.settings.path}}
+          just slt-bin --protocol=rpc  --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -424,38 +424,15 @@ jobs:
           # depend on this.
           unset GOOGLE_APPLICATION_CREDENTIALS
 
-          # Prepare SLT (Postgres)
-          POSTGRES_TEST_DB=$(./scripts/create-test-postgres-db.sh)
-          export POSTGRES_CONN_STRING=$(echo "$POSTGRES_TEST_DB" | sed -n 1p)
-          export POSTGRES_TUNNEL_SSH_CONN_STRING=$(echo "$POSTGRES_TEST_DB" | sed -n 2p)
-
           # Prepare SLT (fake GCS server)
           ./scripts/create-test-gcs-store.sh
 
-          echo "-------------------------------- WITHOUT TUNNEL TEST --------------------------------"
-          # Run all data source tests without running tunnel tests or the basic
-          # SLT tests.
-          just slt-bin --exclude 'sqllogictests/*' \
-            --exclude '*/tunnels/ssh' \
-            --exclude 'sqllogictests_snowflake/*' \
-            --exclude 'sqllogictests_cassandra/*' \
-            --exclude 'sqllogictests_clickhouse/*' \
-            --exclude 'sqllogictests_sqlserver/*' \
-            --exclude 'sqllogictests_mongodb/*' \
-            --exclude 'sqllogictests_mysql/*' \
-
-          echo "-------------------------------- WITH TUNNEL TEST --------------------------------"
-          # SSH tests are prone to fail if we make a lot of connections at the
-          # same time. Hence, it makes sense to run all the SSH tests one-by-one
-          # in order to test the SSH tunnels (which is our aim).
-          just slt-bin  --jobs=1 '*/tunnels/ssh' --exclude 'sqllogictests_mysql/*'
-
-          # TODO: move these into the datasource-integration-tests job
-
           echo "-------------------------------- RPC TESTS --------------------------------"
+          # TODO: move these into the datasource-integration-tests job
 
           echo "--------------------------  BigQuery -------------------------- "
           just slt-bin --protocol=rpc 'sqllogictests_bigquery/*'
+
           echo "--------------------------  Iceberg -------------------------- "
           just slt-bin --protocol=rpc 'sqllogictests_iceberg/*'
 
@@ -464,9 +441,6 @@ jobs:
 
           echo "--------------------------  Object Store -------------------------- "
           just slt-bin --protocol=rpc 'sqllogictests_object_store/*'
-
-          echo "--------------------------  Postgres -------------------------- "
-          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' 'sqllogictests_postgres/*'
 
           echo "--------------------------  Fake GCS server with a subdirectory -------------------------- "
           just slt-bin -l gs://$TEST_BUCKET/path/to/folder/1 -o service_account_path=/tmp/fake-gcs-creds.json 'sqllogictests_native/*'
@@ -604,7 +578,7 @@ jobs:
             path: "sqllogictests_cassandra/*"
             prepare: |
               export CASSANDRA_CONN_STRING=$(./scripts/create-test-cassandra-db.sh | tail -n 1)
-          - name: Mysql
+          - name: MySQL
             path: "sqllogictests_mysql/*"
             prepare: |
               ./scripts/prepare-testdata.sh
@@ -617,11 +591,18 @@ jobs:
               ./scripts/prepare-testdata.sh
               export MONGO_CONN_STRING=$(./scripts/create-test-mongodb.sh)
               ./scripts/create-fixture-mongodb.sh
-          - name: Sqlserver
+          - name: SQLServer
             path: "sqllogictests_sqlserver/*"
             prepare: |
               ./scripts/prepare-testdata.sh
               export SQL_SERVER_CONN_STRING=$(./scripts/create-test-sqlserver-db.sh)
+          - name: PostgreSQL
+            path: "sqllogictests_postgres/*"
+            prepare: |
+               ./scripts/prepare-testdata.sh
+               export POSTGRES_TEST_DB=$(./scripts/create-test-postgres-db.sh)
+               export POSTGRES_CONN_STRING=$(echo "$POSTGRES_TEST_DB" | sed -n 1p)
+               export POSTGRES_TUNNEL_SSH_CONN_STRING=$(echo "$POSTGRES_TEST_DB" | sed -n 2p)
     runs-on: ubuntu-latest
     needs: ["sql-logic-tests"]
     steps:
@@ -649,7 +630,7 @@ jobs:
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 
           # for sqlserver, skip flightsql because the suite takes 4-5
-          # minutes, and Sqlserver is the longest/last task to finish
+          # minutes, and sqlserver is the longest/last task to finish
           [ "${{matrix.settings.name}}" = "Sqlserver" ] && exit 0
 
           just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,7 +625,7 @@ jobs:
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 
-          just slt-bin --protocol=rpc  --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+          just slt-bin --protocol=rpc ${{matrix.settings.path}}
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,12 +625,12 @@ jobs:
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 
-          just slt-bin --protocol=rpc --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+          just slt-bin --protocol=rpc ${{matrix.settings.path}}
 
           [ "${{matrix.settings.name}}" = "MongoDB" ] && ./scripts/create-fixture-mongodb.sh
 
           # for sqlserver, skip flightsql because the suite takes 4-5
           # minutes, and sqlserver is the longest/last task to finish
-          [ "${{matrix.settings.name}}" = "Sqlserver" ] && exit 0
+          [ "${{matrix.settings.name}}" = "SQLServer" ] && exit 0
 
-          just slt-bin --protocol=flightsql --exclude '*/tunnels/ssh' ${{matrix.settings.path}}
+          just slt-bin --protocol=flightsql ${{matrix.settings.path}}

--- a/crates/slt/src/hooks.rs
+++ b/crates/slt/src/hooks.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 use tokio::process::Command;
 use tokio::time::{sleep as tokio_sleep, Instant};
 use tokio_postgres::{Client, Config};
-use tracing::error;
+use tracing::{error, warn};
 
 use super::test::{Hook, TestClient};
 

--- a/crates/slt/src/hooks.rs
+++ b/crates/slt/src/hooks.rs
@@ -192,17 +192,17 @@ impl Hook for SshTunnelHook {
         client: TestClient,
         vars: &mut HashMap<String, String>,
     ) -> Result<()> {
-        let client = match client {
-            TestClient::Pg(client) => client,
-            TestClient::Rpc(_) => {
-                error!("cannot run SSH tunnel test with the RPC protocol. Skipping...");
-                return Ok(());
-            }
-            TestClient::FlightSql(_) => {
-                error!("cannot run SSH tunnel test on FlightSQL protocol. Skipping...");
-                return Ok(());
-            }
-        };
+        // let client = match client {
+        //     TestClient::Pg(client) => client,
+        //     TestClient::Rpc(_) => {
+        //         error!("cannot run SSH tunnel test with the RPC protocol. Skipping...");
+        //         return Ok(());
+        //     }
+        //     TestClient::FlightSql(_) => {
+        //         error!("cannot run SSH tunnel test on FlightSQL protocol. Skipping...");
+        //         return Ok(());
+        //     }
+        // };
 
         let mut err = None;
         // Try upto 5 times

--- a/crates/slt/src/hooks.rs
+++ b/crates/slt/src/hooks.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 use tokio::process::Command;
 use tokio::time::{sleep as tokio_sleep, Instant};
 use tokio_postgres::{Client, Config};
-use tracing::warn;
+use tracing::error;
 
 use super::test::{Hook, TestClient};
 
@@ -194,9 +194,12 @@ impl Hook for SshTunnelHook {
     ) -> Result<()> {
         let client = match client {
             TestClient::Pg(client) => client,
-            TestClient::Rpc(_) => return Err(anyhow!("cannot run SSH tunnel test on rpc")),
+            TestClient::Rpc(_) => {
+                error!("cannot run SSH tunnel test with the RPC protocol. Skipping...");
+                return Ok(());
+            }
             TestClient::FlightSql(_) => {
-                warn!("cannot run SSH tunnel test on flight protocol. Skipping...");
+                error!("cannot run SSH tunnel test on FlightSQL protocol. Skipping...");
                 return Ok(());
             }
         };

--- a/crates/slt/src/test.rs
+++ b/crates/slt/src/test.rs
@@ -47,8 +47,9 @@ pub trait Hook: Send + Sync {
         _config: &Config,
         _client: TestClient,
         _vars: &mut HashMap<String, String>,
-    ) -> Result<()> {
-        Ok(())
+    ) -> Result<bool> {
+        // TODO: make enum for skip/continue rather than booleans
+        Ok(true)
     }
 
     async fn post(


### PR DESCRIPTION
I started with the intention of just having the postgres tasks in
their test, but took the oppertunity to:

- clarify some capitalization that was bugging me (since I'll need to
  update the required builders, which are keyed off of this string).

- while I was editing this I realized that `tunnes/ssh` tests which we
  go through a lot of trouble to test with/without, are only present
  for mysql and postgres, and the only reason to skip running the
  tunnel tests, given the execution of the SLT runner and the hooks,
  is to omit running the `basic.slti` an extra time (but only for
  mysql/postgres), and given the new test architecture I think its
  safe to dispense with (and the invocations were redundnat in the
  main case.)