### PR TITLE
feat: EXCLUDE/EXCEPT and REPLACE wildcard modifiers

### DIFF
--- a/crates/rayexec_execution/src/logical/binder/bind_context.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_context.rs
@@ -168,10 +168,10 @@ impl TableAlias {
 impl fmt::Display for TableAlias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(database) = &self.database {
-            write!(f, "{database}")?;
+            write!(f, "{database}.")?;
         }
         if let Some(schema) = &self.schema {
-            write!(f, "{schema}")?;
+            write!(f, "{schema}.")?;
         }
         write!(f, "{}", self.table)
     }

--- a/crates/rayexec_execution/src/logical/binder/bind_query/select_expr_expander.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_query/select_expr_expander.rs
@@ -98,7 +98,7 @@ impl<'a> SelectExprExpander<'a> {
 
                 for table in self.bind_context.iter_tables(self.current)? {
                     for (col_idx, name) in table.column_names.iter().enumerate() {
-                        // If column is already added from USING or EXLUDE, skip it.
+                        // If column is already added from USING, skip it.
                         if handled.contains(name) {
                             continue;
                         }

--- a/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
+++ b/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
@@ -48,9 +48,9 @@ impl<'a> ExpressionResolver<'a> {
 
     pub async fn resolve_wildcard(
         &self,
-        wildcard: ast::Wildcard<Raw>,
+        wildcard: ast::WildcardModifier<Raw>,
         resolve_context: &mut ResolveContext,
-    ) -> Result<ast::Wildcard<ResolvedMeta>> {
+    ) -> Result<ast::WildcardModifier<ResolvedMeta>> {
         let mut replace_cols = Vec::with_capacity(wildcard.replace_cols.len());
         for replace in wildcard.replace_cols {
             replace_cols.push(ReplaceColumn {
@@ -61,7 +61,7 @@ impl<'a> ExpressionResolver<'a> {
             });
         }
 
-        Ok(ast::Wildcard {
+        Ok(ast::WildcardModifier {
             exclude_cols: wildcard.exclude_cols,
             replace_cols,
         })

--- a/crates/rayexec_parser/src/keywords.rs
+++ b/crates/rayexec_parser/src/keywords.rs
@@ -92,6 +92,7 @@ define_keywords!(
     END,
     EPOCH,
     EXCEPT,
+    EXCLUDE,
     EXISTS,
     EXPLAIN,
     EXTERNAL,

--- a/slt/standard/select/exclude_except.slt
+++ b/slt/standard/select/exclude_except.slt
@@ -1,0 +1,61 @@
+# EXCEPT/EXCLUDE keyword tests
+
+statement ok
+CREATE TEMP TABLE t1 (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO t1 VALUES (2,3,4);
+
+query TT
+DESCRIBE SELECT * EXCLUDE (b) FROM t1;
+----
+a  Int32
+c  Int32
+
+query II
+SELECT * EXCLUDE (b) FROM t1;
+----
+2  4
+
+query II
+SELECT t1.* EXCLUDE (b) FROM t1;
+----
+2  4
+
+query I
+SELECT * EXCLUDE (b, a) FROM t1;
+----
+4
+
+# Alternative keyword.
+query I
+SELECT * EXCEPT (b, a) FROM t1;
+----
+4
+
+statement error Column "d" was in EXCLUDE list, but it's not a column being returned
+SELECT * EXCLUDE (d) FROM t1;
+
+query TT
+DESCRIBE SELECT * EXCLUDE (b) FROM t1, t1 AS t2;
+----
+a  Int32
+c  Int32
+a  Int32
+c  Int32
+
+query IIII
+SELECT * EXCLUDE (b) FROM t1, t1 AS t2;
+----
+2  4  2  4
+
+query TT
+DESCRIBE SELECT t2.* EXCLUDE (b) FROM t1, t1 AS t2;
+----
+a  Int32
+c  Int32
+
+query II
+SELECT t2.* EXCLUDE (b) FROM t1, t1 AS t2;
+----
+2  4

--- a/slt/standard/select/exclude_except.slt
+++ b/slt/standard/select/exclude_except.slt
@@ -36,6 +36,9 @@ SELECT * EXCEPT (b, a) FROM t1;
 statement error Column "d" was in EXCLUDE list, but it's not a column being returned
 SELECT * EXCLUDE (d) FROM t1;
 
+statement error Column "d" was in EXCLUDE list, but it's not a column being returned
+SELECT * EXCLUDE (a, d) FROM t1;
+
 query TT
 DESCRIBE SELECT * EXCLUDE (b) FROM t1, t1 AS t2;
 ----
@@ -59,3 +62,51 @@ query II
 SELECT t2.* EXCLUDE (b) FROM t1, t1 AS t2;
 ----
 2  4
+
+query TT
+DESCRIBE SELECT t2.* EXCLUDE (b), t1.* FROM t1, t1 AS t2
+----
+a  Int32
+c  Int32
+a  Int32
+b  Int32
+c  Int32
+
+query IIIII
+SELECT t2.* EXCLUDE (b), t1.* FROM t1, t1 AS t2;
+----
+2  4  2  3  4
+
+query III
+SELECT a, * EXCLUDE (b) FROM t1;
+----
+2  2  4
+
+query TT
+DESCRIBE SELECT * EXCLUDE (a) FROM t1 INNER JOIN t1 t2 USING(a);
+----
+b  Int32
+c  Int32
+b  Int32
+c  Int32
+
+query IIII
+SELECT * EXCLUDE (a) FROM t1 INNER JOIN t1 t2 USING(a);
+----
+3  4  3  4
+
+query TT
+DESCRIBE SELECT * EXCLUDE (b) FROM t1 INNER JOIN t1 t2 USING(a);
+----
+a  Int32
+c  Int32
+c  Int32
+
+query III
+SELECT * EXCLUDE (b) FROM t1 INNER JOIN t1 t2 USING(a);
+----
+2  4  4
+
+# TODO: Better error
+statement error
+SELECT * EXCLUDE (a, b, c) FROM t1 INNER JOIN t1 t2 USING(a);

--- a/slt/standard/select/replace.slt
+++ b/slt/standard/select/replace.slt
@@ -1,0 +1,75 @@
+# REPLACE wildcard modifier
+
+statement ok
+CREATE TEMP TABLE t1 (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO t1 VALUES (2,3,4);
+
+query TT
+DESCRIBE SELECT * REPLACE (a + 8 AS a) FROM t1
+----
+a  Int32
+b  Int32
+c  Int32
+
+query III
+SELECT * REPLACE (a + 8 AS a) FROM t1;
+----
+10  3  4
+
+query III
+SELECT * REPLACE (a AS a, a AS b, a AS c) FROM t1;
+----
+2  2  2
+
+query TT
+DESCRIBE SELECT * REPLACE (a + 8 AS a, repeat('c', c) AS c) FROM t1;
+----
+a  Int32
+b  Int32
+c  Utf8
+
+query IIT
+SELECT * REPLACE (a + 8 AS a, repeat('c', c) AS c) FROM t1;
+----
+10  3  cccc
+
+query IIIT
+SELECT a, * REPLACE (a + 8 AS a, repeat('c', c) AS c) FROM t1;
+----
+2  10  3  cccc
+
+statement error Duplicate table name: temp.temp.t1
+SELECT * REPLACE (a + 8 AS a) FROM t1, t1;
+
+statement error Ambiguous column name 'a'
+SELECT * REPLACE (a + 8 AS a) FROM t1, t1 AS t2;
+
+query IIII
+SELECT t1.a, t2.* REPLACE (t2.a + 8 AS a) FROM t1, t1 AS t2;
+----
+2  10  3  4
+
+query IIIIIII
+SELECT * REPLACE (t2.a + 8 AS a) FROM t1, t1 AS t2;
+----
+10  3  4  10  3  4
+
+query IIIII
+SELECT * REPLACE (a + 8 AS a) FROM t1 INNER JOIN t1 t2 USING (a);
+----
+10  3  4  3  4
+
+# REPLACE and EXCLUDE
+# TODO: TBD if we want to allow this, could be confusing.
+query TT
+DESCRIBE SELECT * EXCLUDE (a) REPLACE (repeat('c', c) AS c) FROM t1;
+----
+b  Int32
+c  Utf8
+
+query IT
+SELECT * EXCLUDE (a) REPLACE (repeat('c', c) AS c) FROM t1;
+----
+3  cccc


### PR DESCRIPTION
# EXCLUDE/EXCEPT

Omit columns from the out of a `select *`

```
>> CREATE TEMP TABLE t1 (a INT, b INT, c INT);
┌─────────────────────┐
│ Query success       │
│ No columns returned │
└─────────────────────┘

>> INSERT INTO t1 VALUES (2,3,4);
┌───────────────┐
│ rows_inserted │
│ UInt64        │
├───────────────┤
│             1 │
└───────────────┘

>> SELECT * EXCLUDE (b) FROM t1;
┌───────┬───────┐
│ a     │ c     │
│ Int32 │ Int32 │
├───────┼───────┤
│     2 │     4 │
└───────┴───────┘
```

# REPLACE

Replace columns in the output of a `select *`

```
>> CREATE TEMP TABLE t1 (a INT, b INT, c INT);
┌─────────────────────┐
│ Query success       │
│ No columns returned │
└─────────────────────┘

>> INSERT INTO t1 VALUES (2,3,4);
┌───────────────┐
│ rows_inserted │
│ UInt64        │
├───────────────┤
│             1 │
└───────────────┘

>> SELECT * REPLACE (a + 8 AS a) FROM t1;
┌───────┬───────┬───────┐
│ a     │ b     │ c     │
│ Int32 │ Int32 │ Int32 │
├───────┼───────┼───────┤
│    10 │     3 │     4 │
└───────┴───────┴───────┘
```