### PR TITLE
build: Make sure docker image has cmake during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM rust:1.75-bookworm AS builder
 
+# Get cmake for zlib-ng
+#
+# Required to build: <https://github.com/rust-lang/libz-sys?tab=readme-ov-file#zlib-ng>
+RUN apt-get update -y && apt-get install -y cmake
+
 # Copy in source.
 WORKDIR /usr/src/glaredb
 COPY . .
 
 RUN cargo install just
+
 # Build release binary.
 RUN just build --release
 


### PR DESCRIPTION
Required for zlib-ng