### PR TITLE
refactor: extensible function registry

### DIFF
--- a/crates/catalog/src/mutator.rs
+++ b/crates/catalog/src/mutator.rs
@@ -19,6 +19,9 @@ impl CatalogMutator {
         CatalogMutator { client: None }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.client.is_none()
+    }
     pub fn new(client: Option<MetastoreClientHandle>) -> Self {
         CatalogMutator { client }
     }

--- a/crates/glaredb/src/highlighter.rs
+++ b/crates/glaredb/src/highlighter.rs
@@ -5,7 +5,7 @@ use datafusion::sql::sqlparser::keywords::Keyword;
 use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer};
 use nu_ansi_term::{Color, Style};
 use reedline::{Highlighter, Hinter, SearchQuery, StyledText, ValidationResult, Validator};
-use sqlbuiltins::functions::FUNCTION_REGISTRY;
+use sqlbuiltins::functions::DEFAULT_BUILTIN_FUNCTIONS;
 
 use crate::local::is_client_cmd;
 
@@ -192,7 +192,8 @@ fn colorize_sql(query: &str, st: &mut StyledText, is_hint: bool) {
                         st.push((new_style().fg(Color::LightGreen), format!("{w}")))
                     }
                     // Functions
-                    other if FUNCTION_REGISTRY.contains(other) => {
+                    // todo: replace this with the session functions
+                    other if DEFAULT_BUILTIN_FUNCTIONS.contains(other) => {
                         st.push((colorize_function(), format!("{w}")));
                     }
                     _ => {
@@ -201,7 +202,7 @@ fn colorize_sql(query: &str, st: &mut StyledText, is_hint: bool) {
                 },
                 // TODO: add more keywords
                 _ => {
-                    if FUNCTION_REGISTRY.contains(&w.value) {
+                    if DEFAULT_BUILTIN_FUNCTIONS.contains(&w.value) {
                         st.push((colorize_function(), format!("{w}")));
                     } else {
                         st.push((new_style(), format!("{w}")))

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -1039,8 +1039,13 @@ impl State {
                     .schema_objects
                     .get(&schema_id)
                     .and_then(|objs| objs.functions.get(&f.name))
-                    .copied()
-                    .unwrap_or_else(|| self.next_oid());
+                    .copied();
+
+                let oid = match oid {
+                    Some(_) => return Err(MetastoreError::DuplicateName(f.name.clone())),
+                    None => self.next_oid(),
+                };
+
 
                 let ent = FunctionEntry {
                     meta: EntryMeta {
@@ -1056,9 +1061,7 @@ impl State {
                     signature: Some(f.signature),
                     user_defined: true,
                 };
-                if let Some(ent) = self.entries.get(&oid)? {
-                    return Err(MetastoreError::DuplicateName(ent.get_meta().name.clone()));
-                }
+
                 self.entries.insert(oid, CatalogEntry::Function(ent))?;
                 self.schema_objects
                     .entry(schema_id)

--- a/crates/metastore/src/database.rs
+++ b/crates/metastore/src/database.rs
@@ -38,7 +38,7 @@ use sqlbuiltins::builtins::{
     FIRST_NON_STATIC_OID,
     SCHEMA_DEFAULT,
 };
-use sqlbuiltins::functions::{BuiltinFunction, FUNCTION_REGISTRY};
+use sqlbuiltins::functions::{BuiltinFunction, DEFAULT_BUILTIN_FUNCTIONS};
 use sqlbuiltins::validation::{
     validate_database_tunnel_support,
     validate_object_name,
@@ -1312,17 +1312,17 @@ impl BuiltinCatalog {
         let table_func_ents = Self::builtin_function_to_entries(
             &mut oid_gen,
             schema_id,
-            FUNCTION_REGISTRY.table_funcs_iter(),
+            DEFAULT_BUILTIN_FUNCTIONS.table_funcs_iter(),
         );
         let scalar_func_ents = Self::builtin_function_to_entries(
             &mut oid_gen,
             schema_id,
-            FUNCTION_REGISTRY.scalar_funcs_iter(),
+            DEFAULT_BUILTIN_FUNCTIONS.scalar_funcs_iter(),
         );
         let scalar_udf_ents = Self::builtin_function_to_entries(
             &mut oid_gen,
             schema_id,
-            FUNCTION_REGISTRY.scalar_udfs_iter(),
+            DEFAULT_BUILTIN_FUNCTIONS.scalar_udfs_iter(),
         );
 
         for func_ent in table_func_ents

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -188,24 +188,26 @@ message TunnelEntry {
 // available are builtins. We can change this however we need and not have to
 // worry about backwards compatability.
 message FunctionEntry {
-  enum FunctionType {
-    // Unknown catalog entry. We should error if this is encountered.
-    UNKNOWN = 0;
-    AGGREGATE = 1;
-    SCALAR = 2;
-    TABLE_RETURNING = 3;
-  }
-
-  enum RuntimePreference {
-    UNSPECIFIED = 0;
-    LOCAL = 1;
-    REMOTE = 2;
-  }
-
   EntryMeta meta = 1;
   FunctionType func_type = 2;
   reserved 3;  // Function runtime preference (static)
   Signature signature = 4;
+  bool user_defined = 5;
+  // next: 6
+}
+
+enum RuntimePreference {
+  UNSPECIFIED = 0;
+  LOCAL = 1;
+  REMOTE = 2;
+}
+
+enum FunctionType {
+  // Unknown catalog entry. We should error if this is encountered.
+  UNKNOWN = 0;
+  AGGREGATE = 1;
+  SCALAR = 2;
+  TABLE_RETURNING = 3;
 }
 
 message CredentialsEntry {

--- a/crates/protogen/proto/metastore/service.proto
+++ b/crates/protogen/proto/metastore/service.proto
@@ -38,8 +38,9 @@ message Mutation {
     CreateCredentials create_credentials = 15;
     DropCredentials drop_credentials = 16;
     UpdateDeploymentStorage update_deployment_storage = 17;
+    CreateFunction create_function = 18;
   }
-  // next: 17
+  // next: 19
 }
 
 message DropDatabase {
@@ -78,6 +79,13 @@ message CreateTable {
   options.TableOptionsInternal options = 3;
   bool if_not_exists = 4;
   bool or_replace = 5;
+}
+
+message CreateFunction {
+  string name = 1;
+  repeated string aliases = 2;
+  catalog.Signature signature = 3;
+  catalog.FunctionType type = 4;
 }
 
 message CreateExternalTable {

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -559,32 +559,32 @@ impl FunctionType {
 impl TryFrom<i32> for FunctionType {
     type Error = ProtoConvError;
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        catalog::function_entry::FunctionType::try_from(value)
+        catalog::FunctionType::try_from(value)
             .map_err(|_| ProtoConvError::UnknownEnumVariant("FunctionType", value))
             .and_then(|t| t.try_into())
     }
 }
 
-impl TryFrom<catalog::function_entry::FunctionType> for FunctionType {
+impl TryFrom<catalog::FunctionType> for FunctionType {
     type Error = ProtoConvError;
-    fn try_from(value: catalog::function_entry::FunctionType) -> Result<Self, Self::Error> {
+    fn try_from(value: catalog::FunctionType) -> Result<Self, Self::Error> {
         Ok(match value {
-            catalog::function_entry::FunctionType::Unknown => {
+            catalog::FunctionType::Unknown => {
                 return Err(ProtoConvError::ZeroValueEnumVariant("FunctionType"))
             }
-            catalog::function_entry::FunctionType::Aggregate => FunctionType::Aggregate,
-            catalog::function_entry::FunctionType::Scalar => FunctionType::Scalar,
-            catalog::function_entry::FunctionType::TableReturning => FunctionType::TableReturning,
+            catalog::FunctionType::Aggregate => FunctionType::Aggregate,
+            catalog::FunctionType::Scalar => FunctionType::Scalar,
+            catalog::FunctionType::TableReturning => FunctionType::TableReturning,
         })
     }
 }
 
-impl From<FunctionType> for catalog::function_entry::FunctionType {
+impl From<FunctionType> for catalog::FunctionType {
     fn from(value: FunctionType) -> Self {
         match value {
-            FunctionType::Aggregate => catalog::function_entry::FunctionType::Aggregate,
-            FunctionType::Scalar => catalog::function_entry::FunctionType::Scalar,
-            FunctionType::TableReturning => catalog::function_entry::FunctionType::TableReturning,
+            FunctionType::Aggregate => catalog::FunctionType::Aggregate,
+            FunctionType::Scalar => catalog::FunctionType::Scalar,
+            FunctionType::TableReturning => catalog::FunctionType::TableReturning,
         }
     }
 }
@@ -610,32 +610,28 @@ impl RuntimePreference {
 impl TryFrom<i32> for RuntimePreference {
     type Error = ProtoConvError;
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        let pref = catalog::function_entry::RuntimePreference::try_from(value)
+        let pref = catalog::RuntimePreference::try_from(value)
             .map_err(|_| ProtoConvError::UnknownEnumVariant("RuntimePreference", value))?;
         Ok(pref.into())
     }
 }
 
-impl From<catalog::function_entry::RuntimePreference> for RuntimePreference {
-    fn from(value: catalog::function_entry::RuntimePreference) -> Self {
+impl From<catalog::RuntimePreference> for RuntimePreference {
+    fn from(value: catalog::RuntimePreference) -> Self {
         match value {
-            catalog::function_entry::RuntimePreference::Unspecified => {
-                RuntimePreference::Unspecified
-            }
-            catalog::function_entry::RuntimePreference::Local => RuntimePreference::Local,
-            catalog::function_entry::RuntimePreference::Remote => RuntimePreference::Remote,
+            catalog::RuntimePreference::Unspecified => RuntimePreference::Unspecified,
+            catalog::RuntimePreference::Local => RuntimePreference::Local,
+            catalog::RuntimePreference::Remote => RuntimePreference::Remote,
         }
     }
 }
 
-impl From<RuntimePreference> for catalog::function_entry::RuntimePreference {
+impl From<RuntimePreference> for catalog::RuntimePreference {
     fn from(value: RuntimePreference) -> Self {
         match value {
-            RuntimePreference::Unspecified => {
-                catalog::function_entry::RuntimePreference::Unspecified
-            }
-            RuntimePreference::Local => catalog::function_entry::RuntimePreference::Local,
-            RuntimePreference::Remote => catalog::function_entry::RuntimePreference::Remote,
+            RuntimePreference::Unspecified => catalog::RuntimePreference::Unspecified,
+            RuntimePreference::Local => catalog::RuntimePreference::Local,
+            RuntimePreference::Remote => catalog::RuntimePreference::Remote,
         }
     }
 }
@@ -645,6 +641,7 @@ pub struct FunctionEntry {
     pub meta: EntryMeta,
     pub func_type: FunctionType,
     pub signature: Option<Signature>,
+    pub user_defined: bool,
 }
 
 impl TryFrom<catalog::FunctionEntry> for FunctionEntry {
@@ -655,6 +652,7 @@ impl TryFrom<catalog::FunctionEntry> for FunctionEntry {
             meta,
             func_type: value.func_type.try_into()?,
             signature: value.signature.map(|s| s.try_into()).transpose()?,
+            user_defined: value.user_defined,
         })
     }
 }
@@ -801,11 +799,12 @@ impl TryFrom<catalog::Signature> for Signature {
 
 impl From<FunctionEntry> for catalog::FunctionEntry {
     fn from(value: FunctionEntry) -> Self {
-        let func_type: catalog::function_entry::FunctionType = value.func_type.into();
+        let func_type: catalog::FunctionType = value.func_type.into();
         catalog::FunctionEntry {
             meta: Some(value.meta.into()),
             func_type: func_type as i32,
             signature: value.signature.map(|s| s.into()),
+            user_defined: value.user_defined,
         }
     }
 }

--- a/crates/protogen/src/metastore/types/service.rs
+++ b/crates/protogen/src/metastore/types/service.rs
@@ -336,7 +336,7 @@ impl TryFrom<CreateFunction> for service::CreateFunction {
         Ok(service::CreateFunction {
             name: value.name,
             aliases: value.aliases,
-            signature: Some(value.signature.try_into()?),
+            signature: Some(value.signature.into()),
             r#type: value.function_type as i32,
         })
     }

--- a/crates/protogen/src/metastore/types/service.rs
+++ b/crates/protogen/src/metastore/types/service.rs
@@ -735,20 +735,3 @@ impl From<UpdateDeploymentStorage> for service::UpdateDeploymentStorage {
         }
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use proptest::arbitrary::any;
-//     use proptest::proptest;
-
-//     use super::*;
-
-//     proptest! {
-//         #[test]
-//         fn roundtrip_mutation(expected in any::<Mutation>()) {
-//             let p: service::mutation::Mutation = expected.clone().try_into().unwrap();
-//             let got: Mutation = p.try_into().unwrap();
-//             assert_eq!(expected, got)
-//         }
-//     }
-// }

--- a/crates/rpcsrv/src/session.rs
+++ b/crates/rpcsrv/src/session.rs
@@ -58,7 +58,7 @@ impl RemoteSession {
         let plan = PhysicalPlanNode::try_decode(physical_plan.as_ref())?;
 
         let plan = plan.try_into_physical_plan(
-            self.session.get_datafusion_context(),
+            self.session.as_ref(),
             self.session.get_datafusion_context().runtime_env().as_ref(),
             &codec,
         )?;

--- a/crates/sqlbuiltins/src/functions/mod.rs
+++ b/crates/sqlbuiltins/src/functions/mod.rs
@@ -43,8 +43,9 @@ use self::alias_map::AliasMap;
 use crate::functions::scalars::openai::OpenAIEmbed;
 use crate::functions::scalars::similarity::CosineSimilarity;
 
-/// FUNCTION_REGISTRY provides all implementations of [`BuiltinFunction`]
-pub static FUNCTION_REGISTRY: Lazy<FunctionRegistry> = Lazy::new(FunctionRegistry::new);
+/// `DEFAULT_BUILTIN_FUNCTIONS` provides all implementations of [`BuiltinFunction`]
+/// These are functions that are globally available to all sessions.
+pub static DEFAULT_BUILTIN_FUNCTIONS: Lazy<FunctionRegistry> = Lazy::new(FunctionRegistry::new);
 
 /// BuiltinFunction **MUST** be implemented by all builtin functions, including
 /// new ones. This is used to derive catalog entries for all supported functions.

--- a/crates/sqlbuiltins/src/functions/scalars/similarity.rs
+++ b/crates/sqlbuiltins/src/functions/scalars/similarity.rs
@@ -28,6 +28,12 @@ pub struct CosineSimilarity {
     signature: Signature,
 }
 
+impl Default for CosineSimilarity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CosineSimilarity {
     pub fn new() -> Self {
         Self {

--- a/crates/sqlbuiltins/src/functions/scalars/similarity.rs
+++ b/crates/sqlbuiltins/src/functions/scalars/similarity.rs
@@ -16,21 +16,27 @@ use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::expr::ScalarFunction;
-use datafusion::logical_expr::{
-    Expr,
-    ReturnTypeFunction,
-    ScalarFunctionImplementation,
-    ScalarUDF,
-    Signature,
-    Volatility,
-};
+use datafusion::logical_expr::{Expr, ScalarUDF, ScalarUDFImpl, Signature, Volatility};
 use datafusion::physical_plan::ColumnarValue;
 use datafusion::scalar::ScalarValue;
 use protogen::metastore::types::catalog::FunctionType;
 
 use crate::functions::{BuiltinScalarUDF, ConstBuiltinFunction};
 
-pub struct CosineSimilarity;
+#[derive(Debug, Clone)]
+pub struct CosineSimilarity {
+    signature: Signature,
+}
+
+impl CosineSimilarity {
+    pub fn new() -> Self {
+        Self {
+            // TODO: see https://github.com/apache/arrow-datafusion/issues/9139.
+            // This should be ( FixedSizeList | List) [DataType::Float64 | DataType::Float16 | DataType::Float32]
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
 
 impl ConstBuiltinFunction for CosineSimilarity {
     const NAME: &'static str = "cosine_similarity";
@@ -39,13 +45,9 @@ impl ConstBuiltinFunction for CosineSimilarity {
     const EXAMPLE: &'static str = "cosine_similarity([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])";
     const FUNCTION_TYPE: FunctionType = FunctionType::Scalar;
     fn signature(&self) -> Option<Signature> {
-        // TODO: see https://github.com/apache/arrow-datafusion/issues/9139.
-        // This should be ( FixedSizeList | List) [DataType::Float64 | DataType::Float16 | DataType::Float32]
-        let sig = Signature::any(2, Volatility::Immutable);
-        Some(sig)
+        Some(self.signature.clone())
     }
 }
-
 fn arr_to_query_vec(
     arr: &dyn Array,
     to_type: &DataType,
@@ -101,7 +103,6 @@ fn arr_to_target_vec(arr: &dyn Array) -> datafusion::error::Result<Cow<FixedSize
                 let target_vec = cast_fsl_inner(arr, &to_type, *size, &Default::default())
                     .map_err(|e| DataFusionError::Execution(e.to_string()));
 
-
                 Cow::Owned(target_vec?)
             }
 
@@ -147,6 +148,69 @@ fn arr_to_target_vec(arr: &dyn Array) -> datafusion::error::Result<Cow<FixedSize
     })
 }
 
+impl ScalarUDFImpl for CosineSimilarity {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _: &[DataType]) -> datafusion::error::Result<DataType> {
+        Ok(DataType::Float32)
+    }
+
+    fn invoke(&self, args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+        let target_vec = match &args[1] {
+            ColumnarValue::Array(arr) => arr_to_target_vec(arr),
+            ColumnarValue::Scalar(ScalarValue::List(arr)) => arr_to_target_vec(arr.as_ref()),
+            ColumnarValue::Scalar(ScalarValue::FixedSizeList(arr)) => {
+                arr_to_target_vec(arr.as_ref())
+            }
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "Invalid argument type".to_string(),
+                ))
+            }
+        }?;
+
+        let v0 = target_vec.value(0);
+        let to_type = v0.data_type();
+
+        let query_vec = match &args[0] {
+            ColumnarValue::Array(arr) => arr_to_query_vec(arr, to_type),
+            ColumnarValue::Scalar(ScalarValue::List(arr)) => {
+                arr_to_query_vec(arr.as_ref(), to_type)
+            }
+            ColumnarValue::Scalar(ScalarValue::FixedSizeList(arr)) => {
+                arr_to_query_vec(arr.as_ref(), to_type)
+            }
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "Invalid argument type".to_string(),
+                ))
+            }
+        }?;
+
+        let dimension = target_vec.value_length() as usize;
+        if query_vec.len() != dimension {
+            return Err(DataFusionError::Execution(
+                "Query vector and target vector must have the same length".to_string(),
+            ));
+        }
+
+        let result: Arc<dyn Array> =
+            lance_linalg::distance::cosine_distance_arrow_batch(query_vec.as_ref(), &target_vec)
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+
+        Ok(ColumnarValue::Array(result))
+    }
+}
 
 impl BuiltinScalarUDF for CosineSimilarity {
     fn try_as_expr(
@@ -154,72 +218,17 @@ impl BuiltinScalarUDF for CosineSimilarity {
         _: &catalog::session_catalog::SessionCatalog,
         args: Vec<Expr>,
     ) -> datafusion::error::Result<Expr> {
-        let scalar_f: ScalarFunctionImplementation = Arc::new(move |args| {
-            let target_vec = match &args[1] {
-                ColumnarValue::Array(arr) => arr_to_target_vec(arr),
-                ColumnarValue::Scalar(ScalarValue::List(arr)) => arr_to_target_vec(arr.as_ref()),
-                ColumnarValue::Scalar(ScalarValue::FixedSizeList(arr)) => {
-                    arr_to_target_vec(arr.as_ref())
-                }
-                _ => {
-                    return Err(DataFusionError::Execution(
-                        "Invalid argument type".to_string(),
-                    ))
-                }
-            }?;
-
-            let v0 = target_vec.value(0);
-            let to_type = v0.data_type();
-
-            let query_vec = match &args[0] {
-                ColumnarValue::Array(arr) => arr_to_query_vec(arr, to_type),
-                ColumnarValue::Scalar(ScalarValue::List(arr)) => {
-                    arr_to_query_vec(arr.as_ref(), to_type)
-                }
-                ColumnarValue::Scalar(ScalarValue::FixedSizeList(arr)) => {
-                    arr_to_query_vec(arr.as_ref(), to_type)
-                }
-                _ => {
-                    return Err(DataFusionError::Execution(
-                        "Invalid argument type".to_string(),
-                    ))
-                }
-            }?;
-
-
-            let dimension = target_vec.value_length() as usize;
-            if query_vec.len() != dimension {
-                return Err(DataFusionError::Execution(
-                    "Query vector and target vector must have the same length".to_string(),
-                ));
-            }
-
-            let result: Arc<dyn Array> = lance_linalg::distance::cosine_distance_arrow_batch(
-                query_vec.as_ref(),
-                &target_vec,
-            )
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-
-            Ok(ColumnarValue::Array(result))
-        });
-
-        let return_type_fn: ReturnTypeFunction = Arc::new(move |_| {
-            let dtype = DataType::Float32;
-            Ok(Arc::new(dtype))
-        });
-
-        let udf = ScalarUDF::new(
-            Self::NAME,
-            &self.signature().unwrap(),
-            &return_type_fn,
-            &scalar_f,
-        );
-
+        let udf = ScalarUDF::new_from_impl(Self::new());
 
         Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
             Arc::new(udf),
             args,
         )))
+    }
+
+    fn try_into_scalar_udf(self: Arc<Self>) -> datafusion::error::Result<ScalarUDF> {
+        let udf = ScalarUDF::new_from_impl(Self::new());
+        Ok(udf)
     }
 }
 
@@ -296,7 +305,6 @@ where
     Ok(array)
 }
 
-
 // modified copy from arrow_cast
 
 /// modified/copied from arrow_cast
@@ -321,7 +329,6 @@ fn cast_fsl_inner(
     // Nulls in FixedSizeListArray take up space and so we must pad the values
     let values = array.values();
     let values = cast_with_options(values.as_ref(), field.data_type(), cast_options)?;
-
 
     // Construct the FixedSizeListArray
     let nulls = nulls.map(|mut x| x.finish().into());

--- a/crates/sqlbuiltins/src/functions/table/lance.rs
+++ b/crates/sqlbuiltins/src/functions/table/lance.rs
@@ -5,9 +5,11 @@ use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFuncContextProvider};
+use datasources::common::url::DatasourceUrlType;
 use datasources::lance::LanceTable;
 use protogen::metastore::types::catalog::{FunctionType, RuntimePreference};
 
+use super::object_store::urls_from_args;
 use super::{table_location_and_opts, TableFunc};
 use crate::functions::ConstBuiltinFunction;
 
@@ -31,11 +33,19 @@ impl ConstBuiltinFunction for LanceScan {
 impl TableFunc for LanceScan {
     fn detect_runtime(
         &self,
-        _args: &[FuncParamValue],
+        args: &[FuncParamValue],
         _parent: RuntimePreference,
     ) -> Result<RuntimePreference> {
-        // TODO: Detect runtime.
-        Ok(RuntimePreference::Remote)
+        let urls = urls_from_args(args)?;
+        // All urls are of the same type, just need to get the runtime from the
+        // first.
+        Ok(match urls.first().unwrap().datasource_url_type() {
+            DatasourceUrlType::File => RuntimePreference::Local,
+            DatasourceUrlType::Http => RuntimePreference::Remote,
+            DatasourceUrlType::Gcs => RuntimePreference::Remote,
+            DatasourceUrlType::S3 => RuntimePreference::Remote,
+            DatasourceUrlType::Azure => RuntimePreference::Remote,
+        })
     }
 
     async fn create_provider(

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -200,7 +200,7 @@ impl LocalSessionContext {
                 panic!("UDF {} does not have a signature", name);
             }
         };
-        let function_type = udf.function_type().clone();
+        let function_type = udf.function_type();
 
         let catalog_version = self.catalog.version();
         let mutations = vec![Mutation::CreateFunction(CreateFunction {

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -24,11 +24,13 @@ use distexec::scheduler::Scheduler;
 use pgrepr::format::Format;
 use pgrepr::notice::Notice;
 use pgrepr::types::arrow_to_pg_type;
+use protogen::metastore::types::service::{CreateFunction, Mutation};
 use protogen::rpcsrv::types::service::{
     InitializeSessionRequest,
     InitializeSessionRequestFromClient,
 };
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
+use sqlbuiltins::functions::{BuiltinScalarUDF, FunctionRegistry};
 use tokio_postgres::types::Type as PgType;
 use uuid::Uuid;
 
@@ -76,6 +78,8 @@ pub struct LocalSessionContext {
     task_scheduler: Scheduler,
     /// Notices that should be sent to the user.
     notices: Vec<Notice>,
+    /// Functions that are available to the session.
+    functions: FunctionRegistry,
 }
 
 impl LocalSessionContext {
@@ -110,7 +114,7 @@ impl LocalSessionContext {
 
         let df_ctx = DfSessionContext::new_with_state(state);
         df_ctx.register_variable(datafusion::variable::VarType::UserDefined, Arc::new(vars));
-
+        let functions = FunctionRegistry::new();
         Ok(LocalSessionContext {
             database_id,
             exec_client: None,
@@ -123,6 +127,7 @@ impl LocalSessionContext {
             env_reader: None,
             task_scheduler,
             notices: Vec::new(),
+            functions,
         })
     }
 
@@ -171,6 +176,45 @@ impl LocalSessionContext {
         Ok(())
     }
 
+    pub fn function_registry(&self) -> &FunctionRegistry {
+        &self.functions
+    }
+
+    pub async fn register_function(&mut self, udf: Arc<dyn BuiltinScalarUDF>) -> Result<()> {
+        let catalog_mutator = self.catalog_mutator();
+        // This is only empty when running hybrid exec
+        if catalog_mutator.is_empty() {
+            return Err(internal!("Unable to register function in hybrid exec mode"));
+        }
+
+        let name = udf.name().to_string();
+        let aliases = udf
+            .aliases()
+            .iter()
+            .map(|a| a.to_string())
+            .collect::<Vec<_>>();
+
+        let signature = match udf.signature() {
+            Some(s) => s.clone(),
+            None => {
+                panic!("UDF {} does not have a signature", name);
+            }
+        };
+        let function_type = udf.function_type().clone();
+
+        let catalog_version = self.catalog.version();
+        let mutations = vec![Mutation::CreateFunction(CreateFunction {
+            name,
+            aliases,
+            signature,
+            function_type,
+        })];
+
+        catalog_mutator.mutate(catalog_version, mutations).await?;
+        self.functions.register_udf(udf);
+        Ok(())
+    }
+
     pub fn register_env_reader(&mut self, env_reader: Box<dyn EnvironmentReader>) {
         self.env_reader = Some(env_reader);
     }
@@ -210,7 +254,7 @@ impl LocalSessionContext {
             .state()
             .config()
             .get_extension::<CatalogMutator>()
-            .unwrap()
+            .expect("catalog mutator should be present")
     }
 
     /// Get a reference to the session variables.

--- a/crates/sqlexec/src/context/local.rs
+++ b/crates/sqlexec/src/context/local.rs
@@ -180,6 +180,8 @@ impl LocalSessionContext {
         &self.functions
     }
 
+    /// Register a UDF with the session.
+    /// This will error if the function already exists in the catalog.
     pub async fn register_function(&mut self, udf: Arc<dyn BuiltinScalarUDF>) -> Result<()> {
         let catalog_mutator = self.catalog_mutator();
         // This is only empty when running hybrid exec
@@ -193,7 +195,6 @@ impl LocalSessionContext {
             .iter()
             .map(|a| a.to_string())
             .collect::<Vec<_>>();
-
         let signature = match udf.signature() {
             Some(s) => s.clone(),
             None => {
@@ -210,6 +211,7 @@ impl LocalSessionContext {
             function_type,
         })];
 
+        // This will error if the catalog already has a function with the same
         catalog_mutator.mutate(catalog_version, mutations).await?;
         self.functions.register_udf(udf);
         Ok(())

--- a/crates/sqlexec/src/context/remote.rs
+++ b/crates/sqlexec/src/context/remote.rs
@@ -162,7 +162,7 @@ impl RemoteSessionContext {
 
         // Since this is operating on a remote node, always disable local fs
         // access.
-        let dispatcher = ExternalDispatcher::new(&catalog, &self.df_ctx, true);
+        let dispatcher = ExternalDispatcher::new(&catalog, &self.df_ctx, &self.functions, true);
 
         let prov: Arc<dyn TableProvider> = match table_ref {
             ResolvedTableReference::Internal { table_oid } => match catalog.get_by_oid(table_oid) {
@@ -221,7 +221,7 @@ impl DFRegistry for RemoteSessionContext {
             .transpose()?
             .map(Arc::new)
             .ok_or_else(|| {
-                datafusion::error::DataFusionError::Plan(format!("UDF not found: {name}").into())
+                datafusion::error::DataFusionError::Plan(format!("UDF not found: {name}"))
             })
     }
 

--- a/crates/sqlexec/src/context/remote.rs
+++ b/crates/sqlexec/src/context/remote.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 
 use catalog::mutator::CatalogMutator;
 use catalog::session_catalog::SessionCatalog;
+use datafusion::common::not_impl_err;
 use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
 use datafusion::execution::context::{SessionConfig, SessionContext as DfSessionContext};
+use datafusion::execution::FunctionRegistry as DFRegistry;
 use datafusion::physical_plan::{execute_stream, ExecutionPlan, SendableRecordBatchStream};
 use datafusion_ext::functions::FuncParamValue;
 use datafusion_ext::vars::SessionVars;
@@ -13,6 +16,7 @@ use datasources::native::access::NativeTableStorage;
 use distexec::scheduler::Scheduler;
 use protogen::metastore::types::catalog::{CatalogEntry, CatalogState};
 use protogen::rpcsrv::types::service::ResolvedTableReference;
+use sqlbuiltins::functions::FunctionRegistry;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -42,6 +46,7 @@ pub struct RemoteSessionContext {
     df_ctx: DfSessionContext,
     /// Cached table providers.
     provider_cache: ProviderCache,
+    functions: FunctionRegistry,
 }
 
 impl RemoteSessionContext {
@@ -78,6 +83,7 @@ impl RemoteSessionContext {
             tables: native_tables,
             df_ctx,
             provider_cache: ProviderCache::default(),
+            functions: FunctionRegistry::default(),
         })
     }
 
@@ -194,5 +200,42 @@ impl RemoteSessionContext {
         self.provider_cache.put(id, prov.clone());
 
         Ok((id, prov))
+    }
+}
+
+impl DFRegistry for RemoteSessionContext {
+    fn udfs(&self) -> std::collections::HashSet<String> {
+        self.functions
+            .scalar_udfs_iter()
+            .map(|k| k.name().to_string())
+            .collect()
+    }
+
+    fn udf(
+        &self,
+        name: &str,
+    ) -> datafusion::error::Result<Arc<datafusion::logical_expr::ScalarUDF>> {
+        self.functions
+            .get_scalar_udf(name)
+            .map(|f| f.try_into_scalar_udf())
+            .transpose()?
+            .map(Arc::new)
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Plan(format!("UDF not found: {name}").into())
+            })
+    }
+
+    fn udaf(
+        &self,
+        _name: &str,
+    ) -> datafusion::error::Result<Arc<datafusion::logical_expr::AggregateUDF>> {
+        not_impl_err!("aggregate functions")
+    }
+
+    fn udwf(
+        &self,
+        _name: &str,
+    ) -> datafusion::error::Result<Arc<datafusion::logical_expr::WindowUDF>> {
+        not_impl_err!("window functions")
     }
 }

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -68,7 +68,7 @@ use protogen::metastore::types::options::{
     TunnelOptions,
 };
 use sqlbuiltins::builtins::DEFAULT_CATALOG;
-use sqlbuiltins::functions::FUNCTION_REGISTRY;
+use sqlbuiltins::functions::FunctionRegistry;
 
 use super::{DispatchError, Result};
 
@@ -77,6 +77,8 @@ pub struct ExternalDispatcher<'a> {
     catalog: &'a SessionCatalog,
     // TODO: Remove need for this.
     df_ctx: &'a SessionContext,
+
+    function_registry: &'a FunctionRegistry,
     /// Whether or not local file system access should be disabled.
     disable_local_fs_access: bool,
 }
@@ -85,11 +87,13 @@ impl<'a> ExternalDispatcher<'a> {
     pub fn new(
         catalog: &'a SessionCatalog,
         df_ctx: &'a SessionContext,
+        function_registry: &'a FunctionRegistry,
         disable_local_fs_access: bool,
     ) -> Self {
         ExternalDispatcher {
             catalog,
             df_ctx,
+            function_registry,
             disable_local_fs_access,
         }
     }
@@ -644,7 +648,7 @@ impl<'a> ExternalDispatcher<'a> {
         let args = args.unwrap_or_default();
         let opts = opts.unwrap_or_default();
         let resolve_func = if func.meta.builtin {
-            FUNCTION_REGISTRY.get_table_func(&func.meta.name)
+            self.function_registry.get_table_func(&func.meta.name)
         } else {
             // We only have builtin functions right now.
             None

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -194,6 +194,7 @@ impl<'a> Dispatcher<'a> {
             return ExternalDispatcher::new(
                 self.catalog,
                 self.df_ctx,
+                self.function_registry,
                 self.disable_local_fs_access,
             )
             .dispatch_external_table(tbl)
@@ -224,9 +225,14 @@ impl<'a> Dispatcher<'a> {
     ) -> Result<Arc<dyn TableProvider>> {
         let schema = schema.as_ref();
         let name = name.as_ref();
-        ExternalDispatcher::new(self.catalog, self.df_ctx, self.disable_local_fs_access)
-            .dispatch_external(&db_ent.meta.name, schema, name)
-            .await
+        ExternalDispatcher::new(
+            self.catalog,
+            self.df_ctx,
+            self.function_registry,
+            self.disable_local_fs_access,
+        )
+        .dispatch_external(&db_ent.meta.name, schema, name)
+        .await
     }
 
     pub async fn dispatch_table_function(

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -35,6 +35,7 @@ use futures::{Stream, StreamExt};
 use once_cell::sync::Lazy;
 use pgrepr::format::Format;
 use pgrepr::notice::{Notice, NoticeSeverity, SqlState};
+use sqlbuiltins::functions::BuiltinScalarUDF;
 use telemetry::Tracker;
 use uuid::Uuid;
 
@@ -423,6 +424,10 @@ impl Session {
         )?;
 
         Ok(Session { ctx })
+    }
+
+    pub async fn register_function(&mut self, udf: Arc<dyn BuiltinScalarUDF>) -> Result<()> {
+        self.ctx.register_function(udf).await
     }
 
     pub async fn attach_remote_session(


### PR DESCRIPTION
I didn't want to create 1 massive undecipherable PR, so I wanted to submit this first. 

This ties a `FunctionRegistry` instance to a session instead of the previously global `FUNCTION_REGISTRY`. 

Right now, the entries are written to both the catalog and the function registry. 

I'd prefer writing to just one or the other, but havent quite figured that out yet as our udfs are not serializable so they cant be written directly to the catalog. 


Some other the notable changes so far
- some catalog changes to allow for adding new user defined functions to the catalog.
- internally to expose a new method `register_function` on the session. 
- rework `cosine_similarity` to the new datafusion udf impl pattern for easier usage with the new `register_function` method.


I manually tested this by removing cosine_similarity from the builtin functions and registering it manually

```rs
let mut sess = engine
    .new_local_session_context(SessionVars::default(), SessionStorageConfig::default())
    .await?;

let udf = Arc::new(CosineSimilarity::new());
sess.register_function(udf).await?;
```

This works as expected in **local** sessions only. We'll have to modify the planner to handle  udfs in a hybrid context at a later date. 

----
### Next steps. 

I'm going to try to integrate the work I did with this datafusion <--> polars POC in a subsequent PR.

https://github.com/universalmind303/polar-fusion

