### PR TITLE
feat: UNNEST in select list

### DIFF
--- a/crates/rayexec_bullet/src/executor/aggregate/mod.rs
+++ b/crates/rayexec_bullet/src/executor/aggregate/mod.rs
@@ -75,7 +75,7 @@ impl StateFinalizer {
         I: IntoIterator<Item = &'a mut State>,
         I::IntoIter: ExactSizeIterator,
         State: AggregateState<Input, Output> + 'a,
-        Output: Borrow<<B as ArrayDataBuffer>::Type>,
+        Output: Borrow<B::Type>,
     {
         let states = states.into_iter();
         let mut validities = Bitmap::new_with_all_true(states.len());

--- a/crates/rayexec_execution/src/execution/intermediate/planner.rs
+++ b/crates/rayexec_execution/src/execution/intermediate/planner.rs
@@ -1149,13 +1149,21 @@ impl<'a> IntermediatePipelineBuildState<'a> {
         let input_refs = input.get_output_table_refs(self.bind_context);
         self.walk(materializations, id_gen, input)?;
 
-        let expressions = self
+        let project_expressions = self
             .expr_planner
-            .plan_scalars(&input_refs, &unnest.node.expressions)
-            .context("Failed to plan expressions for unnest")?;
+            .plan_scalars(&input_refs, &unnest.node.project_expressions)
+            .context("Failed to plan project expressions for unnest")?;
+
+        let unnest_expressions = self
+            .expr_planner
+            .plan_scalars(&input_refs, &unnest.node.unnest_expressions)
+            .context("Failed to plan unnest expressions for unnest")?;
 
         let operator = IntermediateOperator {
-            operator: Arc::new(PhysicalOperator::Unnest(PhysicalUnnest { expressions })),
+            operator: Arc::new(PhysicalOperator::Unnest(PhysicalUnnest {
+                project_expressions,
+                unnest_expressions,
+            })),
             partitioning_requirement: None,
         };
 

--- a/crates/rayexec_execution/src/execution/intermediate/planner.rs
+++ b/crates/rayexec_execution/src/execution/intermediate/planner.rs
@@ -42,6 +42,7 @@ use crate::execution::operators::sort::scatter_sort::PhysicalScatterSort;
 use crate::execution::operators::table_function::PhysicalTableFunction;
 use crate::execution::operators::ungrouped_aggregate::PhysicalUngroupedAggregate;
 use crate::execution::operators::union::PhysicalUnion;
+use crate::execution::operators::unnest::PhysicalUnnest;
 use crate::execution::operators::values::PhysicalValues;
 use crate::execution::operators::PhysicalOperator;
 use crate::explain::context_display::ContextDisplayMode;
@@ -82,6 +83,7 @@ use crate::logical::logical_project::LogicalProject;
 use crate::logical::logical_scan::{LogicalScan, ScanSource};
 use crate::logical::logical_set::LogicalShowVar;
 use crate::logical::logical_setop::{LogicalSetop, SetOpKind};
+use crate::logical::logical_unnest::LogicalUnnest;
 use crate::logical::operator::{self, LocationRequirement, LogicalNode, LogicalOperator, Node};
 use crate::storage::table_storage::Projections;
 
@@ -256,6 +258,7 @@ impl<'a> IntermediatePipelineBuildState<'a> {
     ) -> Result<()> {
         match plan {
             LogicalOperator::Project(proj) => self.push_project(id_gen, materializations, proj),
+            LogicalOperator::Unnest(unnest) => self.push_unnest(id_gen, materializations, unnest),
             LogicalOperator::Filter(filter) => self.push_filter(id_gen, materializations, filter),
             LogicalOperator::Distinct(distinct) => {
                 self.push_distinct(id_gen, materializations, distinct)
@@ -1126,6 +1129,33 @@ impl<'a> IntermediatePipelineBuildState<'a> {
             operator: Arc::new(PhysicalOperator::Project(SimpleOperator::new(
                 ProjectOperation::new(projections),
             ))),
+            partitioning_requirement: None,
+        };
+
+        self.push_intermediate_operator(operator, location, id_gen)?;
+
+        Ok(())
+    }
+
+    fn push_unnest(
+        &mut self,
+        id_gen: &mut PipelineIdGen,
+        materializations: &mut Materializations,
+        mut unnest: Node<LogicalUnnest>,
+    ) -> Result<()> {
+        let location = unnest.location;
+
+        let input = unnest.take_one_child_exact()?;
+        let input_refs = input.get_output_table_refs(self.bind_context);
+        self.walk(materializations, id_gen, input)?;
+
+        let expressions = self
+            .expr_planner
+            .plan_scalars(&input_refs, &unnest.node.expressions)
+            .context("Failed to plan expressions for unnest")?;
+
+        let operator = IntermediateOperator {
+            operator: Arc::new(PhysicalOperator::Unnest(PhysicalUnnest { expressions })),
             partitioning_requirement: None,
         };
 

--- a/crates/rayexec_execution/src/execution/operators/mod.rs
+++ b/crates/rayexec_execution/src/execution/operators/mod.rs
@@ -73,7 +73,7 @@ use ungrouped_aggregate::{
     UngroupedAggregatePartitionState,
 };
 use union::{PhysicalUnion, UnionBottomPartitionState, UnionOperatorState, UnionTopPartitionState};
-use unnest::PhysicalUnnest;
+use unnest::{PhysicalUnnest, UnnestPartitionState};
 use values::PhysicalValues;
 
 use self::empty::EmptyPartitionState;
@@ -122,6 +122,7 @@ pub enum PartitionState {
     GatherSortPull(GatherSortPullPartitionState),
     ScatterSort(ScatterSortPartitionState),
     Limit(LimitPartitionState),
+    Unnest(UnnestPartitionState),
     UnionTop(UnionTopPartitionState),
     UnionBottom(UnionBottomPartitionState),
     Simple(SimplePartitionState),

--- a/crates/rayexec_execution/src/execution/operators/unnest.rs
+++ b/crates/rayexec_execution/src/execution/operators/unnest.rs
@@ -90,7 +90,7 @@ impl ExecutableOperator for PhysicalUnnest {
         let states: Vec<_> = (0..partitions)
             .map(|_| {
                 PartitionState::Unnest(UnnestPartitionState {
-                    inputs: vec![Array::new_untyped_null_array(0)],
+                    inputs: vec![Array::new_untyped_null_array(0); self.expressions.len()],
                     input_num_rows: 0,
                     current_row: 0,
                     finished: false,

--- a/crates/rayexec_execution/src/execution/operators/unnest.rs
+++ b/crates/rayexec_execution/src/execution/operators/unnest.rs
@@ -1,0 +1,66 @@
+use std::task::Context;
+
+use rayexec_bullet::batch::Batch;
+use rayexec_error::Result;
+
+use super::{
+    ExecutableOperator,
+    ExecutionStates,
+    OperatorState,
+    PartitionState,
+    PollFinalize,
+    PollPull,
+    PollPush,
+};
+use crate::database::DatabaseContext;
+use crate::explain::explainable::{ExplainConfig, ExplainEntry, Explainable};
+use crate::expr::physical::PhysicalScalarExpression;
+
+#[derive(Debug)]
+pub struct PhysicalUnnest {
+    pub expressions: Vec<PhysicalScalarExpression>,
+}
+
+impl ExecutableOperator for PhysicalUnnest {
+    fn create_states(
+        &self,
+        _context: &DatabaseContext,
+        _partitions: Vec<usize>,
+    ) -> Result<ExecutionStates> {
+        unimplemented!()
+    }
+
+    fn poll_push(
+        &self,
+        _cx: &mut Context,
+        _partition_state: &mut PartitionState,
+        _operator_state: &OperatorState,
+        _batch: Batch,
+    ) -> Result<PollPush> {
+        unimplemented!()
+    }
+
+    fn poll_finalize_push(
+        &self,
+        _cx: &mut Context,
+        _partition_state: &mut PartitionState,
+        _operator_state: &OperatorState,
+    ) -> Result<PollFinalize> {
+        unimplemented!()
+    }
+
+    fn poll_pull(
+        &self,
+        _cx: &mut Context,
+        _partition_state: &mut PartitionState,
+        _operator_state: &OperatorState,
+    ) -> Result<PollPull> {
+        unimplemented!()
+    }
+}
+
+impl Explainable for PhysicalUnnest {
+    fn explain_entry(&self, _conf: ExplainConfig) -> ExplainEntry {
+        ExplainEntry::new("Unnest")
+    }
+}

--- a/crates/rayexec_execution/src/execution/operators/unnest.rs
+++ b/crates/rayexec_execution/src/execution/operators/unnest.rs
@@ -299,6 +299,8 @@ impl ExecutableOperator for PhysicalUnnest {
 impl Explainable for PhysicalUnnest {
     fn explain_entry(&self, _conf: ExplainConfig) -> ExplainEntry {
         ExplainEntry::new("Unnest")
+            .with_values("project_expressions", &self.project_expressions)
+            .with_values("unnest_expressions", &self.unnest_expressions)
     }
 }
 
@@ -441,7 +443,7 @@ where
 
     match child.validity() {
         Some(validity) => {
-            let values = S::get_storage(&child.array_data())?;
+            let values = S::get_storage(child.array_data())?;
             let mut out_validity = Bitmap::new_with_all_false(out_len);
 
             for (out_idx, child_idx) in (meta.offset..meta.offset + meta.len).enumerate() {
@@ -464,7 +466,7 @@ where
             ))
         }
         None => {
-            let values = S::get_storage(&child.array_data())?;
+            let values = S::get_storage(child.array_data())?;
 
             // Note we always have an output validity since we may be producing
             // an array from a list that contains fewer items than the number of

--- a/crates/rayexec_execution/src/execution/operators/unnest.rs
+++ b/crates/rayexec_execution/src/execution/operators/unnest.rs
@@ -1,6 +1,9 @@
-use std::task::Context;
+use std::task::{Context, Waker};
 
+use rayexec_bullet::array::Array;
 use rayexec_bullet::batch::Batch;
+use rayexec_bullet::executor::physical_type::PhysicalList;
+use rayexec_bullet::executor::scalar::UnaryExecutor;
 use rayexec_error::Result;
 
 use super::{
@@ -15,6 +18,16 @@ use super::{
 use crate::database::DatabaseContext;
 use crate::explain::explainable::{ExplainConfig, ExplainEntry, Explainable};
 use crate::expr::physical::PhysicalScalarExpression;
+
+#[derive(Debug)]
+pub struct UnnestPartitionState {
+    /// Inputs we're processing.
+    inputs: Vec<Array>,
+    input_num_rows: usize,
+    current_row: usize,
+    push_waker: Option<Waker>,
+    pull_waker: Option<Waker>,
+}
 
 #[derive(Debug)]
 pub struct PhysicalUnnest {
@@ -32,11 +45,31 @@ impl ExecutableOperator for PhysicalUnnest {
 
     fn poll_push(
         &self,
-        _cx: &mut Context,
-        _partition_state: &mut PartitionState,
+        cx: &mut Context,
+        partition_state: &mut PartitionState,
         _operator_state: &OperatorState,
-        _batch: Batch,
+        batch: Batch,
     ) -> Result<PollPush> {
+        let state = match partition_state {
+            PartitionState::Unnest(state) => state,
+            other => panic!("invalid state: {other:?}"),
+        };
+
+        if state.current_row < state.input_num_rows {
+            // Still processing inputs, come back later.
+            state.push_waker = Some(cx.waker().clone());
+            if let Some(waker) = state.pull_waker.take() {
+                waker.wake();
+            }
+
+            return Ok(PollPush::Pending(batch));
+        }
+
+        // Compute inputs. These will be stored until we've processed all rows.
+        for (col_idx, expr) in self.expressions.iter().enumerate() {
+            state.inputs[col_idx] = expr.eval(&batch)?.into_owned();
+        }
+
         unimplemented!()
     }
 
@@ -51,10 +84,38 @@ impl ExecutableOperator for PhysicalUnnest {
 
     fn poll_pull(
         &self,
-        _cx: &mut Context,
-        _partition_state: &mut PartitionState,
+        cx: &mut Context,
+        partition_state: &mut PartitionState,
         _operator_state: &OperatorState,
     ) -> Result<PollPull> {
+        let state = match partition_state {
+            PartitionState::Unnest(state) => state,
+            other => panic!("invalid state: {other:?}"),
+        };
+
+        if state.current_row >= state.input_num_rows {
+            // We're done with these inputs. Come back later.
+            state.pull_waker = Some(cx.waker().clone());
+            if let Some(waker) = state.push_waker.take() {
+                waker.wake();
+            }
+
+            return Ok(PollPull::Pending);
+        }
+
+        // We have input ready, get the longest list for the current row.
+        let mut longest = 0;
+        for input_idx in 0..state.inputs.len() {
+            if let Some(list_meta) = UnaryExecutor::value_at::<PhysicalList>(
+                &state.inputs[input_idx],
+                state.current_row,
+            )? {
+                if list_meta.len > longest {
+                    longest = list_meta.len;
+                }
+            }
+        }
+
         unimplemented!()
     }
 }

--- a/crates/rayexec_execution/src/explain/formatter.rs
+++ b/crates/rayexec_execution/src/explain/formatter.rs
@@ -253,6 +253,7 @@ impl ExplainNode {
             LogicalOperator::ArbitraryJoin(n) => (n.explain_entry(config), &n.children),
             LogicalOperator::ComparisonJoin(n) => (n.explain_entry(config), &n.children),
             LogicalOperator::MagicJoin(n) => (n.explain_entry(config), &n.children),
+            LogicalOperator::Unnest(n) => (n.explain_entry(config), &n.children),
             LogicalOperator::MaterializationScan(n) => {
                 // Materialization special case, walk children by get
                 // materialization from bind context.

--- a/crates/rayexec_execution/src/expr/mod.rs
+++ b/crates/rayexec_execution/src/expr/mod.rs
@@ -256,6 +256,24 @@ impl Expression {
         }
     }
 
+    pub fn contains_unnest(&self) -> bool {
+        match self {
+            Self::Unnest(_) => true,
+            _ => {
+                let mut has_unnest = false;
+                self.for_each_child(&mut |expr| {
+                    if has_unnest {
+                        return Ok(());
+                    }
+                    has_unnest = has_unnest || expr.contains_unnest();
+                    Ok(())
+                })
+                .expect("unnest check to no fail");
+                has_unnest
+            }
+        }
+    }
+
     // TODO: Probably remove.
     pub fn is_constant(&self) -> bool {
         match self {

--- a/crates/rayexec_execution/src/expr/mod.rs
+++ b/crates/rayexec_execution/src/expr/mod.rs
@@ -11,6 +11,7 @@ pub mod literal_expr;
 pub mod negate_expr;
 pub mod scalar_function_expr;
 pub mod subquery_expr;
+pub mod unnest_expr;
 pub mod window_expr;
 
 pub mod physical;
@@ -34,6 +35,7 @@ use rayexec_bullet::scalar::{OwnedScalarValue, ScalarValue};
 use rayexec_error::{not_implemented, RayexecError, Result};
 use scalar_function_expr::ScalarFunctionExpr;
 use subquery_expr::SubqueryExpr;
+use unnest_expr::UnnestExpr;
 use window_expr::WindowExpr;
 
 use crate::explain::context_display::{ContextDisplay, ContextDisplayMode};
@@ -56,6 +58,7 @@ pub enum Expression {
     ScalarFunction(ScalarFunctionExpr),
     Subquery(SubqueryExpr),
     Window(WindowExpr),
+    Unnest(UnnestExpr),
 }
 
 impl Expression {
@@ -81,6 +84,7 @@ impl Expression {
             Self::ScalarFunction(expr) => expr.function.return_type(),
             Self::Subquery(expr) => expr.return_type.clone(),
             Self::Window(_) => not_implemented!("WINDOW"),
+            Self::Unnest(expr) => expr.datatype(bind_context)?,
         })
     }
 
@@ -146,6 +150,7 @@ impl Expression {
                     func(partition)?;
                 }
             }
+            Self::Unnest(unnest) => func(&mut unnest.expr)?,
         }
         Ok(())
     }
@@ -212,6 +217,7 @@ impl Expression {
                     func(partition)?;
                 }
             }
+            Self::Unnest(unnest) => func(&unnest.expr)?,
         }
         Ok(())
     }
@@ -489,6 +495,7 @@ impl ContextDisplay for Expression {
             Self::ScalarFunction(expr) => expr.fmt_using_context(mode, f),
             Self::Subquery(expr) => expr.fmt_using_context(mode, f),
             Self::Window(expr) => expr.fmt_using_context(mode, f),
+            Self::Unnest(expr) => expr.fmt_using_context(mode, f),
         }
     }
 }

--- a/crates/rayexec_execution/src/expr/unnest_expr.rs
+++ b/crates/rayexec_execution/src/expr/unnest_expr.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+
+use rayexec_bullet::datatype::DataType;
+use rayexec_error::{RayexecError, Result};
+
+use super::Expression;
+use crate::explain::context_display::{ContextDisplay, ContextDisplayMode, ContextDisplayWrapper};
+use crate::logical::binder::bind_context::BindContext;
+
+// TODO: Include recurse depth.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnnestExpr {
+    /// Expression being unnested.
+    pub expr: Box<Expression>,
+}
+
+impl UnnestExpr {
+    pub fn datatype(&self, bind_context: &BindContext) -> Result<DataType> {
+        let child_datatype = self.expr.datatype(bind_context)?;
+
+        match child_datatype {
+            DataType::Null => Ok(DataType::Null),
+            DataType::List(list) => Ok(list.datatype.as_ref().clone()),
+            other => Err(RayexecError::new(format!(
+                "Unsupported datatype for UNNEST: {other}"
+            ))),
+        }
+    }
+}
+
+impl ContextDisplay for UnnestExpr {
+    fn fmt_using_context(
+        &self,
+        mode: ContextDisplayMode,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "UNNEST({})",
+            ContextDisplayWrapper::with_mode(self.expr.as_ref(), mode)
+        )
+    }
+}

--- a/crates/rayexec_execution/src/logical/logical_unnest.rs
+++ b/crates/rayexec_execution/src/logical/logical_unnest.rs
@@ -7,19 +7,27 @@ use crate::expr::Expression;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogicalUnnest {
-    /// Output table ref for the unnest.
-    pub table_ref: TableRef,
+    /// Output table ref for expressions that won't be unnested, but still
+    /// projected out of this node.
+    pub projection_ref: TableRef,
+    /// Output table ref expressions being unnested.
+    pub unnest_ref: TableRef,
     /// All expressions being unnested.
-    pub expressions: Vec<Expression>,
+    pub unnest_expressions: Vec<Expression>,
+    /// All expressions being projected.
+    pub project_expressions: Vec<Expression>,
 }
 
 impl Explainable for LogicalUnnest {
     fn explain_entry(&self, conf: ExplainConfig) -> ExplainEntry {
-        let mut ent =
-            ExplainEntry::new("Unnest").with_values_context("expressions", conf, &self.expressions);
+        let mut ent = ExplainEntry::new("Unnest")
+            .with_values_context("unnest_expressions", conf, &self.unnest_expressions)
+            .with_values_context("project_expressions", conf, &self.project_expressions);
 
         if conf.verbose {
-            ent = ent.with_value("table_ref", self.table_ref);
+            ent = ent
+                .with_value("unnest_table_ref", self.unnest_ref)
+                .with_value("project_table_ref", self.projection_ref);
         }
 
         ent
@@ -28,14 +36,17 @@ impl Explainable for LogicalUnnest {
 
 impl LogicalNode for Node<LogicalUnnest> {
     fn get_output_table_refs(&self, _bind_context: &BindContext) -> Vec<TableRef> {
-        vec![self.node.table_ref]
+        vec![self.node.projection_ref, self.node.unnest_ref]
     }
 
     fn for_each_expr<F>(&self, func: &mut F) -> Result<()>
     where
         F: FnMut(&Expression) -> Result<()>,
     {
-        for expr in &self.node.expressions {
+        for expr in &self.node.project_expressions {
+            func(expr)?;
+        }
+        for expr in &self.node.unnest_expressions {
             func(expr)?;
         }
         Ok(())
@@ -45,7 +56,10 @@ impl LogicalNode for Node<LogicalUnnest> {
     where
         F: FnMut(&mut Expression) -> Result<()>,
     {
-        for expr in &mut self.node.expressions {
+        for expr in &mut self.node.project_expressions {
+            func(expr)?;
+        }
+        for expr in &mut self.node.unnest_expressions {
             func(expr)?;
         }
         Ok(())

--- a/crates/rayexec_execution/src/logical/logical_unnest.rs
+++ b/crates/rayexec_execution/src/logical/logical_unnest.rs
@@ -1,0 +1,53 @@
+use rayexec_error::Result;
+
+use super::binder::bind_context::{BindContext, TableRef};
+use super::operator::{LogicalNode, Node};
+use crate::explain::explainable::{ExplainConfig, ExplainEntry, Explainable};
+use crate::expr::Expression;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalUnnest {
+    /// Output table ref for the unnest.
+    pub table_ref: TableRef,
+    /// All expressions being unnested.
+    pub expressions: Vec<Expression>,
+}
+
+impl Explainable for LogicalUnnest {
+    fn explain_entry(&self, conf: ExplainConfig) -> ExplainEntry {
+        let mut ent =
+            ExplainEntry::new("Unnest").with_values_context("expressions", conf, &self.expressions);
+
+        if conf.verbose {
+            ent = ent.with_value("table_ref", self.table_ref);
+        }
+
+        ent
+    }
+}
+
+impl LogicalNode for Node<LogicalUnnest> {
+    fn get_output_table_refs(&self, _bind_context: &BindContext) -> Vec<TableRef> {
+        vec![self.node.table_ref]
+    }
+
+    fn for_each_expr<F>(&self, func: &mut F) -> Result<()>
+    where
+        F: FnMut(&Expression) -> Result<()>,
+    {
+        for expr in &self.node.expressions {
+            func(expr)?;
+        }
+        Ok(())
+    }
+
+    fn for_each_expr_mut<F>(&mut self, func: &mut F) -> Result<()>
+    where
+        F: FnMut(&mut Expression) -> Result<()>,
+    {
+        for expr in &mut self.node.expressions {
+            func(expr)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/rayexec_execution/src/logical/mod.rs
+++ b/crates/rayexec_execution/src/logical/mod.rs
@@ -63,3 +63,4 @@ pub mod logical_project;
 pub mod logical_scan;
 pub mod logical_set;
 pub mod logical_setop;
+pub mod logical_unnest;

--- a/crates/rayexec_execution/src/logical/operator.rs
+++ b/crates/rayexec_execution/src/logical/operator.rs
@@ -28,6 +28,7 @@ use super::logical_project::LogicalProject;
 use super::logical_scan::LogicalScan;
 use super::logical_set::{LogicalResetVar, LogicalSetVar, LogicalShowVar};
 use super::logical_setop::LogicalSetop;
+use super::logical_unnest::LogicalUnnest;
 use super::statistics::StatisticsValue;
 use crate::explain::explainable::{ExplainConfig, ExplainEntry, Explainable};
 use crate::expr::Expression;
@@ -286,6 +287,7 @@ pub enum LogicalOperator {
     ComparisonJoin(Node<LogicalComparisonJoin>),
     ArbitraryJoin(Node<LogicalArbitraryJoin>),
     MagicJoin(Node<LogicalMagicJoin>),
+    Unnest(Node<LogicalUnnest>),
 }
 
 impl LogicalOperator {
@@ -381,6 +383,7 @@ impl LogicalOperator {
             Self::ArbitraryJoin(n) => &n.children,
             Self::ComparisonJoin(n) => &n.children,
             Self::MagicJoin(n) => &n.children,
+            Self::Unnest(n) => &n.children,
         }
     }
 
@@ -415,6 +418,7 @@ impl LogicalOperator {
             Self::ArbitraryJoin(n) => &mut n.children,
             Self::ComparisonJoin(n) => &mut n.children,
             Self::MagicJoin(n) => &mut n.children,
+            Self::Unnest(n) => &mut n.children,
         }
     }
 
@@ -453,6 +457,7 @@ impl LogicalOperator {
             LogicalOperator::ArbitraryJoin(n) => n.estimated_cardinality,
             LogicalOperator::ComparisonJoin(n) => n.estimated_cardinality,
             LogicalOperator::MagicJoin(n) => n.estimated_cardinality,
+            LogicalOperator::Unnest(n) => n.estimated_cardinality,
         }
     }
 }
@@ -489,6 +494,7 @@ impl LogicalNode for LogicalOperator {
             LogicalOperator::ArbitraryJoin(n) => n.get_output_table_refs(bind_context),
             LogicalOperator::ComparisonJoin(n) => n.get_output_table_refs(bind_context),
             LogicalOperator::MagicJoin(n) => n.get_output_table_refs(bind_context),
+            LogicalOperator::Unnest(n) => n.get_output_table_refs(bind_context),
         }
     }
 
@@ -526,6 +532,7 @@ impl LogicalNode for LogicalOperator {
             LogicalOperator::ArbitraryJoin(n) => n.for_each_expr(func),
             LogicalOperator::ComparisonJoin(n) => n.for_each_expr(func),
             LogicalOperator::MagicJoin(n) => n.for_each_expr(func),
+            LogicalOperator::Unnest(n) => n.for_each_expr(func),
         }
     }
 
@@ -563,6 +570,7 @@ impl LogicalNode for LogicalOperator {
             LogicalOperator::ArbitraryJoin(n) => n.for_each_expr_mut(func),
             LogicalOperator::ComparisonJoin(n) => n.for_each_expr_mut(func),
             LogicalOperator::MagicJoin(n) => n.for_each_expr_mut(func),
+            LogicalOperator::Unnest(n) => n.for_each_expr_mut(func),
         }
     }
 }

--- a/crates/rayexec_execution/src/logical/planner/mod.rs
+++ b/crates/rayexec_execution/src/logical/planner/mod.rs
@@ -41,3 +41,4 @@ mod plan_query;
 mod plan_select;
 mod plan_setop;
 mod plan_subquery;
+mod plan_unnest;

--- a/crates/rayexec_execution/src/logical/planner/plan_select.rs
+++ b/crates/rayexec_execution/src/logical/planner/plan_select.rs
@@ -69,7 +69,8 @@ impl SelectPlanner {
                 location: LocationRequirement::Any,
                 children: vec![plan],
                 estimated_cardinality: StatisticsValue::Unknown,
-            })
+            });
+            plan = UnnestPlanner.plan_unnests(bind_context, plan)?;
         }
 
         // Handle projections.

--- a/crates/rayexec_execution/src/logical/planner/plan_select.rs
+++ b/crates/rayexec_execution/src/logical/planner/plan_select.rs
@@ -1,5 +1,6 @@
 use rayexec_error::Result;
 
+use super::plan_unnest::UnnestPlanner;
 use crate::logical::binder::bind_context::BindContext;
 use crate::logical::binder::bind_query::bind_select::BoundSelect;
 use crate::logical::logical_aggregate::LogicalAggregate;
@@ -85,6 +86,8 @@ impl SelectPlanner {
             children: vec![plan],
             estimated_cardinality: StatisticsValue::Unknown,
         });
+        // Handle possible UNNESTing.
+        plan = UnnestPlanner.plan_unnests(bind_context, plan)?;
 
         // Handle HAVING
         if let Some(mut expr) = select.having {

--- a/crates/rayexec_execution/src/logical/planner/plan_unnest.rs
+++ b/crates/rayexec_execution/src/logical/planner/plan_unnest.rs
@@ -1,0 +1,99 @@
+use rayexec_error::Result;
+
+use crate::expr::column_expr::ColumnExpr;
+use crate::expr::Expression;
+use crate::logical::binder::bind_context::BindContext;
+use crate::logical::logical_unnest::LogicalUnnest;
+use crate::logical::operator::{LocationRequirement, LogicalNode, LogicalOperator, Node};
+use crate::logical::statistics::StatisticsValue;
+
+#[derive(Debug)]
+pub struct UnnestPlanner;
+
+impl UnnestPlanner {
+    /// Takes an existing logical plan and replaces all UNNEST expressions with
+    /// references to a dedicated logical node that will handle the unnesting.
+    pub fn plan_unnests(
+        &self,
+        bind_context: &mut BindContext,
+        mut plan: LogicalOperator,
+    ) -> Result<LogicalOperator> {
+        let mut expr_count = 0; // Determines if we need to introduce a cross join.
+        let mut has_unnest = false;
+        plan.for_each_expr(&mut |expr| {
+            expr_count += 1;
+            if expr.contains_unnest() {
+                has_unnest = true;
+            }
+            Ok(())
+        })?;
+
+        if !has_unnest {
+            return Ok(plan);
+        }
+
+        // We have one or more UNNESTs, extract them all into a separate logical
+        // unnest.
+        let unnest_ref = bind_context.new_ephemeral_table()?;
+        let mut extracted_exprs = Vec::new();
+
+        plan.for_each_expr_mut(&mut |expr| {
+            // Generate replacement column expr based on number of extracted
+            // expressions so far.
+            let curr_col = extracted_exprs.len();
+            let replace = ColumnExpr {
+                table_scope: unnest_ref,
+                column: curr_col,
+            };
+            extract_unnest(expr, replace, &mut extracted_exprs)
+        })?;
+
+        if expr_count == extracted_exprs.len() {
+            // All expressions contained an UNNEST call, now they'll just
+            // reference the unnest operator.
+
+            let unnest_children = std::mem::take(plan.children_mut());
+            let unnest = LogicalOperator::Unnest(Node {
+                node: LogicalUnnest {
+                    table_ref: unnest_ref,
+                    expressions: extracted_exprs,
+                },
+                estimated_cardinality: StatisticsValue::Unknown,
+                location: LocationRequirement::Any,
+                children: unnest_children,
+            });
+
+            // Update plan to now have the unnest as its child.
+            *plan.children_mut() = vec![unnest];
+
+            Ok(plan)
+        } else {
+            unimplemented!()
+        }
+    }
+}
+
+fn extract_unnest(
+    expr: &mut Expression,
+    replace: ColumnExpr,
+    extracted: &mut Vec<Expression>,
+) -> Result<()> {
+    match expr {
+        Expression::Unnest(_) => {
+            // Replace with the column expr that'll represent the output of the
+            // UNNEST.
+            let inner = std::mem::replace(expr, Expression::Column(replace));
+
+            // Note we don't support nested UNNESTs.
+            match inner {
+                Expression::Unnest(unnest) => {
+                    extracted.push(*unnest.expr);
+                }
+                _ => unreachable!(),
+            }
+
+            Ok(())
+        }
+        other => other.for_each_child_mut(&mut |child| extract_unnest(child, replace, extracted)),
+    }
+}

--- a/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
+++ b/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
@@ -576,7 +576,7 @@ impl<'a> ExpressionResolver<'a> {
             .ok_or_else(|| RayexecError::new(format!("Missing schema: {schema}")))?;
 
         // Check if this is a special function.
-        if let Some(special) = SpecialBuiltinFunction::try_from_name(&func_name) {
+        if let Some(special) = SpecialBuiltinFunction::try_from_name(func_name) {
             let resolve_idx = resolve_context
                 .functions
                 .push_resolved(ResolvedFunction::Special(special), LocationRequirement::Any);

--- a/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
+++ b/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
@@ -6,7 +6,7 @@ use rayexec_parser::meta::Raw;
 use stackutil::check_stack_redline;
 
 use super::resolve_normal::create_user_facing_resolve_err;
-use super::resolved_function::ResolvedFunction;
+use super::resolved_function::{ResolvedFunction, SpecialBuiltinFunction};
 use super::{ResolveContext, ResolvedMeta, Resolver};
 use crate::database::catalog_entry::CatalogEntryType;
 use crate::functions::table::TableFunctionArgs;
@@ -575,7 +575,21 @@ impl<'a> ExpressionResolver<'a> {
             .get_schema(self.resolver.tx, schema)?
             .ok_or_else(|| RayexecError::new(format!("Missing schema: {schema}")))?;
 
-        // Check scalars first.
+        // Check if this is a special function.
+        if let Some(special) = SpecialBuiltinFunction::try_from_name(&func_name) {
+            let resolve_idx = resolve_context
+                .functions
+                .push_resolved(ResolvedFunction::Special(special), LocationRequirement::Any);
+
+            return Ok(ast::Expr::Function(ast::Function {
+                reference: resolve_idx,
+                distinct: func.distinct,
+                args,
+                filter,
+            }));
+        }
+
+        // Now check scalars.
         if let Some(scalar) = schema_ent.get_scalar_function(self.resolver.tx, func_name)? {
             // TODO: Allow unresolved scalars?
             // TODO: This also assumes scalars (and aggs) are the same everywhere, which

--- a/slt/standard/select/unnest.slt
+++ b/slt/standard/select/unnest.slt
@@ -27,6 +27,37 @@ SELECT unnest([3,4,5]), unnest([3,2,1]);
 5  1
 
 query TT
+DESCRIBE SELECT unnest([NULL, NULL, NULL]);
+----
+unnest  Null
+
+query ?
+SELECT unnest([NULL, NULL, NULL]);
+----
+NULL
+NULL
+NULL
+
+query I
+SELECT unnest([NULL, 4, NULL]) ORDER BY 1 NULLS LAST;
+----
+4
+NULL
+NULL
+
+query TT
+DESCRIBE SELECT unnest([NULL, 4, NULL]) ORDER BY 1 NULLS LAST;
+----
+unnest  Int32
+
+query II rowsort
+SELECT unnest([3,4,5]), unnest([3,2]);
+----
+3  3
+4  2
+5  NULL
+
+query TT
 DESCRIBE SELECT unnest([3,4,5]) a, unnest([3,2,1]) b ORDER BY b
 ----
 a  Int32
@@ -53,3 +84,19 @@ a
 bb
 ccc
 
+query T
+SELECT unnest(a) FROM VALUES (['a', 'b', 'c']),
+                             (['d', 'e', 'f']) v(a)
+  ORDER BY 1
+----
+a
+b
+c
+d
+e
+f
+
+query T
+SELECT sum(unnest(a)), min(unnest(a)), max(unnest(a)) FROM VALUES ([1,2,3]), ([4,5,6]) v(a);
+----
+21  1  6

--- a/slt/standard/select/unnest.slt
+++ b/slt/standard/select/unnest.slt
@@ -1,8 +1,55 @@
 # UNNEST in select list
 
+query TT
+DESCRIBE SELECT unnest([3,4,5])
+----
+unnest  Int32
+
 query I rowsort
 SELECT unnest([3,4,5]);
 ----
 3
 4
 5
+
+query I rowsort
+SELECT unnest([3,4,5]) + 3;
+----
+6
+7
+8
+
+query II rowsort
+SELECT unnest([3,4,5]), unnest([3,2,1]);
+----
+3  3
+4  2
+5  1
+
+query TT
+DESCRIBE SELECT unnest([3,4,5]) a, unnest([3,2,1]) b ORDER BY b
+----
+a  Int32
+b  Int32
+
+query II
+SELECT unnest([3,4,5]) a, unnest([3,2,1]) b ORDER BY b;
+----
+5  1
+4  2
+3  3
+
+query T rowsort
+SELECT repeat(unnest(['a', 'b', 'c']), 3);
+----
+aaa
+bbb
+ccc
+
+query T rowsort
+SELECT repeat(unnest(['a', 'b', 'c']), unnest([1, 2, 3]));
+----
+a
+bb
+ccc
+

--- a/slt/standard/select/unnest.slt
+++ b/slt/standard/select/unnest.slt
@@ -19,6 +19,29 @@ SELECT unnest([3,4,5]) + 3;
 7
 8
 
+query ?
+SELECT unnest(NULL);
+----
+
+# Note this differs from duckdb. We produce rows according to the non-null
+# input, duckdb produces zero rows.
+#
+# The beahvior shown here more closely matches what happens when unnesting a
+# column with null lists.
+query ?I rowsort
+SELECT unnest(NULL), unnest([4,5,6]);
+----
+NULL  4
+NULL  5
+NULL  6
+
+query ?I rowsort
+SELECT unnest([]), unnest([4,5,6]);
+----
+NULL  4
+NULL  5
+NULL  6
+
 query II rowsort
 SELECT unnest([3,4,5]), unnest([3,2,1]);
 ----
@@ -97,6 +120,39 @@ e
 f
 
 query T
+SELECT unnest(a) FROM VALUES (['a', 'b', 'c']),
+                             (NULL),
+                             (['d', 'e', 'f']) v(a)
+  ORDER BY 1
+----
+a
+b
+c
+d
+e
+f
+
+query III
 SELECT sum(unnest(a)), min(unnest(a)), max(unnest(a)) FROM VALUES ([1,2,3]), ([4,5,6]) v(a);
 ----
 21  1  6
+
+query II
+SELECT sum(unnest(a)), sum(unnest(b)) FROM
+    VALUES ([1,NULL,2,3], [4,5]),
+           ([6],          [NULL,7,8,9,10]) v(a,b);
+----
+12  43
+
+# Keep logical types
+query TT
+DESCRIBE SELECT unnest(['2022-01-03'::DATE, '2023-04-05'::DATE]);
+----
+unnest  Date32
+
+query T rowsort
+SELECT unnest(['2022-01-03'::DATE, '2023-04-05'::DATE]);
+----
+2022-01-03
+2023-04-05
+

--- a/slt/standard/select/unnest.slt
+++ b/slt/standard/select/unnest.slt
@@ -1,0 +1,8 @@
+# UNNEST in select list
+
+query I rowsort
+SELECT unnest([3,4,5]);
+----
+3
+4
+5

--- a/slt/standard/select/unnest.slt
+++ b/slt/standard/select/unnest.slt
@@ -12,6 +12,13 @@ SELECT unnest([3,4,5]);
 4
 5
 
+query IT rowsort
+SELECT unnest([3,4,5]), 'dog';
+----
+3  dog
+4  dog
+5  dog
+
 query I rowsort
 SELECT unnest([3,4,5]) + 3;
 ----
@@ -118,6 +125,17 @@ c
 d
 e
 f
+
+query T
+SELECT b, unnest(a), b FROM VALUES (['a', 'b', 'c'], 8),
+                                   (['d', 'e'],      9) v(a, b)
+  ORDER BY 2
+----
+8  a  8
+8  b  8
+8  c  8
+9  d  9
+9  e  9
 
 query T
 SELECT unnest(a) FROM VALUES (['a', 'b', 'c']),


### PR DESCRIPTION
Initial UNNEST support.

Basic list unnest:
```
>> SELECT unnest([3,4,5]);
┌────────┐
│ unnest │
│ Int32  │
├────────┤
│      3 │
│      4 │
│      5 │
└────────┘
```

Unnests with different list lengths:
```
>> SELECT unnest([3,4,5]), unnest([3,2]);
┌────────┬────────┐
│ unnest │ unnest │
│ Int32  │ Int32  │
├────────┼────────┤
│      3 │      3 │
│      4 │      2 │
│      5 │   NULL │
└────────┴────────┘
```

Aggregate list values using unnest:
```
>> SELECT sum(unnest(a)), min(unnest(a)), max(unnest(a)) FROM VALUES ([1,2,3]), ([4,5,6]) v(a);
┌───────┬───────┬───────┐
│ sum   │ min   │ max   │
│ Int64 │ Int32 │ Int32 │
├───────┼───────┼───────┤
│    21 │     1 │     6 │
└───────┴───────┴───────┘
```