### PR TITLE
chore: use a lance fork without the duckdb submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4138,11 +4138,12 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
+ "arrow-cast",
  "arrow-data",
  "arrow-schema",
  "arrow-select",
@@ -4155,8 +4156,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4170,6 +4171,7 @@ dependencies = [
  "futures",
  "lance-arrow",
  "lazy_static",
+ "libc",
  "mock_instant",
  "moka 0.11.3",
  "object_store",
@@ -4186,8 +4188,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4209,8 +4211,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4223,8 +4225,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4251,8 +4253,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4268,6 +4270,7 @@ dependencies = [
  "datafusion-sql",
  "futures",
  "half",
+ "itertools 0.12.0",
  "lance-arrow",
  "lance-core",
  "lance-datafusion",
@@ -4275,6 +4278,7 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
+ "lazy_static",
  "log",
  "num-traits",
  "num_cpus",
@@ -4294,8 +4298,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4323,14 +4327,15 @@ dependencies = [
  "shellexpand",
  "snafu",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "lance-linalg"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -4340,6 +4345,7 @@ dependencies = [
  "half",
  "lance-arrow",
  "lance-core",
+ "lazy_static",
  "log",
  "num-traits",
  "num_cpus",
@@ -4350,8 +4356,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.9.12"
-source = "git+https://github.com/lancedb/lance?rev=310d79eccf93f3c6a48c162c575918cdba13faec#310d79eccf93f3c6a48c162c575918cdba13faec"
+version = "0.10.2"
+source = "git+https://github.com/GlareDB/lance?rev=de6df70d9c5d95a4818b8799c23e3d1ad649bc1d#de6df70d9c5d95a4818b8799c23e3d1ad649bc1d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/datasources/Cargo.toml
+++ b/crates/datasources/Cargo.toml
@@ -69,7 +69,7 @@ tiberius = { version = "0.12.2", default-features = false, features = [
   "rustls",
   "chrono",
 ] }
-lance = { git = "https://github.com/lancedb/lance", rev = "310d79eccf93f3c6a48c162c575918cdba13faec" }
+lance = { git = "https://github.com/GlareDB/lance", rev = "de6df70d9c5d95a4818b8799c23e3d1ad649bc1d" }
 bson = "2.9.0"
 scylla = { version = "0.12.0" }
 glob = "0.3.1"

--- a/crates/sqlbuiltins/Cargo.toml
+++ b/crates/sqlbuiltins/Cargo.toml
@@ -36,4 +36,4 @@ reqwest.workspace = true
 # Important to keep this in sync with the datafusion arrow-cast version
 arrow-cast = { version = "50.0.0" }
 
-lance-linalg = { git = "https://github.com/lancedb/lance", rev = "310d79eccf93f3c6a48c162c575918cdba13faec" }
+lance-linalg = { git = "https://github.com/GlareDB/lance", rev = "de6df70d9c5d95a4818b8799c23e3d1ad649bc1d" }


### PR DESCRIPTION
lance uses duckdb as a submodule, and it's a pretty massive repo, `555.9 MB` on a fresh clone. It currently takes absolutely forever to build glaredb the first time _(or subsequent times if you nuke your cargo cache)_.

`git clone https://github.com/duckdb/duckdb.git` alone takes almost 4 minutes locally. 

this just forks lance and removes the submodule to avoid the problem alltogether. 