### PR TITLE
chore: Create a new temp object when writing lease all the time.

### DIFF
--- a/crates/metastore/src/storage/lease.rs
+++ b/crates/metastore/src/storage/lease.rs
@@ -246,6 +246,13 @@ impl LeaseRenewer {
                 });
             }
 
+            if expires_at - LEASE_DURATION + (LEASE_RENEW_INTERVAL / 2) > now {
+                // Don't acquire a new lease. Let the process use the existing
+                // lease. This should help in reducing the number of writes to
+                // the lease object.
+                return Ok(lease.generation);
+            }
+
             // Lease was locked, but expired. This should not happen in normal
             // cases. Log an error so we can catch it and investigate.
             error!( prev_held_by = %held_by, acquiring_process = %self.process_id, db_id = %self.db_id,

--- a/crates/metastore/src/storage/mod.rs
+++ b/crates/metastore/src/storage/mod.rs
@@ -73,13 +73,14 @@ pub trait StorageObject<S: AsRef<str>> {
 
     /// Get a temporary path to use for this process.
     ///
-    /// Path format: 'database/<db_id>/tmp/<proc_id>/<object_name>'
+    /// Path format: 'database/<db_id>/tmp/<proc_id>/<object_name>/<random_id>'
     fn tmp_path(&self, db_id: &Uuid, process_id: &Uuid) -> ObjectPath {
         ObjectPath::from(format!(
-            "databases/{}/tmp/{}/{}",
+            "databases/{}/tmp/{}/{}/{}",
             db_id,
             process_id,
             self.object_name().as_ref(),
+            Uuid::new_v4(), // Random suffix
         ))
     }
 


### PR DESCRIPTION
The temp path is generated with a random UUID as suffix.