### PR TITLE
chore(npm): fix napi argument

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -47,7 +47,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish --skip-gh-release=true -t npm",
+    "prepublishOnly": "napi prepublish --skip-gh-release -t npm",
     "test": "ava",
     "universal": "napi universal",
     "version": "napi version"


### PR DESCRIPTION
According to the print out here: https://github.com/GlareDB/glaredb/actions/runs/8363511181/job/22898484272#step:10:27

`napi` doesn't accept any args (`=true` in this case) for boolean flags.