### PR TITLE
fix: Don't preprocess database name when setting session catalog alias

### DIFF
--- a/crates/catalog/src/session_catalog.rs
+++ b/crates/catalog/src/session_catalog.rs
@@ -84,15 +84,11 @@ impl SessionCatalog {
     pub fn new_with_alias(
         state: Arc<CatalogState>,
         resolve_conf: ResolveConfig,
-        alias: String,
+        alias: impl Into<String>,
     ) -> SessionCatalog {
-        let catalog = Self::new(state, resolve_conf);
-        catalog.with_alias(alias)
-    }
-
-    pub fn with_alias(mut self, alias: String) -> SessionCatalog {
-        self.alias = Some(alias);
-        self
+        let mut catalog = Self::new(state, resolve_conf);
+        catalog.alias = Some(alias.into());
+        catalog
     }
 
     pub fn alias(&self) -> Option<&str> {

--- a/crates/sqlexec/src/resolve.rs
+++ b/crates/sqlexec/src/resolve.rs
@@ -152,3 +152,170 @@ impl<'a> EntryResolver<'a> {
         Err(ResolveError(format!("failed to find table: {reference}")))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use catalog::session_catalog::ResolveConfig;
+    use protogen::metastore::types::catalog::{
+        CatalogState,
+        DeploymentMetadata,
+        EntryMeta,
+        EntryType,
+        SchemaEntry,
+        SourceAccessMode,
+    };
+    use protogen::metastore::types::options::TableOptionsV0;
+
+    use super::*;
+
+    fn new_test_catalog_state() -> CatalogState {
+        let entries = [
+            // Schemas
+            CatalogEntry::Schema(SchemaEntry {
+                meta: EntryMeta {
+                    entry_type: EntryType::Schema,
+                    id: 1,
+                    parent: 0,
+                    name: "my_schema1".to_string(),
+                    builtin: false,
+                    external: false,
+                    is_temp: false,
+                },
+            }),
+            CatalogEntry::Schema(SchemaEntry {
+                meta: EntryMeta {
+                    entry_type: EntryType::Schema,
+                    id: 2,
+                    parent: 0,
+                    name: "my_schema2".to_string(),
+                    builtin: false,
+                    external: false,
+                    is_temp: false,
+                },
+            }),
+            // Tables
+            CatalogEntry::Table(TableEntry {
+                meta: EntryMeta {
+                    entry_type: EntryType::Schema,
+                    id: 3,
+                    parent: 1,
+                    name: "table1".to_string(),
+                    builtin: false,
+                    external: false,
+                    is_temp: false,
+                },
+                options: TableOptionsV0::new_internal(Vec::new()),
+                tunnel_id: None,
+                access_mode: SourceAccessMode::ReadWrite,
+                columns: None,
+            }),
+            // Tables
+            CatalogEntry::Table(TableEntry {
+                meta: EntryMeta {
+                    entry_type: EntryType::Schema,
+                    id: 4,
+                    parent: 2,
+                    name: "table2".to_string(),
+                    builtin: false,
+                    external: false,
+                    is_temp: false,
+                },
+                options: TableOptionsV0::new_internal(Vec::new()),
+                tunnel_id: None,
+                access_mode: SourceAccessMode::ReadWrite,
+                columns: None,
+            }),
+        ];
+
+        let entries: HashMap<_, _> = entries
+            .into_iter()
+            .map(|ent| (ent.get_meta().id, ent))
+            .collect();
+
+        CatalogState {
+            version: 0,
+            entries,
+            deployment: DeploymentMetadata { storage_size: 0 },
+            catalog_version: 0,
+        }
+    }
+
+    #[test]
+    fn resolve_with_table_name() {
+        let session_catalog = SessionCatalog::new(
+            Arc::new(new_test_catalog_state()),
+            ResolveConfig {
+                default_schema_oid: 0,
+                session_schema_oid: 0,
+            },
+        );
+
+        let resolver = EntryResolver {
+            catalog: &session_catalog,
+            schema_search_path: vec!["my_schema1".to_string()],
+        };
+
+        let ent = resolver
+            .resolve_entry_from_reference(TableReference::Bare {
+                table: "table1".into(),
+            })
+            .unwrap();
+        let table_ent = ent.try_into_table_entry().unwrap();
+
+        assert_eq!("table1", table_ent.meta.name);
+    }
+
+    #[test]
+    fn resolve_fully_qualified_with_default() {
+        let session_catalog = SessionCatalog::new(
+            Arc::new(new_test_catalog_state()),
+            ResolveConfig {
+                default_schema_oid: 0,
+                session_schema_oid: 0,
+            },
+        );
+
+        let resolver = EntryResolver {
+            catalog: &session_catalog,
+            schema_search_path: vec!["my_schema1".to_string()],
+        };
+
+        let ent = resolver
+            .resolve_entry_from_reference(TableReference::full("default", "my_schema2", "table2"))
+            .unwrap();
+        let table_ent = ent.try_into_table_entry().unwrap();
+
+        assert_eq!("table2", table_ent.meta.name);
+    }
+
+    #[test]
+    fn resolve_fully_qualified_with_alias() {
+        let session_catalog = SessionCatalog::new_with_alias(
+            Arc::new(new_test_catalog_state()),
+            ResolveConfig {
+                default_schema_oid: 0,
+                session_schema_oid: 0,
+            },
+            "hello3/crimson_snow",
+        );
+
+        let resolver = EntryResolver {
+            catalog: &session_catalog,
+            schema_search_path: vec!["my_schema1".to_string()],
+        };
+
+        let ent = resolver
+            .resolve_entry_from_reference(TableReference::full(
+                "hello3/crimson_snow",
+                "my_schema2",
+                "table2",
+            ))
+            .unwrap();
+        let table_ent = ent.try_into_table_entry().unwrap();
+
+        assert_eq!("table2", table_ent.meta.name);
+    }
+}


### PR DESCRIPTION
Previously we were doing some processing on the database name to try to extract out the "true" name from names that follow the "org/database" format. However that meant if someone connects to the db over postgres using a hostname like "proxy.glaredb.com/my_org/my_db", we would set the catalog alias to only "my_db", disallowing queries like `SELECT * FROM
"my_org/my_db"."my_schema"."my_table"` even though that's a valid query given the connect string.

This change makes the name returned from `SHOW database_name` consistent with the alias we set on the session catalog, allowing the previous query to work as expected.