### PR TITLE
fix: Retry writing lease when error code 429 (too many requests).

### DIFF
--- a/crates/metastore/src/storage/mod.rs
+++ b/crates/metastore/src/storage/mod.rs
@@ -49,6 +49,9 @@ pub enum StorageError {
     #[error("Lease renewer exited.")]
     LeaseRenewerExited,
 
+    #[error("Unable to write to lease object after retries: {0}")]
+    LeaseWriteError(String),
+
     #[error(transparent)]
     ProtoConv(#[from] protogen::errors::ProtoConvError),
 


### PR DESCRIPTION
This should fix the issue. We are retrying here as suggested by GCS since writing the same object again and again is rate limited to once per second.

Another thing that might help is writing to a new "temp" object every time (instead of using the same one for the same process).

Fixes: https://github.com/GlareDB/cloud/issues/2746