### PR TITLE
fix: case sensitive with cast for delta

### DIFF
--- a/crates/datasources/src/native/access.rs
+++ b/crates/datasources/src/native/access.rs
@@ -8,7 +8,7 @@ use datafusion::common::ToDFSchema;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::context::SessionState;
-use datafusion::logical_expr::{col, Cast, LogicalPlan, TableProviderFilterPushDown, TableType};
+use datafusion::logical_expr::{ident, Cast, LogicalPlan, TableProviderFilterPushDown, TableType};
 use datafusion::physical_expr::create_physical_expr;
 use datafusion::physical_expr::execution_props::ExecutionProps;
 use datafusion::physical_plan::empty::EmptyExec;
@@ -448,10 +448,10 @@ impl TableProvider for NativeTable {
                     .zip(schema.fields())
                     .map(|(f1, f2)| {
                         let expr = if f1.data_type() == f2.data_type() {
-                            col(f1.name())
+                            ident(f1.name())
                         } else {
                             let cast_expr =
-                                Cast::new(Box::new(col(f1.name())), f2.data_type().clone());
+                                Cast::new(Box::new(ident(f1.name())), f2.data_type().clone());
                             Expr::Cast(cast_expr)
                         };
                         let execution_props = ExecutionProps::new();

--- a/testdata/sqllogictests/create_table.slt
+++ b/testdata/sqllogictests/create_table.slt
@@ -119,3 +119,10 @@ select * from "Case_Sensitive"
 statement ok
 select * from "Case Sensitive"
 
+
+# https://github.com/GlareDB/glaredb/issues/2777
+statement ok
+create table test as select vector, point as "Point" from lance_scan('./testdata/lance/table1');
+
+statement ok
+select * from test;


### PR DESCRIPTION
closes https://github.com/GlareDB/glaredb/issues/2777

Note: 
`ident` preserves case sensitivity while `col` does not. 