### PR TITLE
refactor: remove proptests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,21 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4799,8 +4784,6 @@ dependencies = [
  "object_store_util",
  "once_cell",
  "pgrepr",
- "proptest",
- "proptest-derive",
  "prost",
  "prost-types",
  "protogen",
@@ -5985,37 +5968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.4.1",
- "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax 0.8.2",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6075,8 +6027,6 @@ version = "0.9.1"
 dependencies = [
  "datafusion",
  "datafusion-proto",
- "proptest",
- "proptest-derive",
  "prost",
  "prost-build",
  "prost-types",
@@ -6398,15 +6348,6 @@ name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
 ]
@@ -7105,18 +7046,6 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -8920,12 +8849,6 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/crates/metastore/Cargo.toml
+++ b/crates/metastore/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "metastore"
-version = {workspace = true}
-edition = {workspace = true}
+version = { workspace = true }
+edition = { workspace = true }
 
 [lints]
 workspace = true
 
 [dependencies]
-ioutil = {path = "../ioutil"}
-logutil = {path = "../logutil"}
-protogen = {path = "../protogen"}
+ioutil = { path = "../ioutil" }
+logutil = { path = "../logutil" }
+protogen = { path = "../protogen" }
 sqlbuiltins = { path = "../sqlbuiltins" }
-object_store_util = {path = "../object_store_util"}
-pgrepr = {path = "../pgrepr"}
+object_store_util = { path = "../object_store_util" }
+pgrepr = { path = "../pgrepr" }
 async-trait = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }
@@ -26,10 +26,6 @@ tracing = { workspace = true }
 uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 bytes = "1.4"
 once_cell = "1.19.0"
-proptest-derive = "0.4"
 tower = "0.4"
 dashmap = "5.5.0"
 catalog = { path = "../catalog" }
-
-[dev-dependencies]
-proptest = "1.4"

--- a/crates/protogen/Cargo.toml
+++ b/crates/protogen/Cargo.toml
@@ -13,8 +13,6 @@ thiserror.workspace = true
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-proptest = "1.4"
-proptest-derive = "0.4"
 uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 tracing = { workspace = true }
 

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
-use proptest_derive::Arbitrary;
 
 use super::options::{
     CredentialsOptions,
@@ -186,7 +185,7 @@ impl TryFrom<CatalogEntry> for catalog::CatalogEntry {
     }
 }
 
-#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EntryType {
     Database,
     Schema,
@@ -263,7 +262,7 @@ impl fmt::Display for EntryType {
 }
 
 /// Metadata associated with every entry in the catalog.
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EntryMeta {
     pub entry_type: EntryType,
     pub id: u32,
@@ -304,7 +303,7 @@ impl TryFrom<catalog::EntryMeta> for EntryMeta {
     }
 }
 
-#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SourceAccessMode {
     ReadOnly,
     ReadWrite,
@@ -382,7 +381,7 @@ impl From<SourceAccessMode> for i32 {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseEntry {
     pub meta: EntryMeta,
     pub options: DatabaseOptions,
@@ -414,7 +413,7 @@ impl From<DatabaseEntry> for catalog::DatabaseEntry {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaEntry {
     pub meta: EntryMeta,
 }
@@ -484,7 +483,7 @@ impl fmt::Display for TableEntry {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ViewEntry {
     pub meta: EntryMeta,
     pub sql: String,
@@ -513,7 +512,7 @@ impl From<ViewEntry> for catalog::ViewEntry {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TunnelEntry {
     pub meta: EntryMeta,
     pub options: TunnelOptions,
@@ -539,7 +538,7 @@ impl From<TunnelEntry> for catalog::TunnelEntry {
     }
 }
 
-#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FunctionType {
     Aggregate,
     Scalar,
@@ -590,7 +589,7 @@ impl From<FunctionType> for catalog::FunctionType {
 }
 
 /// The runtime preference for a function.
-#[derive(Debug, Clone, Copy, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimePreference {
     Unspecified,
     Local,
@@ -809,7 +808,7 @@ impl From<FunctionEntry> for catalog::FunctionEntry {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialsEntry {
     pub meta: EntryMeta,
     pub options: CredentialsOptions,
@@ -840,28 +839,9 @@ impl From<CredentialsEntry> for catalog::CredentialsEntry {
 
 #[cfg(test)]
 mod tests {
-    use proptest::arbitrary::any;
-    use proptest::proptest;
 
     use super::*;
 
-    proptest! {
-        #[test]
-        fn roundtrip_entry_type(expected in any::<EntryType>()) {
-            let p: catalog::entry_meta::EntryType = expected.into();
-            let got: EntryType = p.try_into().unwrap();
-            assert_eq!(expected, got);
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn roundtrip_entry_meta(expected in any::<EntryMeta>()) {
-            let p: catalog::EntryMeta = expected.clone().into();
-            let got: EntryMeta = p.try_into().unwrap();
-            assert_eq!(expected, got);
-        }
-    }
 
     #[test]
     fn convert_catalog_state_no_deployment_metadata() {

--- a/crates/protogen/src/metastore/types/options.rs
+++ b/crates/protogen/src/metastore/types/options.rs
@@ -3,18 +3,15 @@ use std::fmt;
 
 use datafusion::arrow::datatypes::{DataType, Field, Fields, SchemaRef};
 use datafusion::common::DFSchemaRef;
-use proptest_derive::Arbitrary;
 
 use crate::gen::common::arrow;
 use crate::gen::metastore::options;
 use crate::{FromOptionalField, ProtoConvError};
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InternalColumnDefinition {
     pub name: String,
     pub nullable: bool,
-    // TODO: change proptest strategy to select random DataType
-    #[proptest(value("DataType::Utf8"))]
     pub arrow_type: DataType,
 }
 
@@ -80,7 +77,7 @@ impl TryFrom<InternalColumnDefinition> for options::InternalColumnDefinition {
 
 // Database options
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DatabaseOptions {
     Internal(DatabaseOptionsInternal),
     Debug(DatabaseOptionsDebug),
@@ -212,7 +209,7 @@ impl From<DatabaseOptions> for options::DatabaseOptions {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsInternal {}
 
 impl TryFrom<options::DatabaseOptionsInternal> for DatabaseOptionsInternal {
@@ -228,7 +225,7 @@ impl From<DatabaseOptionsInternal> for options::DatabaseOptionsInternal {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsDebug {}
 
 impl TryFrom<options::DatabaseOptionsDebug> for DatabaseOptionsDebug {
@@ -244,7 +241,7 @@ impl From<DatabaseOptionsDebug> for options::DatabaseOptionsDebug {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsPostgres {
     pub connection_string: String,
 }
@@ -266,7 +263,7 @@ impl From<DatabaseOptionsPostgres> for options::DatabaseOptionsPostgres {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsBigQuery {
     pub service_account_key: String,
     pub project_id: String,
@@ -291,7 +288,7 @@ impl From<DatabaseOptionsBigQuery> for options::DatabaseOptionsBigQuery {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsMysql {
     pub connection_string: String,
 }
@@ -313,7 +310,7 @@ impl From<DatabaseOptionsMysql> for options::DatabaseOptionsMysql {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsMongoDb {
     pub connection_string: String,
 }
@@ -335,7 +332,7 @@ impl From<DatabaseOptionsMongoDb> for options::DatabaseOptionsMongoDb {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsSqlServer {
     pub connection_string: String,
 }
@@ -357,7 +354,7 @@ impl From<DatabaseOptionsSqlServer> for options::DatabaseOptionsSqlServer {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsClickhouse {
     pub connection_string: String,
 }
@@ -378,7 +375,7 @@ impl From<DatabaseOptionsClickhouse> for options::DatabaseOptionsClickhouse {
         }
     }
 }
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsCassandra {
     pub host: String,
     pub username: Option<String>,
@@ -406,7 +403,7 @@ impl From<DatabaseOptionsCassandra> for options::DatabaseOptionsCassandra {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsSqlite {
     pub location: String,
 }
@@ -428,7 +425,7 @@ impl From<DatabaseOptionsSqlite> for options::DatabaseOptionsSqlite {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsSnowflake {
     pub account_name: String,
     pub login_name: String,
@@ -465,7 +462,7 @@ impl From<DatabaseOptionsSnowflake> for options::DatabaseOptionsSnowflake {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseOptionsDeltaLake {
     pub catalog: DeltaLakeCatalog,
     pub storage_options: StorageOptions,
@@ -492,7 +489,7 @@ impl From<DatabaseOptionsDeltaLake> for options::DatabaseOptionsDeltaLake {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DeltaLakeCatalog {
     Unity(DeltaLakeUnityCatalog),
 }
@@ -518,7 +515,7 @@ impl From<DeltaLakeCatalog> for options::database_options_delta_lake::Catalog {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DeltaLakeUnityCatalog {
     pub catalog_id: String,
     pub databricks_access_token: String,
@@ -558,7 +555,7 @@ impl From<DeltaLakeUnityCatalog> for options::DeltaLakeUnityCatalog {
 /// - [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants)
 /// - [S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants)
 /// - [Google options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html#variants)
-#[derive(Debug, Default, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct StorageOptions {
     pub inner: BTreeMap<String, String>,
 }
@@ -592,7 +589,7 @@ impl From<StorageOptions> for options::StorageOptions {
 
 // Table options
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TableOptions {
     Internal(TableOptionsInternal),
     Debug(TableOptionsDebug),
@@ -748,7 +745,7 @@ impl TryFrom<TableOptions> for options::TableOptions {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsInternal {
     pub columns: Vec<InternalColumnDefinition>,
 }
@@ -811,7 +808,7 @@ impl TryFrom<TableOptionsInternal> for options::TableOptionsInternal {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsDebug {
     pub table_type: String,
 }
@@ -833,7 +830,7 @@ impl From<TableOptionsDebug> for options::TableOptionsDebug {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsPostgres {
     pub connection_string: String,
     pub schema: String,
@@ -861,7 +858,7 @@ impl From<TableOptionsPostgres> for options::TableOptionsPostgres {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsBigQuery {
     pub service_account_key: String,
     pub project_id: String,
@@ -892,7 +889,7 @@ impl From<TableOptionsBigQuery> for options::TableOptionsBigQuery {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsMysql {
     pub connection_string: String,
     pub schema: String,
@@ -920,7 +917,7 @@ impl From<TableOptionsMysql> for options::TableOptionsMysql {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsLocal {
     pub location: String,
     pub file_type: String,
@@ -948,7 +945,7 @@ impl From<TableOptionsLocal> for options::TableOptionsLocal {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsGcs {
     pub service_account_key: Option<String>,
     pub bucket: String,
@@ -982,7 +979,7 @@ impl From<TableOptionsGcs> for options::TableOptionsGcs {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsS3 {
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<String>,
@@ -1021,7 +1018,7 @@ impl From<TableOptionsS3> for options::TableOptionsS3 {
         }
     }
 }
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsMongoDb {
     pub connection_string: String,
     pub database: String,
@@ -1049,7 +1046,7 @@ impl From<TableOptionsMongoDb> for options::TableOptionsMongo {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsExcel {
     pub location: String,
     pub storage_options: StorageOptions,
@@ -1086,7 +1083,7 @@ impl From<TableOptionsExcel> for options::TableOptionsExcel {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsSqlServer {
     pub connection_string: String,
     pub schema: String,
@@ -1114,7 +1111,7 @@ impl From<TableOptionsSqlServer> for options::TableOptionsSqlServer {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsClickhouse {
     pub connection_string: String,
     pub table: String,
@@ -1142,7 +1139,7 @@ impl From<TableOptionsClickhouse> for options::TableOptionsClickhouse {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsCassandra {
     pub host: String,
     pub keyspace: String,
@@ -1176,7 +1173,7 @@ impl From<TableOptionsCassandra> for options::TableOptionsCassandra {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsSqlite {
     pub location: String,
     pub table: String,
@@ -1201,7 +1198,7 @@ impl From<TableOptionsSqlite> for options::TableOptionsSqlite {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsSnowflake {
     pub account_name: String,
     pub login_name: String,
@@ -1244,7 +1241,7 @@ impl From<TableOptionsSnowflake> for options::TableOptionsSnowflake {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOptionsObjectStore {
     pub location: String,
     pub storage_options: StorageOptions,
@@ -1278,7 +1275,7 @@ impl From<TableOptionsObjectStore> for options::TableOptionsObjectStore {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TunnelOptions {
     Internal(TunnelOptionsInternal),
     Debug(TunnelOptionsDebug),
@@ -1341,7 +1338,7 @@ impl From<TunnelOptions> for options::TunnelOptions {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TunnelOptionsInternal {}
 
 impl TryFrom<options::TunnelOptionsInternal> for TunnelOptionsInternal {
@@ -1357,7 +1354,7 @@ impl From<TunnelOptionsInternal> for options::TunnelOptionsInternal {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TunnelOptionsDebug {}
 
 impl TryFrom<options::TunnelOptionsDebug> for TunnelOptionsDebug {
@@ -1373,7 +1370,7 @@ impl From<TunnelOptionsDebug> for options::TunnelOptionsDebug {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TunnelOptionsSsh {
     pub connection_string: String,
     pub ssh_key: Vec<u8>,
@@ -1397,34 +1394,7 @@ impl From<TunnelOptionsSsh> for options::TunnelOptionsSsh {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use proptest::arbitrary::any;
-    use proptest::proptest;
-
-    use super::*;
-
-    proptest! {
-        #[test]
-        fn roundtrip_table_options(expected in any::<TableOptions>()) {
-            let p: options::TableOptions = expected.clone().try_into().unwrap();
-            let got: TableOptions = p.try_into().unwrap();
-            assert_eq!(expected, got);
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn roundtrip_connection_options(expected in any::<DatabaseOptions>()) {
-            let p: options::DatabaseOptions = expected.clone().into();
-            let got: DatabaseOptions = p.try_into().unwrap();
-            assert_eq!(expected, got);
-        }
-    }
-}
-
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CredentialsOptions {
     Debug(CredentialsOptionsDebug),
     Gcp(CredentialsOptionsGcp),
@@ -1499,7 +1469,7 @@ impl From<CredentialsOptions> for options::CredentialsOptions {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CredentialsOptionsDebug {
     pub table_type: String,
 }
@@ -1521,7 +1491,7 @@ impl From<CredentialsOptionsDebug> for options::CredentialsOptionsDebug {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CredentialsOptionsGcp {
     pub service_account_key: String,
 }
@@ -1543,7 +1513,7 @@ impl From<CredentialsOptionsGcp> for options::CredentialsOptionsGcp {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CredentialsOptionsAws {
     pub access_key_id: String,
     pub secret_access_key: String,
@@ -1568,7 +1538,7 @@ impl From<CredentialsOptionsAws> for options::CredentialsOptionsAws {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CredentialsOptionsAzure {
     pub account_name: String,
     pub access_key: String,
@@ -1593,7 +1563,7 @@ impl From<CredentialsOptionsAzure> for options::CredentialsOptionsAzure {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CredentialsOptionsOpenAI {
     pub api_key: String,
     pub api_base: Option<String>,

--- a/crates/protogen/src/metastore/types/service.rs
+++ b/crates/protogen/src/metastore/types/service.rs
@@ -1,5 +1,4 @@
 use datafusion::logical_expr::Signature;
-use proptest_derive::Arbitrary;
 
 use super::catalog::{FunctionType, SourceAccessMode};
 use super::options::{
@@ -126,7 +125,7 @@ impl TryFrom<Mutation> for service::Mutation {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropDatabase {
     pub name: String,
     pub if_exists: bool,
@@ -152,7 +151,7 @@ impl From<DropDatabase> for service::DropDatabase {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropSchema {
     pub name: String,
     pub if_exists: bool,
@@ -181,7 +180,7 @@ impl From<DropSchema> for service::DropSchema {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropObject {
     pub schema: String,
     pub name: String,
@@ -210,7 +209,7 @@ impl From<DropObject> for service::DropObject {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateSchema {
     pub name: String,
     pub if_not_exists: bool,
@@ -235,7 +234,7 @@ impl From<CreateSchema> for service::CreateSchema {
         }
     }
 }
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateView {
     pub schema: String,
     pub name: String,
@@ -270,7 +269,7 @@ impl From<CreateView> for service::CreateView {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateTable {
     pub schema: String,
     pub name: String,
@@ -342,7 +341,7 @@ impl TryFrom<CreateFunction> for service::CreateFunction {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateExternalTable {
     pub schema: String,
     pub name: String,
@@ -381,7 +380,7 @@ impl TryFrom<CreateExternalTable> for service::CreateExternalTable {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateExternalDatabase {
     pub name: String,
     pub options: DatabaseOptions,
@@ -412,7 +411,7 @@ impl From<CreateExternalDatabase> for service::CreateExternalDatabase {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterTableOperation {
     RenameTable { new_name: String },
     SetAccessMode { access_mode: SourceAccessMode },
@@ -468,7 +467,7 @@ impl From<AlterTableOperation> for service::AlterTableOperation {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlterTable {
     pub schema: String,
     pub name: String,
@@ -496,7 +495,7 @@ impl From<AlterTable> for service::AlterTable {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterDatabaseOperation {
     RenameDatabase { new_name: String },
     SetAccessMode { access_mode: SourceAccessMode },
@@ -552,7 +551,7 @@ impl From<AlterDatabaseOperation> for service::AlterDatabaseOperation {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlterDatabase {
     pub name: String,
     pub operation: AlterDatabaseOperation,
@@ -577,7 +576,7 @@ impl From<AlterDatabase> for service::AlterDatabase {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateTunnel {
     pub name: String,
     pub options: TunnelOptions,
@@ -605,7 +604,7 @@ impl From<CreateTunnel> for service::CreateTunnel {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropTunnel {
     pub name: String,
     pub if_exists: bool,
@@ -630,7 +629,7 @@ impl From<DropTunnel> for service::DropTunnel {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlterTunnelRotateKeys {
     pub name: String,
     pub if_exists: bool,
@@ -658,7 +657,7 @@ impl From<AlterTunnelRotateKeys> for service::AlterTunnelRotateKeys {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateCredentials {
     pub name: String,
     pub options: CredentialsOptions,
@@ -689,7 +688,7 @@ impl From<CreateCredentials> for service::CreateCredentials {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropCredentials {
     pub name: String,
     pub if_exists: bool,
@@ -714,7 +713,7 @@ impl From<DropCredentials> for service::DropCredentials {
     }
 }
 
-#[derive(Debug, Clone, Arbitrary, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateDeploymentStorage {
     pub new_storage_size: u64,
 }


### PR DESCRIPTION
some more prereq work for making the tableoptions more flexible as part of https://github.com/GlareDB/glaredb/issues/2744.

The `Arbitrary` trait has a cascading effect, so it's kind of all or nothing, and since we can't have `trait TableOptions: Arbitrary` in an object-safe way, it's gotta go. 