### PR TITLE
feat: add nix derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709294055,
+        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A fast SQL database for running analytics across distributed data";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          name = "glaredb";
+          version = "${version}-${self.shortRev or "dirty"}";
+          src = ./.;
+          doCheck = false;
+          nativeBuildInputs = with pkgs; [ protobuf ];
+          buildAndTestSubdir = "crates/glaredb";
+          preBuild = ''
+            export PROTOC=${pkgs.protobuf}/bin/protoc
+          '';
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "bigquery-storage-0.1.2" = "sha256-o23/ALoVtE7SqJsxmXQnykxzqrVZ+Se/gXFYIlIskkI=";
+              "deltalake-0.17.0" = "sha256-p+k/MXimI7HDGvmrk6WMNhf2MbLrG7B9RlESSyhV04o=";
+              "lance-0.9.12" = "sha256-vWyXxoRDStvbToubciQSQgl/PErmM333UUGDsjhgr0k=";
+            };
+          };
+          meta = with pkgs.lib; {
+            description = "A fast SQL database for running analytics across distributed data";
+            homepage = "https://github.com/glaredb/glaredb";
+            license = licenses.agpl3;
+          };
+        };
+        devShells.default = with pkgs; mkShell {
+          packages = [ cargo rustc rust-analyzer rustfmt ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Other nix/rust libs have fancier caching... but this has the advantage of being portable to upstream nixos/nixpkgs.

I've tested this on `x86_64-linux`.

```console
$ nix build
$ ./result/bin/glaredb
GlareDB (v0.9.0)
Type \help for help.
>

```