### PR TITLE
chore: add explicit schema support for json streaming

### DIFF
--- a/crates/sqlbuiltins/src/functions/table/json.rs
+++ b/crates/sqlbuiltins/src/functions/table/json.rs
@@ -61,6 +61,6 @@ impl TableFunc for JsonScan {
         let store_access = storage_options_into_store_access(&source_url, &storage_options)
             .map_err(ExtensionError::access)?;
 
-        Ok(json_streaming_table(store_access, source_url).await?)
+        Ok(json_streaming_table(store_access, source_url, None).await?)
     }
 }


### PR DESCRIPTION
This is the same implementation as in the BSON, need to have an
external table connection to wire this up directly.