### PR TITLE
fix: resolve aliased catalogs

### DIFF
--- a/crates/catalog/src/session_catalog.rs
+++ b/crates/catalog/src/session_catalog.rs
@@ -47,6 +47,8 @@ pub struct ResolveConfig {
 /// from the remote state provided by metastore.
 #[derive(Clone, Debug)]
 pub struct SessionCatalog {
+    /// Optional alias for referencing objects in this catalog
+    alias: Option<String>,
     /// The state retrieved from a remote Metastore.
     state: Arc<CatalogState>,
     /// Map database names to their ids.
@@ -69,6 +71,7 @@ impl SessionCatalog {
     /// Create a new session catalog with an initial state.
     pub fn new(state: Arc<CatalogState>, resolve_conf: ResolveConfig) -> SessionCatalog {
         let mut catalog = SessionCatalog {
+            alias: None,
             state,
             database_names: HashMap::new(),
             tunnel_names: HashMap::new(),
@@ -80,6 +83,20 @@ impl SessionCatalog {
         };
         catalog.rebuild_name_maps();
         catalog
+    }
+
+    pub fn new_with_alias(
+        state: Arc<CatalogState>,
+        resolve_conf: ResolveConfig,
+        alias: String,
+    ) -> SessionCatalog {
+        let mut catalog = Self::new(state, resolve_conf);
+        catalog.alias = Some(alias);
+        catalog
+    }
+
+    pub fn alias(&self) -> Option<&str> {
+        self.alias.as_deref()
     }
 
     /// Get the version of this catalog state.

--- a/crates/sqlexec/src/remote/client.rs
+++ b/crates/sqlexec/src/remote/client.rs
@@ -281,12 +281,13 @@ impl RemoteClient {
 
         Ok((
             remote_sess_client,
-            SessionCatalog::new(
+            SessionCatalog::new_with_alias(
                 Arc::new(resp.catalog),
                 ResolveConfig {
                     default_schema_oid: SCHEMA_DEFAULT.oid,
                     session_schema_oid: SCHEMA_CURRENT_SESSION.oid,
                 },
+                self.get_deployment_name().to_string(),
             ),
         ))
     }

--- a/crates/sqlexec/src/resolve.rs
+++ b/crates/sqlexec/src/resolve.rs
@@ -77,7 +77,7 @@ impl<'a> EntryResolver<'a> {
                     return Ok(ResolvedEntry::Entry(CatalogEntry::Table(table)));
                 }
 
-                // builtin table functions should be independent of schema, pull them out of 'publc' schema
+                // builtin table functions should be independent of schema, pull them out of 'public' schema
                 if let Some(function) = self.catalog.resolve_builtin_table_function(table) {
                     return Ok(ResolvedEntry::Entry(CatalogEntry::Function(function)));
                 }


### PR DESCRIPTION
closes #2779 

Note for Reviewers: 

There isn't a real good way that I know of to add a test for this, so i will just share the steps I took to manually test it. 


1. go to console.glaredb.com
2. create a view in there: `create view "my_view" as select 1;`
3. connect to cloud via local
```sh
> just run local
> \open glaredb://<USER>:<PASS>@o_xTz3cuY.remote.glaredb.com:6443/quiet_frog
Connected to Cloud deployment (TLS enabled): quiet_frog
> select * from "quiet_frog"."public"."my_view";
┌──────────┐
│ Int64(1) │
│       ── │
│    Int64 │
╞══════════╡
│        1 │
└──────────┘
```

it also works the other way around. Previously a create statement `create view quiet_frog.public.my_view_2` would save it to the "default" db, now it properly saves it under the alias name

```sql
> create view "quiet_frog"."public"."my_view_2" as select 2;
View created
> select * from my_view_2;
┌──────────┐
│ Int64(2) │
│       ── │
│    Int64 │
╞══════════╡
│        2 │
└──────────┘
> select * from "quiet_frog"."public"."my_view_2";
┌──────────┐
│ Int64(2) │
│       ── │
│    Int64 │
╞══════════╡
│        2 │
└──────────┘
>
```