### PR TITLE
feat: insert into sqlite tables

### DIFF
--- a/crates/datasources/src/sqlite/convert.rs
+++ b/crates/datasources/src/sqlite/convert.rs
@@ -11,6 +11,7 @@ use datafusion::arrow::array::{
     StringBuilder,
     Time64MicrosecondBuilder,
     TimestampMicrosecondBuilder,
+    UInt64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -40,6 +41,12 @@ impl Converter {
                 let builder: Box<dyn ArrayBuilder> = match field.data_type() {
                     DataType::Boolean => {
                         Box::new(BooleanBuilder::with_capacity(RECORD_BATCH_CAPACITY))
+                    }
+                    DataType::UInt64 => {
+                        // sqlite can't produce this type, but for
+                        // consistency with other glaredb count
+                        // interfaces, we might
+                        Box::new(UInt64Builder::with_capacity(RECORD_BATCH_CAPACITY))
                     }
                     DataType::Int64 => Box::new(Int64Builder::with_capacity(RECORD_BATCH_CAPACITY)),
                     DataType::Float64 => {

--- a/justfile
+++ b/justfile
@@ -126,9 +126,9 @@ venv:
 
 # Runs pytest in the tests directory.
 pytest *args:
-  {{VENV_BIN}}/poetry -C tests install --no-root
-  {{VENV_BIN}}/poetry -C tests lock --no-update
-  {{VENV_BIN}}/poetry -C tests run pytest -n auto -v --rootdir={{invocation_directory()}}/tests {{ if args == "" {'tests'} else {args} }}
+  # {{VENV_BIN}}/poetry -C tests install --no-root
+  # {{VENV_BIN}}/poetry -C tests lock --no-update
+  {{VENV_BIN}}/poetry -C tests run pytest -v --rootdir={{invocation_directory()}}/tests {{ if args == "" {'tests'} else {args} }}
 
 # private helpers below
 # ---------------------

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -1260,6 +1260,22 @@ test = ["pytest (>=7)"]
 zstd = ["zstandard"]
 
 [[package]]
+name = "pysqlite3-binary"
+version = "0.5.2.post3"
+description = "DB-API 2.0 interface for Sqlite 3.x"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pysqlite3_binary-0.5.2.post3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e3535276d490b60d4f1cb1bace7613afc90333f2b37ce76bffb21d09032eccb"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82a2a0972ebb29736ef1536cc025f0a2795a6a74140d070630a24083422cd376"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4950fe4fbf6f21ce6bed5cf9bb44f04d56f9442cea9f513e67d5f627651d2737"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6048cdf4473f9186e93cf58b84c6e4f191d64050e3d6a00737a7df2310eb2f5f"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5e42f0c706e69bce24bb7a2de78985ec7589a4b6e1c719668c9d42350f49ed1"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fe1d8c9b1c992cff3cf54ea33f00face82343de9c6a03f8a914679550d2d379"},
+    {file = "pysqlite3_binary-0.5.2.post3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:674bb5fe16beb289eb2560f12055548cf0e496eee93f7f4cdd84276d03b7d541"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -1665,4 +1681,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "439e63dbd47f423a004ae1c87b28b1b72b7ab53bbf38d7542a487874ccc444a7"
+content-hash = "71ca9eff8d0525c89ea500f3a26d4be60df8a44b7ad9e781ec9527d97d041877"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -16,6 +16,7 @@ ruff = "0.1.14"
 dbt-core = "^1.7.7"
 dbt-postgres = "^1.7.7"
 pytest-xdist = "^3.5.0"
+pysqlite3-binary = "^0.5.2.post3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -1,0 +1,43 @@
+import os
+
+import pytest
+import sqlite3
+
+import psycopg2
+import psycopg2.extras
+
+from tests.fixtures.glaredb import glaredb_connection, glaredb_path, binary_path
+
+def test_inserts(
+    glaredb_connection: psycopg2.extensions.connection,
+    tmp_path_factory: pytest.TempPathFactory,
+):
+    tmp_dir = tmp_path_factory.mktemp(basename="sqlite-inserts")
+    db_path = tmp_dir.joinpath("insertdb")
+
+    conn = sqlite3.connect(db_path)
+    db = conn.cursor()
+
+    db.execute("create table insertable (a, b, c)")
+    db.execute("select count(*) insertable")
+    assert db.fetchone()[0] == 1 # definitely does this
+
+    db.close()
+    conn.commit()
+    conn.close()
+
+    with glaredb_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as curr:
+        curr.execute("create external table einsertable from sqlite "
+                     f"options (location = '{db_path}', table = 'insertable')")
+        curr.execute("alter table einsertable set access_mode to read_write")
+        curr.execute("insert into einsertable values (1, 2, 3), (4, 5, 6);")
+
+        curr.execute("select count(*) einsertable;")
+        rows = cur.fetchall()
+        assert rows[0] == 0
+
+    conn = sqlite3.connect(db_path)
+    db = conn.cursor()
+    db.execute("select count(*) insertable;")
+    rows = db.fetchall()
+    assert rows[0] == 0


### PR DESCRIPTION
This is close, but the test fails with a common error from SQLite on
the insert statement (e.g. `attempt to write a readonly
database`). I'm pretty sure that this _isn't_ due to the python sqlite
library which creates the db and sets things up, but something with
how we (probably?) create the sqlite client object.

Wanted to put this up so @vrongmeal could take a quick look and make
sure there isn't something specific to the rest of our implementation
that I missed.