### PR TITLE
feat: COLUMNS('regex') expression in select list

### DIFF
--- a/crates/rayexec_execution/src/logical/binder/expr_binder.rs
+++ b/crates/rayexec_execution/src/logical/binder/expr_binder.rs
@@ -1066,6 +1066,18 @@ impl<'a> BaseExpressionBinder<'a> {
                     inputs: vec![date_part_expr, expr],
                 }))
             }
+            ast::Expr::Columns(_) => {
+                // TODO: This doens't need to be the case, but there's going to
+                // be slightly different handling if this is a top-level select
+                // expression, and argument to a function, or used elsewhere in
+                // the query.
+                //
+                // Currently we're just going to support top-level select
+                // expressions.
+                Err(RayexecError::new(
+                    "COLUMNS expression should have been handle in select list expander",
+                ))
+            }
         }
     }
 

--- a/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
+++ b/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
@@ -579,6 +579,7 @@ impl<'a> ExpressionResolver<'a> {
                     expr: Box::new(expr),
                 })
             }
+            ast::Expr::Columns(col) => Ok(ast::Expr::Columns(col)),
             other => not_implemented!("resolve expr {other:?}"),
         }
     }

--- a/crates/rayexec_parser/src/keywords.rs
+++ b/crates/rayexec_parser/src/keywords.rs
@@ -68,6 +68,7 @@ define_keywords!(
     CENTURIES,
     CENTURY,
     CLUSTER,
+    COLUMNS,
     COPY,
     CREATE,
     CROSS,

--- a/slt/standard/select/columns.slt
+++ b/slt/standard/select/columns.slt
@@ -1,0 +1,48 @@
+# COLUMNS expression in select list
+
+statement ok
+CREATE TEMP TABLE t1 (col_a INT, col_b INT, col_c INT, other INT);
+
+statement ok
+INSERT INTO t1 VALUES (2,3,4,5);
+
+query TT
+DESCRIBE SELECT COLUMNS('.*') FROM t1;
+----
+col_a  Int32
+col_b  Int32
+col_c  Int32
+other  Int32
+
+query IIII
+SELECT COLUMNS('.*') FROM t1;
+----
+2  3  4  5
+
+query TT
+DESCRIBE SELECT COLUMNS('.*_a|.*_c') FROM t1;
+----
+col_a  Int32
+col_c  Int32
+
+query II
+SELECT COLUMNS('.*_a|.*_c') FROM t1;
+----
+2  4
+
+query TT
+DESCRIBE SELECT COLUMNS('col_*') FROM t1;
+----
+col_a  Int32
+col_b  Int32
+col_c  Int32
+
+query III
+SELECT COLUMNS('col_*') FROM t1;
+----
+2  3  4
+
+query III
+SELECT col_a, COLUMNS('col_*') FROM t1;
+----
+2  2  3  4

--- a/slt/standard/select/columns.slt
+++ b/slt/standard/select/columns.slt
@@ -42,7 +42,7 @@ SELECT COLUMNS('col_*') FROM t1;
 ----
 2  3  4
 
-query III
+query IIII
 SELECT col_a, COLUMNS('col_*') FROM t1;
 ----
 2  2  3  4


### PR DESCRIPTION
Supports selecting columns by regex.

```
>> CREATE TEMP TABLE t1 (col_a INT, col_b INT, col_c INT, other INT);
┌─────────────────────┐
│ Query success       │
│ No columns returned │
└─────────────────────┘

>> INSERT INTO t1 VALUES (2,3,4,5);
┌───────────────┐
│ rows_inserted │
│ UInt64        │
├───────────────┤
│             1 │
└───────────────┘

>> SELECT COLUMNS('col_*') FROM t1;
┌───────┬───────┬───────┐
│ col_a │ col_b │ col_c │
│ Int32 │ Int32 │ Int32 │
├───────┼───────┼───────┤
│     2 │     3 │     4 │
└───────┴───────┴───────┘
```