### PR TITLE
refactor(table options): pull credentials entirely out of `TableOptions`

### DIFF
--- a/crates/catalog/src/session_catalog.rs
+++ b/crates/catalog/src/session_catalog.rs
@@ -459,6 +459,7 @@ impl TempCatalog {
                 },
                 options: TableOptionsInternal { columns }.into(),
                 tunnel_id: None,
+                credentials_id: None,
                 access_mode: SourceAccessMode::ReadWrite,
                 schema: Some(schema.as_ref().clone()),
             }
@@ -504,6 +505,7 @@ impl TempCatalog {
                 }
                 .into(),
                 tunnel_id: None,
+                credentials_id: None,
                 access_mode: SourceAccessMode::ReadWrite,
                 schema: None,
             });

--- a/crates/datasources/src/lance/mod.rs
+++ b/crates/datasources/src/lance/mod.rs
@@ -122,10 +122,6 @@ impl Datasource for LanceDatasource {
                 return Err(ObjectStoreSourceError::NotSupportFileType(file_type).into());
             }
         }
-
-        // TODO: the credentials shouldn't be stored in the table options.
-        // Currently We are storing them in the catalog as both a credential and nested in the table options.
-        // We should only store them in the catalog as a credential and instead pass [`CredentialsOptions`] to `create_table_provider` as a separate argument.
         if let Some(creds) = creds {
             storage_options_with_credentials(&mut storage_options, creds);
         }

--- a/crates/datasources/src/lib.rs
+++ b/crates/datasources/src/lib.rs
@@ -44,14 +44,13 @@ pub trait Datasource: Send + Sync {
     fn table_options_from_stmt(
         &self,
         opts: &mut StatementOptions,
-        creds: Option<CredentialsOptions>,
-        tunnel_opts: Option<TunnelOptions>,
     ) -> Result<TableOptions, DatasourceError>;
 
 
     async fn create_table_provider(
         &self,
         tbl_options: &TableOptions,
-        _tunnel_opts: Option<&TunnelOptions>,
+        creds: Option<CredentialsOptions>,
+        tunnel_opts: Option<TunnelOptions>,
     ) -> Result<Arc<dyn TableProvider>, DatasourceError>;
 }

--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -538,6 +538,7 @@ mod tests {
             }
             .into(),
             tunnel_id: None,
+            credentials_id: None,
             access_mode: SourceAccessMode::ReadOnly,
             schema: None,
         };

--- a/crates/protogen/proto/metastore/catalog.proto
+++ b/crates/protogen/proto/metastore/catalog.proto
@@ -164,7 +164,8 @@ message TableEntry {
   optional uint32 tunnel_id = 4;
   SourceAccessMode access_mode = 5;
   optional common.arrow.Schema schema = 6;
-  // next: 7
+  optional uint32 credentials_id = 7;
+  // next: 8
 }
 
 message ViewEntry {

--- a/crates/protogen/proto/metastore/service.proto
+++ b/crates/protogen/proto/metastore/service.proto
@@ -95,7 +95,8 @@ message CreateExternalTable {
   bool if_not_exists = 4;
   optional string tunnel = 5;
   bool or_replace = 6;
-  // next: 7
+  optional string credentials = 7;
+  // next: 8
 }
 
 message CreateExternalDatabase {

--- a/crates/protogen/src/metastore/types/catalog.rs
+++ b/crates/protogen/src/metastore/types/catalog.rs
@@ -439,8 +439,12 @@ impl From<SchemaEntry> for catalog::SchemaEntry {
 pub struct TableEntry {
     pub meta: EntryMeta,
     pub options: TableOptions,
+    /// Reference to the tunnel used to access the table.
     pub tunnel_id: Option<u32>,
+    /// Reference to the credentials used to access the table.
+    pub credentials_id: Option<u32>,
     pub access_mode: SourceAccessMode,
+    /// The (optional) user defined schema of the table.
     pub schema: Option<Schema>,
 }
 
@@ -471,6 +475,7 @@ impl TryFrom<catalog::TableEntry> for TableEntry {
             meta,
             options: value.options.required("options")?,
             tunnel_id: value.tunnel_id,
+            credentials_id: value.credentials_id,
             access_mode: value.access_mode.try_into()?,
             schema: None,
         })
@@ -483,6 +488,7 @@ impl From<TableEntry> for catalog::TableEntry {
             meta: Some(value.meta.into()),
             options: Some(value.options.into()),
             tunnel_id: value.tunnel_id,
+            credentials_id: value.credentials_id,
             access_mode: value.access_mode.into(),
             schema: None,
         }

--- a/crates/protogen/src/metastore/types/service.rs
+++ b/crates/protogen/src/metastore/types/service.rs
@@ -348,6 +348,7 @@ pub struct CreateExternalTable {
     pub or_replace: bool,
     pub if_not_exists: bool,
     pub tunnel: Option<String>,
+    pub credentials: Option<String>,
 }
 
 
@@ -362,6 +363,7 @@ impl TryFrom<service::CreateExternalTable> for CreateExternalTable {
             or_replace: value.or_replace,
             if_not_exists: value.if_not_exists,
             tunnel: value.tunnel,
+            credentials: value.credentials,
         })
     }
 }
@@ -376,6 +378,7 @@ impl TryFrom<CreateExternalTable> for service::CreateExternalTable {
             or_replace: value.or_replace,
             if_not_exists: value.if_not_exists,
             tunnel: value.tunnel,
+            credentials: value.credentials,
         })
     }
 }

--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -203,6 +203,8 @@ pub struct CreateExternalTableExec {
     pub tunnel: Option<String>,
     #[prost(bool, tag = "6")]
     pub or_replace: bool,
+    #[prost(message, optional, tag = "7")]
+    pub credentials: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Message)]

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -415,11 +415,11 @@ impl<'a> ExternalDispatcher<'a> {
             let ent = self
                 .catalog
                 .get_by_oid(creds_id)
-                .ok_or(DispatchError::MissingTunnel(creds_id))?;
+                .ok_or(DispatchError::MissingObjectWithOid(creds_id))?;
 
             let ent = match ent {
                 CatalogEntry::Credentials(ent) => ent,
-                _ => return Err(DispatchError::MissingTunnel(creds_id)),
+                _ => return Err(DispatchError::MissingObjectWithOid(creds_id)),
             };
             Some(ent.options.clone())
         } else {

--- a/crates/sqlexec/src/dispatch/mod.rs
+++ b/crates/sqlexec/src/dispatch/mod.rs
@@ -44,6 +44,7 @@ pub enum DispatchError {
     #[error("Missing tunnel connection: {0}")]
     MissingTunnel(u32),
 
+
     #[error("failed to plan view: {0}")]
     ViewPlanning(Box<crate::planner::errors::PlanError>),
 

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -307,6 +307,7 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                     if_not_exists: ext.if_not_exists,
                     table_options: table_options.try_into()?,
                     tunnel: ext.tunnel,
+                    credentials: ext.credentials,
                 })
             }
             proto::ExecutionPlanExtensionType::CreateTunnelExec(ext) => {
@@ -633,6 +634,7 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                     if_not_exists: exec.if_not_exists,
                     table_options: Some(exec.table_options.clone().into()),
                     tunnel: exec.tunnel.clone(),
+                    credentials: exec.credentials.clone(),
                 },
             )
         } else if let Some(exec) = node.as_any().downcast_ref::<CreateTunnelExec>() {

--- a/crates/sqlexec/src/planner/logical_plan/create_external_table.rs
+++ b/crates/sqlexec/src/planner/logical_plan/create_external_table.rs
@@ -16,6 +16,7 @@ pub struct CreateExternalTable {
     pub if_not_exists: bool,
     pub table_options: TableOptions,
     pub tunnel: Option<String>,
+    pub credentials: Option<String>,
     pub columns: Option<Vec<FieldRef>>,
 }
 

--- a/crates/sqlexec/src/planner/physical_plan/create_external_table.rs
+++ b/crates/sqlexec/src/planner/physical_plan/create_external_table.rs
@@ -32,6 +32,7 @@ pub struct CreateExternalTableExec {
     pub if_not_exists: bool,
     pub table_options: TableOptions,
     pub tunnel: Option<String>,
+    pub credentials: Option<String>,
 }
 
 impl ExecutionPlan for CreateExternalTableExec {
@@ -118,6 +119,7 @@ async fn create_external_table(
                     or_replace: plan.or_replace,
                     if_not_exists: plan.if_not_exists,
                     tunnel: plan.tunnel,
+                    credentials: plan.credentials,
                 },
             )],
         )

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -927,6 +927,7 @@ impl<'a> SessionPlanner<'a> {
         let datasource = normalize_ident(stmt.datasource);
 
         let tunnel = stmt.tunnel.map(normalize_ident);
+
         let tunnel_options = self.get_tunnel_opts(&tunnel)?;
         if let Some(tunnel_options) = &tunnel_options {
             // Validate if the tunnel type is supported by the datasource
@@ -952,7 +953,7 @@ impl<'a> SessionPlanner<'a> {
         // for the datasource instead of the static [`DEFAULT_DATASOURCES`]
             if let Some(datasource) = DEFAULT_DATASOURCES.get(datasource.as_str()) {
                 datasource
-                    .table_options_from_stmt(m, creds_options, tunnel_options)
+                    .table_options_from_stmt(m, creds_options)
                     .map_err(|e| PlanError::InvalidExternalTable { source: e })?
             } else {
                 self.opts_from_old_tblopts(datasource.as_str(), m, creds_options, tunnel_options)
@@ -968,6 +969,7 @@ impl<'a> SessionPlanner<'a> {
             if_not_exists: stmt.if_not_exists,
             table_options: external_table_options,
             tunnel,
+            credentials: creds,
             columns: None,
         };
 

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -159,6 +159,7 @@ impl ExtensionPlanner for DDLExtensionPlanner {
                     or_replace: lp.or_replace,
                     if_not_exists: lp.if_not_exists,
                     tunnel: lp.tunnel.clone(),
+                    credentials: lp.credentials.clone(),
                     table_options: lp.table_options.clone(),
                 };
                 RuntimeGroupExec::new(RuntimePreference::Remote, Arc::new(exec))


### PR DESCRIPTION
previously we were storing and passing around the credentials in two places for many datasources. 

We were often storing it in the catalog as a `CredentialEntry`, and also storing certain fields directly in the `TableOptions`. This required a bunch of extra work on both ends (storage and retrieval)

This PR makes the credential have first class support in the `TableEntry`. Similar to the `tunnel_id` or `columns`. the credential reference is now stored directly into the catalog entry. 



```sql
CREATE CREDENTIALS debug_creds 
PROVIDER debug
OPTIONS (table_type = 'never_ending');

CREATE EXTERNAL TABLE debug_creds_table
FROM debug
CREDENTIALS debug_creds;
```

In the current release's implementation, the credentials are parsed into table options **resulting in them being stored twice**. Now, we just validate the credential and pass a reference to it to be later retrieved during table creation. 


