### PR TITLE
refactor: use "arc<mutex<session>>" in repl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "object_store_util",
+ "parking_lot",
  "parser",
  "pgrepr",
  "pgsrv",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ glob = "0.3.1"
 
 # Prevent dynamic linking of lzma, which comes from datafusion
 lzma-sys = { version = "*", features = ["static"] }
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 predicates = "3.1.0"


### PR DESCRIPTION
very small PR to use `Arc<Mutex<>>` in the repl for `TrackedSession`. Just some prereq work for adding tab completions. 