### PR TITLE
feat: read_google_sheets table function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,6 @@ version = "0.8.5"
 dependencies = [
  "datafusion",
  "logutil",
- "metastore",
  "object_store",
  "parking_lot",
  "protogen",
@@ -2438,6 +2437,7 @@ dependencies = [
  "env_logger",
  "futures",
  "ioutil",
+ "object_store",
  "once_cell",
  "parking_lot",
  "paste",
@@ -2445,6 +2445,7 @@ dependencies = [
  "protogen",
  "rand",
  "regex",
+ "reqwest",
  "rstest",
  "serde_json",
  "telemetry",
@@ -7765,6 +7766,7 @@ dependencies = [
  "telemetry",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/crates/datafusion_ext/Cargo.toml
+++ b/crates/datafusion_ext/Cargo.toml
@@ -15,24 +15,26 @@ unicode_expressions = []
 ioutil = { path = "../ioutil" }
 telemetry = { path = "../telemetry" }
 catalog = { path = "../catalog" }
-serde_json = { workspace = true }
-datafusion = { workspace = true }
-async-trait = { workspace = true }
-async-recursion = "1.0.4"
-uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
-regex = "1.10"
-once_cell = "1.19.0"
-tracing = { workspace = true }
-thiserror.workspace = true
 decimal = { path = "../decimal" }
 protogen = { path = "../protogen" }
 pgrepr = { path = "../pgrepr" }
+serde_json = { workspace = true }
+datafusion = { workspace = true }
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
 futures = { workspace = true }
+thiserror = { workspace = true }
+object_store = { workspace = true }
+uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+async-recursion = "1.0.4"
+regex = "1.10"
+once_cell = "1.19.0"
 parking_lot = "0.12.1"
 bson = "2.9.0"
 
 [dev-dependencies]
-chrono.workspace = true
+chrono = { workspace = true }
 ctor = "0.2.6"
 env_logger = "0.10"
 paste = "^1.0"

--- a/crates/datafusion_ext/src/errors.rs
+++ b/crates/datafusion_ext/src/errors.rs
@@ -39,8 +39,17 @@ pub enum ExtensionError {
     #[error(transparent)]
     ListingErrBoxed(#[from] Box<dyn std::error::Error + Sync + Send>),
 
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
     #[error("object store: {0}")]
-    ObjectStore(String),
+    ObjectStoreSource(String),
+
+    #[error(transparent)]
+    ObjectStore(#[from] object_store::Error),
+
+    #[error(transparent)]
+    ObjectStorePath(#[from] object_store::path::Error),
 
     #[error("{0}")]
     String(String),

--- a/crates/datasources/src/object_store/errors.rs
+++ b/crates/datasources/src/object_store/errors.rs
@@ -51,6 +51,6 @@ impl From<ObjectStoreSourceError> for ArrowError {
 
 impl From<ObjectStoreSourceError> for ExtensionError {
     fn from(e: ObjectStoreSourceError) -> Self {
-        ExtensionError::ObjectStore(e.to_string())
+        ExtensionError::ObjectStoreSource(e.to_string())
     }
 }

--- a/crates/sqlbuiltins/Cargo.toml
+++ b/crates/sqlbuiltins/Cargo.toml
@@ -20,16 +20,17 @@ async-trait = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }
 object_store = { workspace = true }
-thiserror.workspace = true
 tracing = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
 uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+memoize = { version = "0.4.2", features = ["full"] }
+tokio-util = { version = "*" }
 once_cell = "1.19.0"
 num-traits = "0.2.18"
 strum = "0.25.0"
 kdl = "5.0.0-alpha.1"
 siphasher = "1.0.0"
 fnv = "1.0.7"
-memoize = { version = "0.4.2", features = ["full"] }
 async-openai = "0.18.3"
-tokio.workspace = true
-reqwest.workspace = true

--- a/crates/sqlbuiltins/src/functions/table/google_sheets.rs
+++ b/crates/sqlbuiltins/src/functions/table/google_sheets.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::file_format::FileFormat;
+use datafusion::datasource::TableProvider;
+use datafusion_ext::errors::ExtensionError;
+use datafusion_ext::functions::{FuncParamValue, TableFuncContextProvider};
+use futures::StreamExt;
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::{ObjectMeta, ObjectStore};
+
+use crate::functions::table::{RuntimePreference, TableFunc};
+use crate::functions::{ConstBuiltinFunction, FunctionType};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GoogleSheets;
+
+impl ConstBuiltinFunction for GoogleSheets {
+    const NAME: &'static str = "read_google_sheet";
+    const DESCRIPTION: &'static str = "Reads a google sheet.";
+    const EXAMPLE: &'static str = "SELECT * FROM read_google_sheet('[key]')";
+    const FUNCTION_TYPE: FunctionType = FunctionType::TableReturning;
+}
+
+#[async_trait]
+impl TableFunc for GoogleSheets {
+    fn detect_runtime(
+        &self,
+        _args: &[FuncParamValue],
+        _parent: RuntimePreference,
+    ) -> Result<RuntimePreference, ExtensionError> {
+        Ok(RuntimePreference::Remote)
+    }
+
+    async fn create_provider(
+        &self,
+        ctx: &dyn TableFuncContextProvider,
+        args: Vec<FuncParamValue>,
+        mut opts: HashMap<String, FuncParamValue>,
+    ) -> Result<Arc<dyn TableProvider>, ExtensionError> {
+        if args.len() == 0 {
+            return Err(ExtensionError::InvalidNumArgs);
+        }
+        let sheet_id: String = opts
+            .get("sheet")
+            .map(|val| format!("&sheet={}", val).to_string())
+            .unwrap_or_default();
+
+        let key: String = args.into_iter().next().unwrap().try_into()?;
+        let url = format!(
+            "https://docs.google.com/spreadsheet/ccc?key={}{}&output=csv",
+            key, sheet_id
+        );
+
+        let stream = reqwest::get(url).await?.bytes_stream().await?;
+        let sheet_path = Path::parse("sheet")?;
+
+        let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let  = obj_store.put(&sheet_path, stream).await?;
+        let obj_meta = obj_store
+            .list(Some(&sheet_path))
+            .collect::<Vec<Result<ObjectMeta, _>>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let frmt: Box<dyn FileFormat> = Box::new(
+            CsvFormat::default()
+                .with_schema_infer_max_rec(Some(
+                    opts.get("schema_infer_max")
+                        .map(|fpv| {
+                            i64::try_from(fpv.to_owned()).map_err(|_| {
+                                ExtensionError::InvalidParamValue {
+                                    param: "schema_infer_max".to_string(),
+                                    expected: "integer",
+                                }
+                            })
+                        })
+                        .unwrap_or_else(|| Ok(1000))? as usize,
+                ))
+                .with_has_header(
+                    opts.get("has_header")
+                        .map(|fpv| bool::try_from(fpv.to_owned()))
+                        .unwrap_or_else(|| Ok(true))?,
+                )
+                .with_delimiter(
+                    opts.get("delimiter")
+                        .map(|fpv| {
+                            String::try_from(fpv.to_owned())
+                                .map(|v| v.as_bytes().first().map(|v| v.to_owned()).unwrap_or(b','))
+                        })
+                        .unwrap_or_else(|| Ok(b','))?,
+                )
+                .with_quote(
+                    opts.get("quote")
+                        .map(|fpv| {
+                            String::try_from(fpv.to_owned())
+                                .map(|v| v.as_bytes().first().map(|v| v.to_owned()).unwrap_or(b'"'))
+                        })
+                        .unwrap_or_else(|| Ok(b'"'))?,
+                ),
+        );
+
+        let _schema = frmt
+            .infer_schema(&ctx.get_session_state(), &obj_store, obj_meta.as_slice())
+            .await?;
+
+        
+        panic!()
+    }
+}

--- a/crates/sqlbuiltins/src/functions/table/mod.rs
+++ b/crates/sqlbuiltins/src/functions/table/mod.rs
@@ -6,6 +6,7 @@ mod clickhouse;
 mod delta;
 mod excel;
 mod generate_series;
+mod google_sheets;
 mod iceberg;
 mod json;
 mod lance;
@@ -39,6 +40,7 @@ use self::clickhouse::ReadClickhouse;
 use self::delta::DeltaScan;
 use self::excel::ExcelScan;
 use self::generate_series::GenerateSeries;
+use self::google_sheets::GoogleSheets;
 use self::iceberg::data_files::IcebergDataFiles;
 use self::iceberg::scan::IcebergScan;
 use self::iceberg::snapshots::IcebergSnapshots;
@@ -100,12 +102,14 @@ impl BuiltinTableFuncs {
             Arc::new(READ_JSON),
             Arc::new(BsonScan),
             Arc::new(JsonScan),
+            // Spreadsheets
+            Arc::new(GoogleSheets),
+            Arc::new(ExcelScan),
             // Data lakes
             Arc::new(DeltaScan),
             Arc::new(IcebergScan),
             Arc::new(IcebergSnapshots),
             Arc::new(IcebergDataFiles),
-            Arc::new(ExcelScan),
             Arc::new(LanceScan),
             // Listing
             Arc::new(ListSchemas),

--- a/crates/sqlbuiltins/src/functions/table/object_store.rs
+++ b/crates/sqlbuiltins/src/functions/table/object_store.rs
@@ -362,7 +362,7 @@ impl<Opts> ObjScanTableFunc<Opts> {
 ///
 /// If the file is detected to be local, the table provider will be wrapped in a
 /// local table hint.
-async fn get_table_provider(
+pub(crate) async fn get_table_provider(
     ctx: &dyn TableFuncContextProvider,
     ft: Arc<dyn FileFormat>,
     access: Arc<dyn ObjStoreAccess>,


### PR DESCRIPTION
I got pretty far yesterday, but would like to get more eyes on how to do more of this. 

I think some the challenge is that the object store reads (part? all?)
of the CSV file twice (once for schema inference and once for the
actual load, and I _think_ if we read the file into memory entirely
then we won't end up downloading it twice, but then it'll all be in
memory, and that also seems bad. 

Not sure what the right thing to do here is, probably pulling the data
twice is ok.

Would be nice to have some folks spot this and see if there's
something I've missed.