### PR TITLE
fix(virtual_listing): signatures

### DIFF
--- a/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
+++ b/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
@@ -46,6 +46,7 @@ impl ConstBuiltinFunction for ListSchemas {
     const DESCRIPTION: &'static str = "Lists schemas in a database";
     const EXAMPLE: &'static str = "SELECT * FROM list_schemas('database')";
     const FUNCTION_TYPE: FunctionType = FunctionType::TableReturning;
+
     fn signature(&self) -> Option<Signature> {
         Some(Signature::uniform(
             1,

--- a/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
+++ b/crates/sqlbuiltins/src/functions/table/virtual_listing.rs
@@ -46,6 +46,13 @@ impl ConstBuiltinFunction for ListSchemas {
     const DESCRIPTION: &'static str = "Lists schemas in a database";
     const EXAMPLE: &'static str = "SELECT * FROM list_schemas('database')";
     const FUNCTION_TYPE: FunctionType = FunctionType::TableReturning;
+    fn signature(&self) -> Option<Signature> {
+        Some(Signature::uniform(
+            1,
+            vec![DataType::Utf8],
+            Volatility::Stable,
+        ))
+    }
 }
 
 #[async_trait]
@@ -103,7 +110,7 @@ impl ConstBuiltinFunction for ListTables {
     const FUNCTION_TYPE: FunctionType = FunctionType::TableReturning;
     fn signature(&self) -> Option<Signature> {
         Some(Signature::uniform(
-            3,
+            2,
             vec![DataType::Utf8],
             Volatility::Stable,
         ))


### PR DESCRIPTION
A very minor fix to df signature implementations for `list_schemas` (missing) and `list_tables` (wrong len) that I found while working on something else.