### PR TITLE
fix: error string clarifying quotes

### DIFF
--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -668,7 +668,7 @@ impl<'a> ExternalDispatcher<'a> {
             )
             .await?),
             _ => Err(DispatchError::String(
-                format!("Unsupported file type: {}, for '{}'", file_type, path,).to_string(),
+                format!("Unsupported file type: '{}', for '{}'", file_type, path,).to_string(),
             )),
         }
     }


### PR DESCRIPTION
Closes #2405

We put the filetype in this error message if we have it, and we'd
previously put in the path so users can deduce what's up in the case
that they're running an external table from an object store provider.