### PR TITLE
chore: add postgres dbt model to dbt tests

### DIFF
--- a/tests/fixtures/dbt_project/models/glaredb_data/postgres_datasource_view_materialization.sql
+++ b/tests/fixtures/dbt_project/models/glaredb_data/postgres_datasource_view_materialization.sql
@@ -1,4 +1,4 @@
 {{ config(materialized='view') }}
 
 select *
-from {{ source('basic', 'dbt_test')}}
+from {{ source('my_pg', 'borough_lookup')}}

--- a/tests/fixtures/dbt_project/models/glaredb_data/sources.yml
+++ b/tests/fixtures/dbt_project/models/glaredb_data/sources.yml
@@ -1,7 +1,13 @@
 version: 2
 
 sources:
-  - name: public
+  - name: basic
+    schema: public
     database: default
     tables: 
       - name: dbt_test
+  - name: my_pg
+    schema: public
+    database: my_pg
+    tables:
+      - name: borough_lookup

--- a/tests/fixtures/dbt_project/models/glaredb_data/table_materialization.sql
+++ b/tests/fixtures/dbt_project/models/glaredb_data/table_materialization.sql
@@ -1,4 +1,4 @@
 {{ config(materialized='table') }}
 
 select *
-from {{ source('public', 'dbt_test')}}
+from {{ source('basic', 'dbt_test')}}

--- a/tests/fixtures/dbt_project/profiles.yml
+++ b/tests/fixtures/dbt_project/profiles.yml
@@ -4,7 +4,7 @@ glaredb_dbt_test:
       dbname: default
       host: 127.0.0.1
       pass: ""
-      port: 5432
+      port: 5436
       schema: public
       threads: 1
       type: postgres

--- a/tests/tests/test_dbt.py
+++ b/tests/tests/test_dbt.py
@@ -13,20 +13,20 @@ from dbt.cli.main import dbtRunner, dbtRunnerResult
 def dbt_project_path() -> pathlib.Path:
     return tests.PKG_DIRECTORY.joinpath("tests", "fixtures", "dbt_project")
 
+
 @pytest.mark.parametrize("model_name,run_success,query_result",
                          [
                              ("table_materialization", True, 10),
-                             pytest.param("view_materialization", True, 10, marks=pytest.mark.xfail),
+                             ("view_materialization", True, 10),
                          ]
                          )
-def test_dbt_glaredb(
+def test_dbt_glaredb_basic(
     glaredb_connection: psycopg2.extensions.connection,
     dbt_project_path,
     model_name,
     run_success,
     query_result
 ):
-    print("LISTDIR", os.listdir('.'))
     dbt: dbtRunner = dbtRunner()
 
     os.environ["DBT_USER"] = glaredb_connection.info.user
@@ -39,6 +39,9 @@ def test_dbt_glaredb(
         curr.execute(
             "INSERT INTO dbt_test (amount) VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)"
         )
+        curr.execute("SELECT * FROM public.dbt_test")
+        a = curr.fetchall()
+        1==1
 
     cli_args: list = [
         "run",
@@ -59,3 +62,57 @@ def test_dbt_glaredb(
         result: list = curr.fetchone()[0]
 
     assert result == query_result
+
+def test_dbt_glaredb_external_postgres(
+    glaredb_connection: psycopg2.extensions.connection,
+    dbt_project_path
+):
+    dbt: dbtRunner = dbtRunner()
+    model_name = "postgres_datasource_view_materialization"
+    os.environ["DBT_USER"] = glaredb_connection.info.user
+
+    dbt_project_directory: pathlib.Path = dbt_project_path
+    dbt_profiles_directory: pathlib.Path = dbt_project_path
+
+    with glaredb_connection.cursor() as curr:
+        curr.execute(
+            """
+                CREATE EXTERNAL DATABASE my_pg
+                FROM postgres
+                OPTIONS (
+                    host = 'pg.demo.glaredb.com',
+                    port = '5432',
+                    user = 'demo',
+                    password = 'demo',
+                    database = 'postgres',
+                );
+            """
+        )
+
+    cli_args: list = [
+        "run",
+        "--project-dir",
+        dbt_project_directory,
+        "--profiles-dir",
+        dbt_profiles_directory,
+        "-m",
+        model_name
+    ]
+    #
+    res: dbtRunnerResult = dbt.invoke(cli_args)
+
+    assert res.success is True
+
+    with glaredb_connection.cursor() as curr:
+        curr.execute(f"select count(*) from {model_name}")
+        result: list = curr.fetchone()[0]
+
+    assert result == 5
+
+
+@pytest.fixture
+def test_fixture(a, b):
+    return a+b
+
+def test_my_fixture(test_fixture):
+    1 ==1


### PR DESCRIPTION
- Changes the expected test outcome for the view materialization in the existing dbt test from fail to pass
- Adds a test confirming that dbt will work with an external postgres database. This uses the actual external demo postgres instance that we mention in our docs, so is probably brittle. Ideally, we would spin something up (Docker?) for the purpose of the test.
- Overall, this could also probably use some refactoring, but I _think_ that that will take some pytest magic which may make the tests less legible.