### PR TITLE
chore(infer_func_for_file): remove dead code

### DIFF
--- a/crates/datafusion_ext/src/planner/relation/mod.rs
+++ b/crates/datafusion_ext/src/planner/relation/mod.rs
@@ -266,10 +266,6 @@ fn infer_func_for_file(path: &str) -> Result<OwnedTableReference> {
             schema: "public".into(),
             table: "read_bson".into(),
         },
-        "xlsx" => OwnedTableReference::Partial {
-            schema: "public".into(),
-            table: "read_excel".into(),
-        },
         ext => {
             if let Ok(compression_type) = ext.parse::<FileCompressionType>() {
                 let ext = compression_type.get_ext();


### PR DESCRIPTION
Duplicated match arm (dead code) causing lint failure in CI (see: https://github.com/GlareDB/glaredb/actions/runs/7991177287/job/21822034352)