### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # Keep this up to date with .gitignore
+.DS_Store
 
 .pre-commit-config.yaml
 # nix build results

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Adding something new? It's probably good to add to .dockerignore too.
+.DS_Store
 
 .pre-commit-config.yaml
 # Cargo target directories.


### PR DESCRIPTION
Occasionally, I like to use finder and it always creates these `.DS_Store` files. Best to just ignore them. 