### PR TITLE
fix: Support null credentials for object store access.

### DIFF
--- a/crates/datasources/src/object_store/azure.rs
+++ b/crates/datasources/src/object_store/azure.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use datafusion::execution::object_store::ObjectStoreUrl;
-use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use object_store::azure::{AzureConfigKey, AzureCredential, MicrosoftAzureBuilder};
 use object_store::path::Path as ObjectStorePath;
-use object_store::ObjectStore;
+use object_store::{CredentialProvider, ObjectStore};
 use protogen::metastore::types::options::StorageOptions;
 
 use super::errors::{ObjectStoreSourceError, Result};
@@ -70,16 +71,36 @@ impl ObjStoreAccess for AzureStoreAccess {
     fn create_store(&self) -> Result<Arc<dyn ObjectStore>> {
         let mut builder = MicrosoftAzureBuilder::new();
 
+        let mut creds = false;
+
         for (key, val) in self.opts.iter() {
+            if matches!(
+                key,
+                AzureConfigKey::AccountName
+                    | AzureConfigKey::AccessKey
+                    | AzureConfigKey::ClientId
+                    | AzureConfigKey::ClientSecret
+                    | AzureConfigKey::SasKey
+                    | AzureConfigKey::Token
+            ) {
+                creds = true;
+            }
+
             builder = builder.with_config(*key, val);
         }
 
         if let Some(account_name) = &self.account_name {
+            creds = true;
             builder = builder.with_account(account_name);
         }
 
         if let Some(access_key) = &self.access_key {
+            creds = true;
             builder = builder.with_access_key(access_key);
+        }
+
+        if !creds {
+            builder = builder.with_credentials(Arc::new(NullCredentialProvider));
         }
 
         let build = builder.with_container_name(&self.container).build()?;
@@ -88,5 +109,17 @@ impl ObjStoreAccess for AzureStoreAccess {
 
     fn path(&self, location: &str) -> Result<ObjectStorePath> {
         Ok(ObjectStorePath::from_url_path(location)?)
+    }
+}
+
+#[derive(Debug)]
+struct NullCredentialProvider;
+
+#[async_trait]
+impl CredentialProvider for NullCredentialProvider {
+    type Credential = AzureCredential;
+
+    async fn get_credential(&self) -> Result<Arc<Self::Credential>, object_store::Error> {
+        Ok(Arc::new(AzureCredential::BearerToken(String::new())))
     }
 }


### PR DESCRIPTION
GCS works (raising a PR for NULL Credentials):

```
> select * from 'gs://vrongmeal-public-test/data.csv';
┌───────┬─────────┐
│    id │ name    │
│    ── │ ──      │
│ Int64 │ Utf8    │
╞═══════╪═════════╡
│     1 │ vaibhav │
│     2 │ sean    │
│     3 │ grey    │
└───────┴─────────┘
```

Need to make a similar change upstream for S3 and Azure.

Fixes: #1065