### PR TITLE
fix: clarify evaluation semantics for DDL operations in bindings

### DIFF
--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -34,6 +34,10 @@ impl From<PyDatabaseError> for PyErr {
                 glaredb::DatabaseError::ConfigurationBuilder(err) => {
                     ConfigurationException::new_err(err.to_string())
                 }
+                glaredb::DatabaseError::CannotResolveUnevaluatedOperation
+                | glaredb::DatabaseError::UnsupportedLazyEvaluation => {
+                    PyRuntimeError::new_err(gerr.to_string())
+                }
             },
         }
     }

--- a/bindings/python/tests/test_execution_model.py
+++ b/bindings/python/tests/test_execution_model.py
@@ -26,6 +26,12 @@ def test_eager_ddl():
     two.execute()
     assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 3
 
+    three = con.sql("insert into tblsqlhelper values (5, 6);").to_pandas()
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 4
+
+    four = con.sql("insert into tblsqlhelper values (7, 8);").show()
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 5
+
 
 def test_execute_is_eager():
     con = glaredb.connect()

--- a/bindings/python/tests/test_execution_model.py
+++ b/bindings/python/tests/test_execution_model.py
@@ -2,20 +2,30 @@ import glaredb
 import pytest
 
 
-def test_sql_validates_plan():
+def test_eager_ddl():
     con = glaredb.connect()
-
+    
     with pytest.raises(Exception):
-        con.sql("select count(*) from tblsqlhelper;")
+        con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 0
 
-def test_sql_excludes_ddl():
-    con = glaredb.connect()
+    one = con.sql("create table tblsqlhelper (a int, b int);")
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 0
 
-    with pytest.raises(Exception):
-        con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0]
+    two = con.sql("insert into tblsqlhelper values (4, 2);")
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 1
 
-    with pytest.raises(Exception):
-        con.sql("create table tblsqlhelper (a int, b int);")
+    with pytest.raises(Exception, match="Duplicate name"):
+        one.execute()
+
+    assert con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 1
+
+    two = con.sql("insert into tblsqlhelper values (1, 2);")
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 2
+    assert con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 2
+
+    two.execute()
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 3
+
 
 def test_execute_is_eager():
     con = glaredb.connect()
@@ -26,3 +36,4 @@ def test_execute_is_eager():
     con.execute("create table tblexechelper (a int, b int);")
 
     assert con.sql("select count(*) from tblexechelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 0
+

--- a/bindings/python/tests/test_execution_model.py
+++ b/bindings/python/tests/test_execution_model.py
@@ -14,9 +14,6 @@ def test_eager_ddl():
     two = con.sql("insert into tblsqlhelper values (4, 2);")
     assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 1
 
-    with pytest.raises(Exception, match="Duplicate name"):
-        one.execute()
-
     assert con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 1
 
     two = con.sql("insert into tblsqlhelper values (1, 2);")
@@ -24,13 +21,13 @@ def test_eager_ddl():
     assert con.sql("select count(*) from tblsqlhelper;").to_arrow().to_pydict()["COUNT(*)"][0] == 2
 
     two.execute()
-    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 3
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 2
 
     three = con.sql("insert into tblsqlhelper values (5, 6);").to_pandas()
-    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 4
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 3
 
     four = con.sql("insert into tblsqlhelper values (7, 8);").show()
-    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 5
+    assert con.sql("select * from tblsqlhelper;").to_arrow().num_rows == 4
 
 
 def test_execute_is_eager():

--- a/crates/glaredb/src/lib.rs
+++ b/crates/glaredb/src/lib.rs
@@ -562,7 +562,7 @@ impl Operation {
 
         match self.op {
             OperationType::Sql => {
-                match &plan {
+                match plan.clone() {
                     sqlexec::LogicalPlan::Datafusion(dfplan) => match dfplan {
                         LogicalPlan::Dml(_)
                         | LogicalPlan::Ddl(_)
@@ -572,8 +572,9 @@ impl Operation {
                             Some(batches) => {
                                 return Ok(Box::pin(RecordBatchStreamAdapter::new(
                                     self.schema().clone().unwrap(),
+                                    #[allow(clippy::unnecessary_to_owned)]
                                     stream::iter(batches.to_owned().into_iter().map(Ok)).boxed(),
-                                )))
+                                )));
                             }
                             None => return Err(DatabaseError::UnsupportedLazyEvaluation),
                         },
@@ -624,8 +625,9 @@ impl Operation {
                 Some(batches) => {
                     return Ok(Box::pin(RecordBatchStreamAdapter::new(
                         self.schema().clone().unwrap(),
+                        #[allow(clippy::unnecessary_to_owned)]
                         stream::iter(batches.to_owned().into_iter().map(Ok)).boxed(),
-                    )))
+                    )));
                 }
                 None => {
                     let mut ses = self.conn.session.lock().await;

--- a/crates/glaredb/src/lib.rs
+++ b/crates/glaredb/src/lib.rs
@@ -572,8 +572,7 @@ impl Operation {
                             Some(batches) => {
                                 return Ok(Box::pin(RecordBatchStreamAdapter::new(
                                     self.schema().clone().unwrap(),
-                                    #[allow(clippy::unnecessary_to_owned)]
-                                    stream::iter(batches.to_owned().into_iter().map(Ok)).boxed(),
+                                    stream::iter(batches.clone().into_iter().map(Ok)).boxed(),
                                 )));
                             }
                             None => return Err(DatabaseError::UnsupportedLazyEvaluation),
@@ -625,8 +624,7 @@ impl Operation {
                 Some(batches) => {
                     return Ok(Box::pin(RecordBatchStreamAdapter::new(
                         self.schema().clone().unwrap(),
-                        #[allow(clippy::unnecessary_to_owned)]
-                        stream::iter(batches.to_owned().into_iter().map(Ok)).boxed(),
+                        stream::iter(batches.clone().into_iter().map(Ok)).boxed(),
                     )));
                 }
                 None => {

--- a/crates/pgrepr/src/notice.rs
+++ b/crates/pgrepr/src/notice.rs
@@ -117,6 +117,14 @@ impl Notice {
             message: msg.into(),
         }
     }
+
+    pub fn warning(msg: impl Into<String>) -> Notice {
+        Notice {
+            severity: NoticeSeverity::Warning,
+            code: SqlState::Warning,
+            message: msg.into(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -581,6 +581,11 @@ impl Session {
         self.ctx.take_notices()
     }
 
+    pub fn push_notice(&mut self, notice: Notice) {
+        self.ctx.push_notice(notice)
+    }
+
+
     /// Bind the parameters of a prepared statement to the given values.
     ///
     /// If successful, the bound statement will create a portal which can be

--- a/crates/sqlexec/src/session.rs
+++ b/crates/sqlexec/src/session.rs
@@ -585,7 +585,6 @@ impl Session {
         self.ctx.push_notice(notice)
     }
 
-
     /// Bind the parameters of a prepared statement to the given values.
     ///
     /// If successful, the bound statement will create a portal which can be


### PR DESCRIPTION
This restores the legacy semantics (ish) but caches the results for eagerly executed options so that calling the resolving methods (e.g. `to_pandas()`) won't error in the case of rexecution.

This will be weird in cases where `INSERT INTO foo VALUES(123, now()) "tick-tock")`, which you might expect to insert more than one row if it were being lazily evaluated in the old way.