### PR TITLE
fix: excel table function should read data more consistently from remote sources

### DIFF
--- a/crates/datasources/src/excel/table.rs
+++ b/crates/datasources/src/excel/table.rs
@@ -32,7 +32,7 @@ pub struct ExcelTableProvider {
 
 impl ExcelTableProvider {
     pub async fn try_new(t: ExcelTable) -> Result<Self, ExcelError> {
-        let infer_num = t.cell_range.height();
+        let infer_num = t.cell_range.width();
         Self::try_new_with_inferred(t, infer_num).await
     }
 

--- a/crates/datasources/src/excel/table.rs
+++ b/crates/datasources/src/excel/table.rs
@@ -26,20 +26,25 @@ use crate::excel::ExcelTable;
 
 pub struct ExcelTableProvider {
     cell_range: calamine::Range<calamine::Data>,
-    header: bool,
+    has_header: bool,
     schema: Arc<Schema>,
 }
 
 impl ExcelTableProvider {
     pub async fn try_new(t: ExcelTable) -> Result<Self, ExcelError> {
-        let cell_range = t.cell_range;
-        let schema_len = cell_range.width();
-        let schema = excel::infer_schema(&cell_range, t.has_header, schema_len)?;
+        let infer_num = t.cell_range.height();
+        Self::try_new_with_inferred(t, infer_num).await
+    }
 
-        Ok(ExcelTableProvider {
-            schema: Arc::new(schema),
+    pub async fn try_new_with_inferred(t: ExcelTable, num: usize) -> Result<Self, ExcelError> {
+        let cell_range = t.cell_range;
+        let has_header = t.has_header;
+        let schema = Arc::new(excel::infer_schema(&cell_range, t.has_header, num)?);
+
+        Ok(Self {
+            schema,
             cell_range,
-            header: t.has_header,
+            has_header,
         })
     }
 }
@@ -76,7 +81,7 @@ impl TableProvider for ExcelTableProvider {
         Ok(Arc::new(ExcelExecutionPlan {
             arrow_schema: projected_schema,
             cell_range: self.cell_range.clone(),
-            header: self.header,
+            header: self.has_header,
         }))
     }
 }

--- a/crates/protogen/proto/metastore/options.proto
+++ b/crates/protogen/proto/metastore/options.proto
@@ -218,7 +218,7 @@ message TableOptionsExcel {
   optional string file_type = 3;
   optional string compression = 4;
   optional string sheet_name = 5;
-  bool has_header = 6;
+  optional bool has_header = 6;
 }
 
 message TableOptionsSnowflake {

--- a/crates/protogen/src/metastore/types/options.rs
+++ b/crates/protogen/src/metastore/types/options.rs
@@ -1369,7 +1369,7 @@ pub struct TableOptionsExcel {
     pub file_type: Option<String>,
     pub compression: Option<String>,
     pub sheet_name: Option<String>,
-    pub has_header: bool,
+    pub has_header: Option<bool>,
 }
 
 impl From<TableOptionsExcel> for TableOptionsV0 {

--- a/crates/sqlbuiltins/src/functions/table/excel.rs
+++ b/crates/sqlbuiltins/src/functions/table/excel.rs
@@ -4,15 +4,18 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{DataType, Field, Fields};
 use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
 use datafusion_ext::errors::{ExtensionError, Result};
 use datafusion_ext::functions::{FuncParamValue, TableFuncContextProvider};
-use datasources::common::url::DatasourceUrl;
-use datasources::excel::read_excel_impl;
-use ioutil::resolve_path;
+use datasources::common::url::DatasourceUrlType;
+use datasources::excel::table::ExcelTableProvider;
+use datasources::excel::ExcelTable;
+use datasources::lake::storage_options_into_store_access;
 use protogen::metastore::types::catalog::{FunctionType, RuntimePreference};
 
 use super::{table_location_and_opts, TableFunc};
+use crate::functions::table::object_store::urls_from_args;
 use crate::functions::ConstBuiltinFunction;
 
 #[derive(Debug, Clone, Copy)]
@@ -48,10 +51,24 @@ impl ConstBuiltinFunction for ExcelScan {
 impl TableFunc for ExcelScan {
     fn detect_runtime(
         &self,
-        _args: &[FuncParamValue],
+        args: &[FuncParamValue],
         _parent: RuntimePreference,
     ) -> Result<RuntimePreference> {
-        Ok(RuntimePreference::Local)
+        let urls = urls_from_args(args)?;
+        if urls.is_empty() {
+            return Err(ExtensionError::ExpectedIndexedArgument {
+                index: 0,
+                what: "location of the table".to_string(),
+            });
+        }
+
+        Ok(match urls.first().unwrap().datasource_url_type() {
+            DatasourceUrlType::File => RuntimePreference::Local,
+            DatasourceUrlType::Http => RuntimePreference::Remote,
+            DatasourceUrlType::Gcs => RuntimePreference::Remote,
+            DatasourceUrlType::S3 => RuntimePreference::Remote,
+            DatasourceUrlType::Azure => RuntimePreference::Remote,
+        })
     }
 
     async fn create_provider(
@@ -60,19 +77,11 @@ impl TableFunc for ExcelScan {
         args: Vec<FuncParamValue>,
         mut opts: HashMap<String, FuncParamValue>,
     ) -> Result<Arc<dyn TableProvider>> {
-        let (source_url, _) = table_location_and_opts(ctx, args, &mut opts)?;
+        let (source_url, storage_options) = table_location_and_opts(ctx, args, &mut opts)?;
 
-        let url = match source_url {
-            DatasourceUrl::File(path) => path,
-            DatasourceUrl::Url(url) => {
-                return Err(ExtensionError::String(format!(
-                    "Expected file, received url: {}",
-                    url
-                )))
-            }
-        };
+        let store_access = storage_options_into_store_access(&source_url, &storage_options)
+            .map_err(ExtensionError::access)?;
 
-        let url = resolve_path(&url)?;
         let sheet_name: Option<String> = opts
             .remove("sheet_name")
             .map(FuncParamValue::try_into)
@@ -84,16 +93,20 @@ impl TableFunc for ExcelScan {
             .transpose()?
             .unwrap_or(true);
 
-        let infer_schema_len = opts
+        let infer_num = opts
             .remove("infer_rows")
             .map(FuncParamValue::try_into)
             .transpose()?
             .unwrap_or(100);
 
-        let table = read_excel_impl(&url, sheet_name.as_deref(), has_header, infer_schema_len)
+        let table = ExcelTable::open(store_access, source_url, sheet_name, has_header)
             .await
-            .map_err(|e| ExtensionError::Access(Box::new(e)))?;
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        Ok(Arc::new(table))
+        let provider = ExcelTableProvider::try_new_with_inferred(table, infer_num)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(Arc::new(provider))
     }
 }

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -444,10 +444,10 @@ impl<'a> ExternalDispatcher<'a> {
             }) => {
                 let source_url = DatasourceUrl::try_new(location)?;
                 let store_access = storage_options_into_store_access(&source_url, storage_options)?;
-                let sheet_name: Option<&str> = sheet_name.as_deref();
 
                 let table =
-                    ExcelTable::open(store_access, source_url, sheet_name, *has_header).await?;
+                    ExcelTable::open(store_access, source_url, sheet_name.to_owned(), *has_header)
+                        .await?;
                 let provider = ExcelTableProvider::try_new(table).await?;
 
                 Ok(Arc::new(provider))

--- a/crates/sqlexec/src/dispatch/external.rs
+++ b/crates/sqlexec/src/dispatch/external.rs
@@ -445,9 +445,13 @@ impl<'a> ExternalDispatcher<'a> {
                 let source_url = DatasourceUrl::try_new(location)?;
                 let store_access = storage_options_into_store_access(&source_url, storage_options)?;
 
-                let table =
-                    ExcelTable::open(store_access, source_url, sheet_name.to_owned(), *has_header)
-                        .await?;
+                let table = ExcelTable::open(
+                    store_access,
+                    source_url,
+                    sheet_name.to_owned(),
+                    has_header.unwrap_or(true),
+                )
+                .await?;
                 let provider = ExcelTableProvider::try_new(table).await?;
 
                 Ok(Arc::new(provider))

--- a/crates/sqlexec/src/planner/session_planner.rs
+++ b/crates/sqlexec/src/planner/session_planner.rs
@@ -925,8 +925,7 @@ impl<'a> SessionPlanner<'a> {
                 let has_header = storage_options
                     .inner
                     .get("has_header")
-                    .map(|val| val.parse::<bool>().unwrap_or(true))
-                    .unwrap_or_default();
+                    .map(|val| val.parse::<bool>().unwrap_or(true));
 
                 if let DatasourceUrl::File(p) = DatasourceUrl::try_new(&location)? {
                     if !p.exists() {

--- a/testdata/sqllogictests/xlsx.slt
+++ b/testdata/sqllogictests/xlsx.slt
@@ -116,7 +116,7 @@ drop table basic_report;
 statement error
 create external table bad_report from excel options(location='./invalid_path/random.abc');
 
-# should default to header=true and the first sheet of the file, if not specified
+# should default to has_header=true and the first sheet of the file, if not specified
 statement ok
 create external table html_table from excel options(location='https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx');
 
@@ -129,7 +129,7 @@ select "Resources", "Cost", "Revenue" from html_table;
 4 40 400
 5 50 500
 
-# should default to header=true and the first sheet of the file, if not specified
+# should default to has_header=true and the first sheet of the file, if not specified
 query
 select "Resources", "Cost", "Revenue" from read_excel('https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx');
 ----

--- a/testdata/sqllogictests/xlsx.slt
+++ b/testdata/sqllogictests/xlsx.slt
@@ -115,3 +115,34 @@ drop table basic_report;
 
 statement error
 create external table bad_report from excel options(location='./invalid_path/random.abc');
+
+# should default to header=true and the first sheet of the file, if not specified
+statement ok
+create external table html_table from excel options(location='https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx');
+
+query
+select "Resources", "Cost", "Revenue" from html_table;
+----
+1 10 100
+2 20 200
+3 30 300
+4 40 400
+5 50 500
+
+# should default to header=true and the first sheet of the file, if not specified
+query
+select "Resources", "Cost", "Revenue" from read_excel('https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx');
+----
+1 10 100
+2 20 200
+3 30 300
+4 40 400
+5 50 500
+
+query
+select "Resources", "Cost", "Revenue" from read_excel('https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx', sheet_name => 'other', has_header => false);
+----
+"HEADING"
+1
+2
+3

--- a/testdata/sqllogictests/xlsx.slt
+++ b/testdata/sqllogictests/xlsx.slt
@@ -140,9 +140,9 @@ select "Resources", "Cost", "Revenue" from read_excel('https://github.com/GlareD
 5 50 500
 
 query
-select "Resources", "Cost", "Revenue" from read_excel('https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx', sheet_name => 'other', has_header => false);
+select * from read_excel('https://github.com/GlareDB/glaredb/raw/main/testdata/xlsx/multiple_sheets.xlsx', sheet_name => 'other', has_header => false);
 ----
-"HEADING"
+NULL
 1
 2
 3


### PR DESCRIPTION
We previously had different dispatching and validation rules for
`read_excel` and other tables. This should make the code paths more
similar for the table function and the external tables.

@talagluck maybe worth adding some more tests to this one