### PR TITLE
fix: properly alias all sessions

### DIFF
--- a/crates/catalog/src/session_catalog.rs
+++ b/crates/catalog/src/session_catalog.rs
@@ -90,7 +90,7 @@ impl SessionCatalog {
         resolve_conf: ResolveConfig,
         alias: String,
     ) -> SessionCatalog {
-        let mut catalog = Self::new(state, resolve_conf);
+        let catalog = Self::new(state, resolve_conf);
         catalog.with_alias(alias)
     }
 

--- a/crates/catalog/src/session_catalog.rs
+++ b/crates/catalog/src/session_catalog.rs
@@ -91,8 +91,12 @@ impl SessionCatalog {
         alias: String,
     ) -> SessionCatalog {
         let mut catalog = Self::new(state, resolve_conf);
-        catalog.alias = Some(alias);
-        catalog
+        catalog.with_alias(alias)
+    }
+
+    pub fn with_alias(mut self, alias: String) -> SessionCatalog {
+        self.alias = Some(alias);
+        self
     }
 
     pub fn alias(&self) -> Option<&str> {

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -420,8 +420,6 @@ impl Engine {
         vars: SessionVars,
         storage: SessionStorageConfig,
     ) -> Result<TrackedSession> {
-        println!("new_local_session_context");
-
         let session = self.new_untracked_session(vars, storage).await?;
 
         let prev = self.session_counter.fetch_add(1, Ordering::Relaxed);

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -456,13 +456,13 @@ impl Engine {
 
         // If the database name is in the form of `<UUID>/<db_id>`, then we
         // should use the <db_id> as the alias for the database.
-        // else, we should just use the entire database name as the alias.
         let database_name = vars.database_name();
         if let Some((org_id, db_id)) = database_name.split_once('/') {
             if Uuid::parse_str(org_id).is_ok() {
                 catalog = catalog.with_alias(db_id.to_string());
             }
-        } else {
+        // else, we should use the entire database name as the alias if it's not empty
+        } else if !database_name.is_empty() {
             catalog = catalog.with_alias(database_name);
         }
 

--- a/crates/sqlexec/src/engine.rs
+++ b/crates/sqlexec/src/engine.rs
@@ -457,10 +457,12 @@ impl Engine {
         // If the database name is in the form of `<UUID>/<db_id>`, then we
         // should use the <db_id> as the alias for the database.
         let database_name = vars.database_name();
-        if let Some((org_id, db_id)) = database_name.split_once('/') {
-            if Uuid::parse_str(org_id).is_ok() {
-                catalog = catalog.with_alias(db_id.to_string());
-            }
+        if let Some(db_id) = database_name
+            .split_once('/')
+            // check if the first part is a valid UUID
+            .and_then(|(org_id, db_id)| Uuid::parse_str(org_id).ok().map(|_| db_id))
+        {
+            catalog = catalog.with_alias(db_id.to_string());
         // else, we should use the entire database name as the alias if it's not empty
         } else if !database_name.is_empty() {
             catalog = catalog.with_alias(database_name);


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2779

manually tested in cloud via:

```sql
create view "broken_sky"."public"."my_view" as select 1;
```

```sql
select * from "broken_sky"."public"."my_view";
```