### PR TITLE
feat: support for `create external table excel <options>`

### DIFF
--- a/crates/datasources/src/excel/errors.rs
+++ b/crates/datasources/src/excel/errors.rs
@@ -1,0 +1,70 @@
+use std::fmt::Debug;
+
+use calamine::{self, XlsxError};
+use datafusion::arrow::error::ArrowError;
+use datafusion::error::DataFusionError;
+use datafusion_ext::errors::ExtensionError;
+
+use crate::object_store::errors::ObjectStoreSourceError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExcelError {
+    #[error("Failed to load XLSX: {0}")]
+    Load(String),
+    #[error("Failed to create record batch: {0}")]
+    CreateRecordBatch(#[from] ArrowError),
+    #[error(transparent)]
+    CalamineError(#[from] calamine::XlsxError),
+    #[error(transparent)]
+    ObjectStoreError(#[from] object_store::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CalamineError {
+    #[error("Failed to open workbook: {0}")]
+    OpenWorkbook(#[from] calamine::XlsxError),
+}
+
+
+impl From<calamine::Error> for ExcelError {
+    fn from(error: calamine::Error) -> Self {
+        ExcelError::Load(error.to_string())
+    }
+}
+
+
+impl From<ExcelError> for DataFusionError {
+    fn from(e: ExcelError) -> Self {
+        DataFusionError::Execution(e.to_string())
+    }
+}
+
+impl From<CalamineError> for ExcelError {
+    fn from(error: CalamineError) -> Self {
+        ExcelError::Load(error.to_string())
+    }
+}
+
+impl From<ObjectStoreSourceError> for ExcelError {
+    fn from(error: ObjectStoreSourceError) -> Self {
+        ExcelError::Load(error.to_string())
+    }
+}
+
+impl From<std::io::Error> for ExcelError {
+    fn from(error: std::io::Error) -> Self {
+        ExcelError::Load(error.to_string())
+    }
+}
+
+impl From<ExcelError> for calamine::XlsxError {
+    fn from(e: ExcelError) -> Self {
+        XlsxError::FileNotFound(e.to_string())
+    }
+}
+
+impl From<ExcelError> for ExtensionError {
+    fn from(e: ExcelError) -> Self {
+        ExtensionError::String(e.to_string())
+    }
+}

--- a/crates/datasources/src/excel/mod.rs
+++ b/crates/datasources/src/excel/mod.rs
@@ -1,89 +1,109 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use calamine::{open_workbook, DataType as CalamineDataType, Range, Reader, Xlsx};
+use calamine::{open_workbook, DataType as CalamineDataType, Range, Reader, Sheets, Xlsx};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Date64Array, PrimitiveArray, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Float64Type, Int64Type, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use object_store::ObjectStore;
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Failed to load XLSX: {msg}")]
-    Load { msg: String },
-    #[error("Failed to create record batch: {0}")]
-    CreateRecordBatch(#[from] datafusion::arrow::error::ArrowError),
-    #[error("Failed to open workbook: {0}")]
-    OpenWorkbook(#[from] calamine::XlsxError),
-}
+use crate::common::url::DatasourceUrl;
+use crate::object_store::generic::GenericStoreAccess;
+use crate::object_store::ObjStoreAccess;
 
-fn infer_value_type(v: &calamine::Data) -> Result<DataType, Error> {
-    match v {
-        calamine::Data::Int(_) => Ok(DataType::Int64),
-        calamine::Data::Float(_) => Ok(DataType::Float64),
-        calamine::Data::Bool(_) => Ok(DataType::Boolean),
-        calamine::Data::String(_) => Ok(DataType::Utf8),
-        calamine::Data::Error(e) => Err(Error::Load { msg: e.to_string() }),
-        calamine::Data::DateTime(_) => Ok(DataType::Date64),
-        calamine::Data::Empty => Ok(DataType::Null),
-        _ => Err(Error::Load {
-            msg: "Failed to parse the cell value".to_owned(),
-        }),
-    }
-}
+pub mod errors;
+pub mod stream;
+pub mod table;
 
-fn infer_schema(
-    r: &Range<calamine::Data>,
+use errors::ExcelError;
+
+pub struct ExcelTable {
+    cell_range: Range<calamine::Data>,
     has_header: bool,
-    infer_schema_length: usize,
-) -> Result<Schema, Error> {
-    let mut col_types: HashMap<&str, HashSet<DataType>> = HashMap::new();
-    let mut rows = r.rows();
-    let col_names: Vec<String> = rows
-        .next()
-        .unwrap()
-        .iter()
-        .enumerate()
-        .map(
-            |(i, c)| match (has_header, c.get_string().map(|s| s.to_string())) {
-                (true, Some(s)) => Ok(s),
-                (true, None) => Err(Error::Load {
-                    msg: "failed to parse header".to_string(),
-                }),
-                (false, _) => Ok(format!("col{}", i)),
-            },
-        )
-        .collect::<Result<_, _>>()?;
+}
 
-    for row in rows.take(infer_schema_length) {
-        for (i, col_val) in row.iter().enumerate() {
-            let col_name = col_names.get(i).unwrap();
-            let col_type = infer_value_type(col_val).unwrap();
-            if col_type == DataType::Null {
-                continue;
+impl ExcelTable {
+    pub async fn open(
+        store_access: GenericStoreAccess,
+        source_url: DatasourceUrl,
+        sheet_name: Option<&str>,
+        has_header: bool,
+    ) -> Result<ExcelTable, ExcelError> {
+        match source_url {
+            DatasourceUrl::File(path) => {
+                let path = ioutil::resolve_path(&path)?;
+                let mut sheet = calamine::open_workbook_auto(path)?;
+
+                let first_sheet = sheet_name.map(Cow::Borrowed).unwrap_or_else(|| {
+                    let sheets = sheet.sheet_names();
+                    let first = sheets.first().expect("file has a sheet");
+                    Cow::Owned(first.clone())
+                });
+
+                Ok(ExcelTable {
+                    cell_range: sheet.worksheet_range(&first_sheet)?,
+                    has_header,
+                })
             }
-            let entry = col_types.entry(col_name).or_default();
-            entry.insert(col_type);
+
+            DatasourceUrl::Url(_) => {
+                let store = store_access.create_store()?;
+                let list = store_access
+                    .list_globbed(&store, source_url.path().as_ref())
+                    .await?;
+
+                if list.is_empty() {
+                    return Err(ExcelError::Load(
+                        "could not find .xlsx file at remote".to_string(),
+                    ));
+                };
+
+                let meta = list.first().expect("remote file has a sheet");
+                let bs = store.get(&meta.location).await?.bytes().await?;
+
+                let buffer = Cursor::new(bs);
+                let mut sheets: Sheets<_> = calamine::open_workbook_auto_from_rs(buffer).unwrap();
+
+                let first_sheet = sheet_name.map(Cow::Borrowed).unwrap_or_else(|| {
+                    let sheets = sheets.sheet_names();
+                    let first = sheets.first().unwrap();
+                    Cow::Owned(first.clone())
+                });
+
+                Ok(ExcelTable {
+                    cell_range: sheets.worksheet_range(&first_sheet).unwrap(),
+                    has_header,
+                })
+            }
         }
     }
+}
 
-    let fields: Vec<Field> = col_names
-        .iter()
-        .map(|col_name| {
-            let set = col_types.entry(col_name).or_insert_with(|| {
-                let mut set = HashSet::new();
-                set.insert(DataType::Utf8);
-                set
-            });
+pub async fn read_excel_impl(
+    path: &PathBuf,
+    sheet_name: Option<&str>,
+    has_header: bool,
+    infer_schema_length: usize,
+) -> Result<MemTable, ExcelError> {
+    let mut workbook: Xlsx<_> = open_workbook(path).unwrap();
+    let sheet = sheet_name.map(Cow::Borrowed).unwrap_or_else(|| {
+        let sheets = workbook.sheet_names();
+        let first = sheets.first().expect("sheet is not empty");
+        Cow::Owned(first.clone())
+    });
 
-            let mut dt_iter = set.iter().cloned();
-            let dt = dt_iter.next().unwrap_or(DataType::Utf8);
-            Field::new(col_name.replace(' ', "_"), dt, true)
-        })
-        .collect();
-
-    Ok(Schema::new(fields))
+    if let Ok(r) = workbook.worksheet_range(&sheet) {
+        let batch = xlsx_sheet_value_to_record_batch(r, has_header, infer_schema_length)?;
+        let schema_ref = batch.schema();
+        let partitions = vec![vec![batch]];
+        Ok(MemTable::try_new(schema_ref, partitions).unwrap())
+    } else {
+        Err(ExcelError::Load("Failed to open .xlsx file.".to_owned()))
+    }
 }
 
 // TODO: vectorize this to improve performance
@@ -92,7 +112,7 @@ fn xlsx_sheet_value_to_record_batch(
     r: Range<calamine::Data>,
     has_header: bool,
     infer_schema_length: usize,
-) -> Result<RecordBatch, Error> {
+) -> Result<RecordBatch, ExcelError> {
     let schema = infer_schema(&r, has_header, infer_schema_length)?;
     let arrays = schema
         .fields()
@@ -143,27 +163,69 @@ fn xlsx_sheet_value_to_record_batch(
 
     Ok(RecordBatch::try_new(Arc::new(schema), arrays)?)
 }
-pub async fn read_excel_impl(
-    path: &PathBuf,
-    sheet_name: Option<&str>,
+
+pub fn infer_schema(
+    r: &Range<calamine::Data>,
     has_header: bool,
     infer_schema_length: usize,
-) -> Result<datafusion::datasource::MemTable, Error> {
-    let mut workbook: Xlsx<_> = open_workbook(path)?;
-    let sheet = sheet_name.map(Cow::Borrowed).unwrap_or_else(|| {
-        let sheets = workbook.sheet_names();
-        let first = sheets.first().unwrap();
-        Cow::Owned(first.clone())
-    });
+) -> Result<Schema, ExcelError> {
+    let mut col_types: HashMap<&str, HashSet<DataType>> = HashMap::new();
+    let mut rows = r.rows();
+    let col_names: Vec<String> = rows
+        .next()
+        .unwrap()
+        .iter()
+        .enumerate()
+        .map(
+            |(i, c)| match (has_header, c.get_string().map(|s| s.to_string())) {
+                (true, Some(s)) => Ok(s),
+                (true, None) => Err(ExcelError::Load("failed to parse header".to_string())),
+                (false, _) => Ok(format!("col{}", i)),
+            },
+        )
+        .collect::<Result<_, _>>()?;
 
-    if let Ok(r) = workbook.worksheet_range(&sheet) {
-        let batch = xlsx_sheet_value_to_record_batch(r, has_header, infer_schema_length)?;
-        let schema_ref = batch.schema();
-        let partitions = vec![vec![batch]];
-        Ok(datafusion::datasource::MemTable::try_new(schema_ref, partitions).unwrap())
-    } else {
-        Err(Error::Load {
-            msg: "Failed to open .xlsx file.".to_owned(),
+    for row in rows.take(infer_schema_length) {
+        for (i, col_val) in row.iter().enumerate() {
+            let col_name = col_names.get(i).unwrap();
+            let col_type = infer_value_type(col_val).unwrap();
+            if col_type == DataType::Null {
+                continue;
+            }
+            let entry = col_types.entry(col_name).or_default();
+            entry.insert(col_type);
+        }
+    }
+
+    let fields: Vec<Field> = col_names
+        .iter()
+        .map(|col_name| {
+            let set = col_types.entry(col_name).or_insert_with(|| {
+                let mut set = HashSet::new();
+                set.insert(DataType::Utf8);
+                set
+            });
+
+            let mut dt_iter = set.iter().cloned();
+            let dt = dt_iter.next().unwrap_or(DataType::Utf8);
+            Field::new(col_name.replace(' ', "_"), dt, true)
         })
+        .collect();
+
+    Ok(Schema::new(fields))
+}
+
+fn infer_value_type(v: &calamine::Data) -> Result<DataType, ExcelError> {
+    match v {
+        calamine::Data::Int(_) => Ok(DataType::Int64),
+        calamine::Data::Float(_) => Ok(DataType::Float64),
+        calamine::Data::Bool(_) => Ok(DataType::Boolean),
+        calamine::Data::String(_) => Ok(DataType::Utf8),
+        calamine::Data::Error(e) => Err(ExcelError::Load(e.to_string())),
+        calamine::Data::DateTime(_) => Ok(DataType::Date64),
+        calamine::Data::Empty => Ok(DataType::Null),
+        _ => Err(ExcelError::Load(
+            "Failed to parse the cell value".to_owned(),
+        )),
     }
 }

--- a/crates/datasources/src/excel/stream.rs
+++ b/crates/datasources/src/excel/stream.rs
@@ -1,0 +1,46 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use calamine::{Data, Range};
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion::physical_plan::RecordBatchStream;
+use futures::{Stream, StreamExt};
+
+use crate::excel;
+use crate::excel::errors::ExcelError;
+
+pub struct ExcelStream {
+    schema: Arc<Schema>,
+    stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, ExcelError>> + Send>>,
+}
+
+impl ExcelStream {
+    pub fn new(r: Range<Data>, header: bool, schema: Arc<Schema>) -> Self {
+        let schema = schema.clone();
+        let inferred_schema_length = r.width();
+
+        let batch = excel::xlsx_sheet_value_to_record_batch(r, header, inferred_schema_length);
+        let stream = Box::pin(futures::stream::iter(vec![batch]));
+
+        Self { schema, stream }
+    }
+}
+
+impl Stream for ExcelStream {
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.stream
+            .poll_next_unpin(cx)
+            .map_err(DataFusionError::from)
+    }
+}
+
+impl RecordBatchStream for ExcelStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/crates/datasources/src/excel/table.rs
+++ b/crates/datasources/src/excel/table.rs
@@ -1,0 +1,153 @@
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{Schema, SchemaRef as ArrowSchemaRef};
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DatafusionResult};
+use datafusion::execution::context::{SessionState, TaskContext};
+use datafusion::logical_expr::{Expr, TableType};
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs,
+    DisplayFormatType,
+    ExecutionPlan,
+    Partitioning,
+    SendableRecordBatchStream,
+    Statistics,
+};
+
+use super::errors::ExcelError;
+use crate::excel;
+use crate::excel::stream::ExcelStream;
+use crate::excel::ExcelTable;
+
+pub struct ExcelTableProvider {
+    cell_range: calamine::Range<calamine::Data>,
+    header: bool,
+    schema: Arc<Schema>,
+}
+
+impl ExcelTableProvider {
+    pub async fn try_new(t: ExcelTable) -> Result<Self, ExcelError> {
+        let cell_range = t.cell_range;
+        let schema_len = cell_range.width();
+        let schema = excel::infer_schema(&cell_range, t.has_header, schema_len)?;
+
+        Ok(ExcelTableProvider {
+            schema: Arc::new(schema),
+            cell_range,
+            header: t.has_header,
+        })
+    }
+}
+
+#[async_trait]
+impl TableProvider for ExcelTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _ctx: &SessionState,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
+        // Basic Projection
+        let projected_schema = match projection {
+            Some(projection) if !projection.is_empty() => {
+                Arc::new(self.schema.project(projection)?)
+            }
+            _ => self.schema.clone(),
+        };
+
+        Ok(Arc::new(ExcelExecutionPlan {
+            arrow_schema: projected_schema,
+            cell_range: self.cell_range.clone(),
+            header: self.header,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct ExcelExecutionPlan {
+    arrow_schema: ArrowSchemaRef,
+    cell_range: calamine::Range<calamine::Data>,
+    header: bool,
+}
+
+impl ExecutionPlan for ExcelExecutionPlan {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.arrow_schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DatafusionResult<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Execution(
+                "cannot replace children for ExcelExecutionPlan".to_string(),
+            ))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DatafusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(
+                "only single excel sheet partition supported".to_string(),
+            ));
+        }
+
+        let stream = ExcelStream::new(self.cell_range.clone(), self.header, self.schema());
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream,
+        )))
+    }
+
+    fn statistics(&self) -> DatafusionResult<Statistics> {
+        Ok(Statistics::new_unknown(self.schema().as_ref()))
+    }
+}
+
+impl DisplayAs for ExcelExecutionPlan {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ExcelExec")
+    }
+}

--- a/crates/datasources/src/json/stream.rs
+++ b/crates/datasources/src/json/stream.rs
@@ -16,12 +16,12 @@ use serde_json::{Map, Value};
 use crate::json::errors::JsonError;
 use crate::json::table::push_unwind_json_values;
 
-pub type SendableCheckedRecordBatchStrem =
+pub type SendableCheckedRecordBatchStream =
     Pin<Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>>;
 
 pub struct JsonStream {
     schema: Arc<Schema>,
-    stream: SendableCheckedRecordBatchStrem,
+    stream: SendableCheckedRecordBatchStream,
 }
 
 impl Stream for JsonStream {
@@ -40,7 +40,7 @@ impl RecordBatchStream for JsonStream {
 
 pub struct JsonPartitionStream {
     schema: Arc<Schema>,
-    stream: Mutex<Option<SendableCheckedRecordBatchStrem>>,
+    stream: Mutex<Option<SendableCheckedRecordBatchStream>>,
 }
 
 impl PartitionStream for JsonPartitionStream {

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -88,6 +88,8 @@ pub enum DispatchError {
     CassandraDatasource(#[from] datasources::cassandra::CassandraError),
     #[error(transparent)]
     SqliteDatasource(#[from] datasources::sqlite::errors::SqliteError),
+    #[error(transparent)]
+    ExcelDatasource(#[from] datasources::excel::errors::ExcelError),
 
     #[error("{0}")]
     String(String),

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -914,9 +914,9 @@ impl<'a> SessionPlanner<'a> {
 
                 if let DatasourceUrl::File(p) = DatasourceUrl::try_new(&location)? {
                     if !p.exists() {
-                        return Err(PlanError::String(format!(
-                            "invalid local file path specified"
-                        )));
+                        return Err(PlanError::String(
+                            "invalid local file path specified".to_string(),
+                        ));
                     }
                 };
 

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -901,18 +901,25 @@ impl<'a> SessionPlanner<'a> {
                 if let Some(creds) = creds_options {
                     storage_options_with_credentials(&mut storage_options, creds);
                 }
-                let sheet_name = Some(
-                    storage_options
-                        .inner
-                        .get("sheet_name")
-                        .map(|val| val.to_owned())
-                        .unwrap_or(String::from("Sheet1")),
-                );
+                let sheet_name = storage_options
+                    .inner
+                    .get("sheet_name")
+                    .map(|val| val.to_owned());
+
                 let has_header = storage_options
                     .inner
                     .get("has_header")
                     .map(|val| val.parse::<bool>().unwrap_or(true))
-                    .unwrap();
+                    .unwrap_or_default();
+
+                if let DatasourceUrl::File(p) = DatasourceUrl::try_new(&location)? {
+                    if !p.exists() {
+                        return Err(PlanError::String(format!(
+                            "invalid local file path specified"
+                        )));
+                    }
+                };
+
                 TableOptions::Excel(TableOptionsExcel {
                     location,
                     storage_options,

--- a/testdata/sqllogictests/xlsx.slt
+++ b/testdata/sqllogictests/xlsx.slt
@@ -57,3 +57,37 @@ select "HEADING" from read_excel('file://${PWD}/testdata/xlsx/multiple_sheets.xl
 # negatives are not allowed for infer_rows
 statement error
 select * from read_excel('file://${PWD}/testdata/xlsx/multiple_sheets.xlsx', sheet_name => 'other', infer_rows => -1);
+
+
+# create external table
+statement ok
+create external table multi_report from excel options(location='./testdata/xlsx/multiple_sheets.xlsx', file_type = 'xlsx', sheet_name = 'other', has_header = false);
+
+statement ok
+create external table basic_report from excel options(location='./testdata/xlsx/userdata1.xlsx', has_header='false');
+
+statement ok
+create external table basic_report_two from excel options(location='./testdata/xlsx/userdata1.xlsx', has_header='true');
+
+query
+select count(*) from basic_report;
+----
+1001
+
+query
+select count(*) from basic_report_two;
+----
+1000
+
+query
+select "HEADING" from multi_report;
+----
+1
+2
+3
+
+statement ok
+drop table basic_report;
+
+statement error
+create external table bad_report from excel options(location='./invalid_path/random.abc');

--- a/testdata/sqllogictests/xlsx.slt
+++ b/testdata/sqllogictests/xlsx.slt
@@ -64,6 +64,9 @@ statement ok
 create external table multi_report from excel options(location='./testdata/xlsx/multiple_sheets.xlsx', file_type = 'xlsx', sheet_name = 'other', has_header = false);
 
 statement ok
+create external table quarter_projection from excel options(location='./testdata/xlsx/multiple_sheets.xlsx', sheet_name='cost_projection', has_header='true');
+
+statement ok
 create external table basic_report from excel options(location='./testdata/xlsx/userdata1.xlsx', has_header='false');
 
 statement ok
@@ -85,6 +88,15 @@ select "HEADING" from multi_report;
 1
 2
 3
+
+query
+select "Resources", "Cost", "Revenue" from quarter_projection;
+----
+1 10 100
+2 20 200
+3 30 300
+4 40 400
+5 50 500
 
 statement ok
 drop table basic_report;


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2644, summary of changes:
- implements the `create external table excel <options>` sql command by adding a "streaming table" interface that maps excel rows/columns into a `RecordBatch`.

this will likely be superseded with a followup after the `TableProvider` is implemented for (https://github.com/GlareDB/glaredb/issues/2645) to allow querying on tables and it's missing support for streaming multiple sheets from a worksheet, it's also not super optimal quite yet, but happy to iterate on it on this pr or a followup.