### PR TITLE
feat: deprecate "drop credentials"

### DIFF
--- a/crates/pgsrv/src/handler.rs
+++ b/crates/pgsrv/src/handler.rs
@@ -757,8 +757,17 @@ where
             ExecutionResult::DropSchemas => Self::command_complete(conn, "DROP SCHEMA").await?,
             ExecutionResult::DropDatabase => Self::command_complete(conn, "DROP DATABASE").await?,
             ExecutionResult::DropTunnel => Self::command_complete(conn, "DROP TUNNEL").await?,
-            ExecutionResult::DropCredentials => {
-                Self::command_complete(conn, "DROP CREDENTIALS").await?
+            ExecutionResult::DropCredentials {
+                deprecation_message: None,
+            } => Self::command_complete(conn, "DROP CREDENTIALS").await?,
+            ExecutionResult::DropCredentials {
+                deprecation_message: Some(message),
+            } => {
+                Self::command_complete(
+                    conn,
+                    format!("DROP CREDENTIALS\nDEPRECATION WARNING. {message}"),
+                )
+                .await?
             }
         };
         Ok(())

--- a/crates/protogen/src/sqlexec/physical_plan.rs
+++ b/crates/protogen/src/sqlexec/physical_plan.rs
@@ -239,6 +239,8 @@ pub struct DropCredentialsExec {
     pub names: Vec<String>, // TODO: Do these live in schemas?
     #[prost(bool, tag = "3")]
     pub if_exists: bool,
+    #[prost(bool, tag = "4")]
+    pub show_deprecation_warning: bool,
 }
 
 #[derive(Clone, PartialEq, Message)]

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -335,7 +335,7 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                     catalog_version: ext.catalog_version,
                     names: ext.names,
                     if_exists: ext.if_exists,
-                    show_deprecation_warning: false,
+                    show_deprecation_warning: ext.show_deprecation_warning,
                 })
             }
             proto::ExecutionPlanExtensionType::DropTablesExec(ext) => Arc::new(DropTablesExec {
@@ -660,6 +660,7 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                 catalog_version: exec.catalog_version,
                 names: exec.names.clone(),
                 if_exists: exec.if_exists,
+                show_deprecation_warning: exec.show_deprecation_warning,
             })
         } else if let Some(exec) = node.as_any().downcast_ref::<DropTablesExec>() {
             proto::ExecutionPlanExtensionType::DropTablesExec(proto::DropTablesExec {

--- a/crates/sqlexec/src/extension_codec.rs
+++ b/crates/sqlexec/src/extension_codec.rs
@@ -335,6 +335,7 @@ impl<'a> PhysicalExtensionCodec for GlareDBExtensionCodec<'a> {
                     catalog_version: ext.catalog_version,
                     names: ext.names,
                     if_exists: ext.if_exists,
+                    show_deprecation_warning: false,
                 })
             }
             proto::ExecutionPlanExtensionType::DropTablesExec(ext) => Arc::new(DropTablesExec {

--- a/crates/sqlexec/src/planner/logical_plan/drop_credentials.rs
+++ b/crates/sqlexec/src/planner/logical_plan/drop_credentials.rs
@@ -8,6 +8,8 @@ use super::{
 pub struct DropCredentials {
     pub names: Vec<String>,
     pub if_exists: bool,
+    /// If true, show a deprecation warning when the operation is executed.
+    pub show_deprecation_warning: bool,
 }
 
 impl UserDefinedLogicalNodeCore for DropCredentials {

--- a/crates/sqlexec/src/planner/physical_plan/drop_credentials.rs
+++ b/crates/sqlexec/src/planner/physical_plan/drop_credentials.rs
@@ -24,6 +24,7 @@ use super::{
     new_operation_batch,
     new_operation_with_deprecation_batch,
     GENERIC_OPERATION_PHYSICAL_SCHEMA,
+    GENERIC_OPERATION_WITH_DEPRECATION_PHYSICAL_SCHEMA,
 };
 
 const DEPRECATION_MESSAGE: &str = "`DROP CREDENTIALS` is deprecated and will be removed in a future release. Use `DROP CREDENTIAL` instead.";
@@ -43,7 +44,11 @@ impl ExecutionPlan for DropCredentialsExec {
     }
 
     fn schema(&self) -> Arc<Schema> {
-        GENERIC_OPERATION_PHYSICAL_SCHEMA.clone()
+        if self.show_deprecation_warning {
+            GENERIC_OPERATION_WITH_DEPRECATION_PHYSICAL_SCHEMA.clone()
+        } else {
+            GENERIC_OPERATION_PHYSICAL_SCHEMA.clone()
+        }
     }
 
     fn output_partitioning(&self) -> Partitioning {

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -1717,6 +1717,7 @@ impl<'a> SessionPlanner<'a> {
         Ok(DropCredentials {
             names,
             if_exists: stmt.if_exists,
+            show_deprecation_warning: stmt.deprecated,
         }
         .into_logical_plan())
     }

--- a/crates/sqlexec/src/remote/planner.rs
+++ b/crates/sqlexec/src/remote/planner.rs
@@ -287,6 +287,7 @@ impl ExtensionPlanner for DDLExtensionPlanner {
                     catalog_version: self.catalog.version(),
                     names: lp.names.clone(),
                     if_exists: lp.if_exists,
+                    show_deprecation_warning: lp.show_deprecation_warning,
                 };
                 RuntimeGroupExec::new(RuntimePreference::Remote, Arc::new(exec))
             }

--- a/testdata/sqllogictests/drop.slt
+++ b/testdata/sqllogictests/drop.slt
@@ -114,6 +114,22 @@ drop credentials drop_credentials;
 statement ok
 drop credentials if exists drop_credentials;
 
+# try again but with `credential` keyword instead of `credentials`
+
+statement ok
+create credential drop_credentials provider debug options (table_type = 'never_ending');
+
+statement ok
+drop credential drop_credentials;
+
+statement error
+drop credential drop_credentials;
+
+statement ok
+drop credential if exists drop_credentials;
+
+# ---
+
 query TT
 select credentials_name, provider
     from glare_catalog.credentials where credentials_name='drop_credentials';


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2796

```sh
> drop credential if exists debug_creds;
Credentials dropped
> drop credentials exists debug_creds;
Credentials dropped
DEPRECATION WARNING: `DROP CREDENTIALS` is deprecated and will be removed in a future release. Use `DROP CREDENTIAL` instead.
```

## Note for reviewers

The deprecation message itself is purposely not tested in the SLT's as it will be removed in a future release. 

