### PR TITLE
fix: non-deterministic http test

### DIFF
--- a/testdata/sqllogictests/http.slt
+++ b/testdata/sqllogictests/http.slt
@@ -5,7 +5,10 @@ statement error  Error during planning: missing file extension: http://host.com/
 select * from 'http://host.com/path/*'
 
 # Querying a source without "Content-Length" information.
+# TODO: this test is flaky as the source changes. Verify with:
+#    curl 'https://opdb.org/api/search/typeahead?q=*' | jq length
+#
 query I
 SELECT count(*) FROM read_json('https://opdb.org/api/search/typeahead?q=*');
 ----
-100
+99


### PR DESCRIPTION
(this is failing in a number of orthogonal open PRs. verified that the
result is correct without using glaredb.) wanted to make a PR for only
this change just to create a paper trail for this one.