### PR TITLE
chore: Benchmark framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayexec_bench"
+version = "0.0.82"
+dependencies = [
+ "clap",
+ "futures",
+ "logutil",
+ "rayexec_bullet",
+ "rayexec_error",
+ "rayexec_execution",
+ "rayexec_rt_native",
+ "rayexec_shell",
+]
+
+[[package]]
 name = "rayexec_bin"
 version = "0.0.82"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bench_bin"
+version = "0.0.82"
+dependencies = [
+ "rayexec_bench",
+ "rayexec_bullet",
+ "rayexec_csv",
+ "rayexec_debug",
+ "rayexec_delta",
+ "rayexec_error",
+ "rayexec_execution",
+ "rayexec_iceberg",
+ "rayexec_parquet",
+ "rayexec_postgres",
+ "rayexec_rt_native",
+ "rayexec_server",
+ "rayexec_shell",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["crates/*", "test_bin"]
-default-members = ["crates/*", "test_bin"]
+members = ["crates/*", "test_bin", "bench_bin"]
+default-members = ["crates/*", "test_bin", "bench_bin"]
 resolver = "2"
 
 [workspace.package]

--- a/bench/standard/min_max_generate_series_10M.bench
+++ b/bench/standard/min_max_generate_series_10M.bench
@@ -1,0 +1,7 @@
+# min/max from output of 10M ints.
+
+setup
+CREATE TEMP VIEW ints AS SELECT * FROM FROM generate_series(1, 10000000);
+
+run
+SELECT min(a), max(a) FROM ints;

--- a/bench/standard/min_max_generate_series_10M.bench
+++ b/bench/standard/min_max_generate_series_10M.bench
@@ -1,7 +1,7 @@
 # min/max from output of 10M ints.
 
 setup
-CREATE TEMP VIEW ints AS SELECT * FROM FROM generate_series(1, 10000000);
+CREATE TEMP VIEW ints AS SELECT * FROM generate_series(1, 10000000) g(a);
 
 run
 SELECT min(a), max(a) FROM ints;

--- a/bench/standard/select_1.bench
+++ b/bench/standard/select_1.bench
@@ -1,0 +1,4 @@
+# Testing the bench stuff.
+
+run
+SELECT 1

--- a/bench_bin/Cargo.toml
+++ b/bench_bin/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bench_bin"
+version.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rayexec_error = { path = '../crates/rayexec_error' }
+rayexec_execution = { path = '../crates/rayexec_execution' }
+rayexec_server = { path = '../crates/rayexec_server' }
+rayexec_shell = { path = '../crates/rayexec_shell' }
+rayexec_rt_native = { path = '../crates/rayexec_rt_native' }
+rayexec_bench = { path = '../crates/rayexec_bench' }
+rayexec_bullet = { path = '../crates/rayexec_bullet' }
+rayexec_postgres = { path = '../crates/rayexec_postgres' }
+rayexec_parquet = { path = '../crates/rayexec_parquet' }
+rayexec_csv = { path = '../crates/rayexec_csv' }
+rayexec_delta = { path = '../crates/rayexec_delta' }
+rayexec_iceberg = { path = '../crates/rayexec_iceberg' }
+rayexec_debug = { path = '../crates/rayexec_debug' }
+
+# TODO: Figure out the bench harness stuff.
+
+[[bin]]
+name = "bench_standard"
+path = "bench_standard.rs"

--- a/bench_bin/bench_standard.rs
+++ b/bench_bin/bench_standard.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+use rayexec_bench::DefaultEngineBuilder;
+use rayexec_error::Result;
+
+pub fn main() -> Result<()> {
+    let builder = DefaultEngineBuilder::try_new()?;
+    let paths = rayexec_bench::find_files(Path::new("../bench/standard"))?;
+    rayexec_bench::run(builder, paths)?;
+    Ok(())
+}

--- a/bench_bin/bench_standard.rs
+++ b/bench_bin/bench_standard.rs
@@ -5,7 +5,7 @@ use rayexec_error::Result;
 
 pub fn main() -> Result<()> {
     let builder = DefaultEngineBuilder::try_new()?;
-    let paths = rayexec_bench::find_files(Path::new("../bench/standard"))?;
+    let paths = rayexec_bench::find_files(Path::new("./bench/standard"))?;
     rayexec_bench::run(builder, paths)?;
     Ok(())
 }

--- a/bench_bin/bench_standard.rs
+++ b/bench_bin/bench_standard.rs
@@ -1,11 +1,8 @@
-use std::path::Path;
-
 use rayexec_bench::DefaultEngineBuilder;
 use rayexec_error::Result;
 
 pub fn main() -> Result<()> {
     let builder = DefaultEngineBuilder::try_new()?;
-    let paths = rayexec_bench::find_files(Path::new("./bench/standard"))?;
-    rayexec_bench::run(builder, paths)?;
+    rayexec_bench::run(builder, "./bench/standard")?;
     Ok(())
 }

--- a/crates/rayexec_bench/Cargo.toml
+++ b/crates/rayexec_bench/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rayexec_bench"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+rayexec_error = { path = '../rayexec_error' }
+rayexec_execution = { path = '../rayexec_execution' }
+rayexec_bullet = { path = '../rayexec_bullet' }
+rayexec_rt_native = { path = '../rayexec_rt_native' }
+rayexec_shell = { path = '../rayexec_shell' }
+logutil = { path = '../logutil' }
+futures = { workspace = true }
+clap = { version = "4.5.9", features = ["derive", "env"] }

--- a/crates/rayexec_bench/src/benchmark.rs
+++ b/crates/rayexec_bench/src/benchmark.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use rayexec_error::{RayexecError, Result};
+use rayexec_execution::runtime::{Runtime, TokioHandlerProvider};
+use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
+use rayexec_shell::session::SingleUserEngine;
+
+/// Describes a benchmark to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Benchmark {
+    /// Setup queries to run prior to running the actual benchmark queries.
+    pub setup: Vec<String>,
+    /// The benchmark queries.
+    pub queries: Vec<String>,
+}
+
+impl Benchmark {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        unimplemented!()
+    }
+}

--- a/crates/rayexec_bench/src/benchmark.rs
+++ b/crates/rayexec_bench/src/benchmark.rs
@@ -1,9 +1,8 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use rayexec_error::{RayexecError, Result};
-use rayexec_execution::runtime::{Runtime, TokioHandlerProvider};
-use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
-use rayexec_shell::session::SingleUserEngine;
+use rayexec_error::{RayexecError, Result, ResultExt};
 
 /// Describes a benchmark to run.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,6 +15,211 @@ pub struct Benchmark {
 
 impl Benchmark {
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        unimplemented!()
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Self::from_buf_read(reader)
+    }
+
+    pub fn from_buf_read(reader: impl BufRead) -> Result<Self> {
+        let lines = reader.lines();
+
+        let mut setup = Vec::new();
+        let mut queries = Vec::new();
+
+        let mut current_section: Option<&mut Vec<String>> = None;
+
+        let mut setup_finished = false;
+        let mut query_buffer = String::new();
+
+        for line in lines {
+            let line = line.context("failed to get line")?;
+            let trimmed = line.trim();
+
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                // Ignore empty lines and comments
+                continue;
+            }
+
+            match trimmed {
+                "setup" => {
+                    // Files should be read and executed top-to-bottom, enforce
+                    // that by not allowing a setup to happen after reading in a
+                    // 'run' query.
+                    if setup_finished {
+                        return Err(RayexecError::new(
+                            "'setup' queries must come before 'run' queries",
+                        ));
+                    }
+
+                    flush_query_buffer(&mut query_buffer, &mut current_section)?;
+                    current_section = Some(&mut setup);
+                }
+                "run" => {
+                    setup_finished = true;
+                    flush_query_buffer(&mut query_buffer, &mut current_section)?;
+                    current_section = Some(&mut queries);
+                }
+                _ => {
+                    // Append the line to the query buffer
+                    if !query_buffer.is_empty() {
+                        query_buffer.push('\n');
+                    }
+                    // Push the original line to preserve whitespace.
+                    query_buffer.push_str(&line);
+                }
+            }
+        }
+
+        flush_query_buffer(&mut query_buffer, &mut current_section)?;
+
+        // Setup can be empty, but benchmark queries cannot.
+        if queries.is_empty() {
+            return Err(RayexecError::new("No benchmark queries"));
+        }
+
+        Ok(Benchmark { setup, queries })
+    }
+}
+
+/// Flush the query buffer to the current section
+fn flush_query_buffer(
+    query_buffer: &mut String,
+    current_section: &mut Option<&mut Vec<String>>,
+) -> Result<()> {
+    if !query_buffer.is_empty() {
+        if let Some(section) = current_section {
+            section.push(query_buffer.trim().to_string());
+            query_buffer.clear();
+        } else {
+            return Err(RayexecError::new(format!(
+                "Query found outside of any section: {query_buffer}",
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn single_setup_and_run() {
+        let contents = r#"
+# This is a comment.
+
+setup
+CREATE TABLE hello (a INT)
+
+run
+SELECT * FROM hello
+"#;
+
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
+        let expected = Benchmark {
+            setup: vec!["CREATE TABLE hello (a INT)".to_string()],
+            queries: vec!["SELECT * FROM hello".to_string()],
+        };
+
+        assert_eq!(expected, bench);
+    }
+
+    #[test]
+    fn single_run() {
+        let contents = r#"run
+SELECT * FROM hello
+"#;
+
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
+        let expected = Benchmark {
+            setup: vec![],
+            queries: vec!["SELECT * FROM hello".to_string()],
+        };
+
+        assert_eq!(expected, bench);
+    }
+
+    #[test]
+    fn missing_run() {
+        let contents = r#"
+# This is a comment.
+
+setup
+CREATE TABLE hello (a INT)
+"#;
+
+        let _ = Benchmark::from_buf_read(Cursor::new(contents)).unwrap_err();
+    }
+
+    #[test]
+    fn multiple_setups_and_runs() {
+        let contents = r#"
+# This is a comment.
+
+setup
+CREATE TABLE hello (a INT)
+
+setup
+CREATE TABLE hello2 (a INT)
+
+run
+SELECT * FROM hello
+
+run
+SELECT * FROM hello2
+"#;
+
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
+        let expected = Benchmark {
+            setup: vec![
+                "CREATE TABLE hello (a INT)".to_string(),
+                "CREATE TABLE hello2 (a INT)".to_string(),
+            ],
+            queries: vec![
+                "SELECT * FROM hello".to_string(),
+                "SELECT * FROM hello2".to_string(),
+            ],
+        };
+
+        assert_eq!(expected, bench);
+    }
+
+    #[test]
+    fn setup_after_run() {
+        let contents = r#"
+setup
+CREATE TABLE hello (a INT)
+
+run
+SELECT * FROM hello
+
+setup
+CREATE TABLE hello2 (a INT)
+"#;
+
+        let _ = Benchmark::from_buf_read(Cursor::new(contents)).unwrap_err();
+    }
+
+    #[test]
+    fn multiline_setup() {
+        let contents = r#"
+setup
+CREATE TABLE
+  hello (a INT)
+
+run
+SELECT * FROM hello
+"#;
+
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
+        let expected = Benchmark {
+            setup: vec!["CREATE TABLE\n  hello (a INT)".to_string()],
+            queries: vec!["SELECT * FROM hello".to_string()],
+        };
+
+        assert_eq!(expected, bench);
     }
 }

--- a/crates/rayexec_bench/src/lib.rs
+++ b/crates/rayexec_bench/src/lib.rs
@@ -1,0 +1,32 @@
+mod benchmark;
+mod runner;
+
+use clap::Parser;
+use rayexec_error::Result;
+use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
+use rayexec_shell::session::SingleUserEngine;
+
+#[derive(Parser)]
+#[clap(name = "rayexec_bin")]
+struct Arguments {
+    // /// Print the EXPLAIN output for queries prior to running them.
+    // #[clap(long, env = "DEBUG_PRINT_EXPLAIN")]
+    // print_explain: bool,
+    // /// Print the profile data for a query after running it.
+    // #[clap(long, env = "DEBUG_PRINT_PROFILE_DATA")]
+    // print_profile_data: bool,
+    /// Pattern to match benchmark files to run.
+    #[clap()]
+    pattern: Option<String>,
+}
+
+pub trait EngineBuilder {
+    fn build() -> Result<SingleUserEngine<ThreadedNativeExecutor, NativeRuntime>>;
+}
+
+pub fn run<B>(builder: B) -> Result<()>
+where
+    B: EngineBuilder,
+{
+    unimplemented!()
+}

--- a/crates/rayexec_bench/src/lib.rs
+++ b/crates/rayexec_bench/src/lib.rs
@@ -82,7 +82,11 @@ pub fn run(builder: impl EngineBuilder, files: impl IntoIterator<Item = PathBuf>
 
         let times = runner.run(args.count)?;
 
-        let name = path_str.trim_end_matches(".bench").to_string();
+        let name = path_str
+            .trim_end_matches(".bench")
+            .trim_start_matches("./")
+            .trim_start_matches("../")
+            .to_string();
         all_times.insert(name, times);
     }
 

--- a/crates/rayexec_bench/src/lib.rs
+++ b/crates/rayexec_bench/src/lib.rs
@@ -1,10 +1,17 @@
 mod benchmark;
 mod runner;
 
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use benchmark::Benchmark;
 use clap::Parser;
-use rayexec_error::Result;
+use rayexec_error::{RayexecError, Result, ResultExt};
+use rayexec_execution::datasource::{DataSourceRegistry, MemoryDataSource};
 use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
 use rayexec_shell::session::SingleUserEngine;
+use runner::{BenchmarkRunner, BenchmarkTimes};
 
 #[derive(Parser)]
 #[clap(name = "rayexec_bin")]
@@ -15,18 +22,106 @@ struct Arguments {
     // /// Print the profile data for a query after running it.
     // #[clap(long, env = "DEBUG_PRINT_PROFILE_DATA")]
     // print_profile_data: bool,
+    #[clap(long, short, default_value = "5")]
+    count: usize,
     /// Pattern to match benchmark files to run.
     #[clap()]
     pattern: Option<String>,
 }
 
 pub trait EngineBuilder {
-    fn build() -> Result<SingleUserEngine<ThreadedNativeExecutor, NativeRuntime>>;
+    fn build(&self) -> Result<SingleUserEngine<ThreadedNativeExecutor, NativeRuntime>>;
 }
 
-pub fn run<B>(builder: B) -> Result<()>
-where
-    B: EngineBuilder,
-{
-    unimplemented!()
+#[derive(Debug)]
+pub struct DefaultEngineBuilder {
+    executor: ThreadedNativeExecutor,
+    runtime: NativeRuntime,
+}
+
+impl DefaultEngineBuilder {
+    pub fn try_new() -> Result<Self> {
+        Ok(DefaultEngineBuilder {
+            executor: ThreadedNativeExecutor::try_new()?,
+            runtime: NativeRuntime::with_default_tokio()?,
+        })
+    }
+}
+
+impl EngineBuilder for DefaultEngineBuilder {
+    fn build(&self) -> Result<SingleUserEngine<ThreadedNativeExecutor, NativeRuntime>> {
+        let registry =
+            DataSourceRegistry::default().with_datasource("memory", Box::new(MemoryDataSource))?;
+
+        SingleUserEngine::try_new(self.executor.clone(), self.runtime.clone(), registry)
+    }
+}
+
+pub fn run(builder: impl EngineBuilder, files: impl IntoIterator<Item = PathBuf>) -> Result<()> {
+    let args = Arguments::parse();
+
+    // Times keyed by the file names.
+    let mut all_times: BTreeMap<String, BenchmarkTimes> = BTreeMap::new(); // BTree for sorted output.
+
+    for path in files {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| RayexecError::new("File path not valid utf8"))?;
+
+        if let Some(pattern) = &args.pattern {
+            if !path_str.contains(pattern) {
+                continue;
+            }
+        }
+
+        let bench = Benchmark::from_file(&path)?;
+        let runner = BenchmarkRunner {
+            engine: builder.build()?,
+            benchmark: bench,
+        };
+
+        let times = runner.run(args.count)?;
+
+        let name = path_str.trim_end_matches(".bench").to_string();
+        all_times.insert(name, times);
+    }
+
+    // Print results.
+    println!(
+        "{:<40}\t{:>7}\t{:>14}",
+        "benchmark_name", "count", "time_ms"
+    );
+
+    for (name, times) in &all_times {
+        for (idx, query_time) in times.query_times_ms.iter().enumerate() {
+            println!("{:<40}\t{:>7}\t{:>14}", name, idx + 1, query_time);
+        }
+    }
+
+    // TODO: Allow writing to csv/tsv
+
+    Ok(())
+}
+
+/// Recursively find all files in the given directory.
+pub fn find_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    fn inner(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+        if dir.is_dir() {
+            for entry in fs::read_dir(dir).context("read dir")? {
+                let entry = entry.context("entry")?;
+                let path = entry.path();
+                if path.is_dir() {
+                    inner(&path, paths)?;
+                } else {
+                    paths.push(path.to_path_buf());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    let mut paths = Vec::new();
+    inner(dir, &mut paths)?;
+
+    Ok(paths)
 }

--- a/crates/rayexec_bench/src/runner.rs
+++ b/crates/rayexec_bench/src/runner.rs
@@ -1,7 +1,6 @@
-use std::path::Path;
 use std::time::Instant;
 
-use rayexec_error::{RayexecError, Result};
+use rayexec_error::Result;
 use rayexec_execution::runtime::{Runtime, TokioHandlerProvider};
 use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
 use rayexec_shell::session::SingleUserEngine;
@@ -40,7 +39,7 @@ impl BenchmarkRunner {
             }
             Ok(())
         });
-        let _ = result?;
+        result?;
         let setup_time_ms = Instant::now().duration_since(setup_start).as_millis() as u64;
 
         let mut query_times_ms = Vec::with_capacity(count);
@@ -54,7 +53,7 @@ impl BenchmarkRunner {
                 }
                 Ok(())
             });
-            let _ = result?;
+            result?;
             let query_time_ms = Instant::now().duration_since(bench_start).as_millis() as u64;
 
             query_times_ms.push(query_time_ms);

--- a/crates/rayexec_bench/src/runner.rs
+++ b/crates/rayexec_bench/src/runner.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+use std::time::Instant;
+
+use rayexec_error::{RayexecError, Result};
+use rayexec_execution::runtime::{Runtime, TokioHandlerProvider};
+use rayexec_rt_native::runtime::{NativeRuntime, ThreadedNativeExecutor};
+use rayexec_shell::session::SingleUserEngine;
+
+use crate::benchmark::Benchmark;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BenchmarkTimes {
+    pub setup_time_ms: u64,
+    pub query_time_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct BenchmarkRunner {
+    pub engine: SingleUserEngine<ThreadedNativeExecutor, NativeRuntime>,
+    pub benchmark: Benchmark,
+}
+
+impl BenchmarkRunner {
+    /// Run the benchmark to completion.
+    ///
+    /// This will make use of the tokio runtime configured on the engine runtime
+    /// for pulling the results.
+    pub fn run(&self) -> Result<BenchmarkTimes> {
+        let handle = self.engine.runtime.tokio_handle().handle()?;
+
+        let setup_start = Instant::now();
+        let result: Result<()> = handle.block_on(async {
+            for setup_query in &self.benchmark.setup {
+                for pending in self.engine.session().query_many(setup_query)? {
+                    let _ = pending.execute().await?.collect().await?;
+                }
+            }
+            Ok(())
+        });
+        let _ = result?;
+        let setup_time_ms = Instant::now().duration_since(setup_start).as_millis() as u64;
+
+        let bench_start = Instant::now();
+        let result: Result<()> = handle.block_on(async {
+            for query in &self.benchmark.queries {
+                for pending in self.engine.session().query_many(query)? {
+                    let _ = pending.execute().await?.collect().await?;
+                }
+            }
+            Ok(())
+        });
+        let _ = result?;
+        let query_time_ms = Instant::now().duration_since(bench_start).as_millis() as u64;
+
+        Ok(BenchmarkTimes {
+            setup_time_ms,
+            query_time_ms,
+        })
+    }
+}


### PR DESCRIPTION
```
% cargo run -r --bin bench_standard
    Finished `release` profile [optimized] target(s) in 0.13s
     Running `target/release/bench_standard`
benchmark_name                                    count        time_ms
bench/standard/min_max_generate_series_10M            1             56
bench/standard/min_max_generate_series_10M            2             35
bench/standard/min_max_generate_series_10M            3             31
bench/standard/min_max_generate_series_10M            4             31
bench/standard/min_max_generate_series_10M            5             31
bench/standard/select_1                               1              0
bench/standard/select_1                               2              0
bench/standard/select_1                               3              0
bench/standard/select_1                               4              0
bench/standard/select_1                               5              0
```

File format:

```
# min/max from output of 10M ints.

setup
CREATE TEMP VIEW ints AS SELECT * FROM generate_series(1, 10000000) g(a);

run
SELECT min(a), max(a) FROM ints;
```