### PR TITLE
chore: Remove LargeUtf8/LargeBinary

### DIFF
--- a/crates/fmtutil/src/displayable.rs
+++ b/crates/fmtutil/src/displayable.rs
@@ -11,7 +11,7 @@ pub trait IntoDisplayableSlice<T: Display> {
     fn display_as_list(&self) -> DisplayableSlice<T>;
 }
 
-impl<'a, T: Display> IntoDisplayableSlice<T> for &'a [T] {
+impl<T: Display> IntoDisplayableSlice<T> for &[T] {
     fn display_with_brackets(&self) -> DisplayableSlice<T> {
         DisplayableSlice {
             left_delim: "[",
@@ -83,7 +83,7 @@ impl<'a, T: Display, V: AsRef<[T]>> From<&'a V> for DisplayableSlice<'a, T> {
     }
 }
 
-impl<'a, T: Display> Display for DisplayableSlice<'a, T> {
+impl<T: Display> Display for DisplayableSlice<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.left_delim)?;
         for (idx, item) in self.slice.iter().enumerate() {

--- a/crates/parquet/src/data_type.rs
+++ b/crates/parquet/src/data_type.rs
@@ -584,7 +584,7 @@ impl AsBytes for Vec<u8> {
     }
 }
 
-impl<'a> AsBytes for &'a str {
+impl AsBytes for &str {
     fn as_bytes(&self) -> &[u8] {
         (self as &str).as_bytes()
     }

--- a/crates/parquet/src/encodings/rle.rs
+++ b/crates/parquet/src/encodings/rle.rs
@@ -15,6 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Rle/Bit-Packing Hybrid Encoding
+//! The grammar for this encoding looks like the following (copied verbatim
+//! from <https://github.com/Parquet/parquet-format/blob/master/Encodings.md>):
+//!
+//! rle-bit-packed-hybrid: `<length>` `<encoded-data>`
+//! length := length of the `<encoded-data>` in bytes stored as 4 bytes little endian
+//! encoded-data := `<run>`*
+//! run := `<bit-packed-run>` | `<rle-run>`
+//! bit-packed-run := `<bit-packed-header>` `<bit-packed-values>`
+//! bit-packed-header := varint-encode(`<bit-pack-count>` << 1 | 1)
+//! we always bit-pack a multiple of 8 values at a time, so we only store the number of
+//! values / 8
+//! bit-pack-count := (number of values in this run) / 8
+//! bit-packed-values := *see 1 below*
+//! rle-run := `<rle-header>` `<repeated-value>`
+//! rle-header := varint-encode( (number of times repeated) << 1)
+//! repeated-value := value that is repeated, using a fixed-width of
+//! round-up-to-next-byte(bit-width)
+
 use std::cmp;
 use std::mem::size_of;
 
@@ -22,25 +41,6 @@ use bytes::Bytes;
 
 use crate::errors::Result;
 use crate::util::bit_util::{self, from_le_slice, BitReader, BitWriter, FromBytes};
-
-/// Rle/Bit-Packing Hybrid Encoding
-/// The grammar for this encoding looks like the following (copied verbatim
-/// from <https://github.com/Parquet/parquet-format/blob/master/Encodings.md>):
-///
-/// rle-bit-packed-hybrid: `<length>` `<encoded-data>`
-/// length := length of the `<encoded-data>` in bytes stored as 4 bytes little endian
-/// encoded-data := `<run>`*
-/// run := `<bit-packed-run>` | `<rle-run>`
-/// bit-packed-run := `<bit-packed-header>` `<bit-packed-values>`
-/// bit-packed-header := varint-encode(`<bit-pack-count>` << 1 | 1)
-/// we always bit-pack a multiple of 8 values at a time, so we only store the number of
-/// values / 8
-/// bit-pack-count := (number of values in this run) / 8
-/// bit-packed-values := *see 1 below*
-/// rle-run := `<rle-header>` `<repeated-value>`
-/// rle-header := varint-encode( (number of times repeated) << 1)
-/// repeated-value := value that is repeated, using a fixed-width of
-/// round-up-to-next-byte(bit-width)
 
 /// Maximum groups of 8 values per bit-packed run. Current value is 64.
 const MAX_GROUPS_PER_BIT_PACKED_RUN: usize = 1 << 6;

--- a/crates/parquet/src/file/serialized_reader.rs
+++ b/crates/parquet/src/file/serialized_reader.rs
@@ -49,7 +49,7 @@ impl TryFrom<File> for SerializedFileReader<File> {
     }
 }
 
-impl<'a> TryFrom<&'a Path> for SerializedFileReader<File> {
+impl TryFrom<&Path> for SerializedFileReader<File> {
     type Error = ParquetError;
 
     fn try_from(path: &Path) -> Result<Self> {
@@ -66,7 +66,7 @@ impl TryFrom<String> for SerializedFileReader<File> {
     }
 }
 
-impl<'a> TryFrom<&'a str> for SerializedFileReader<File> {
+impl TryFrom<&str> for SerializedFileReader<File> {
     type Error = ParquetError;
 
     fn try_from(path: &str) -> Result<Self> {

--- a/crates/parquet/src/file/writer.rs
+++ b/crates/parquet/src/file/writer.rs
@@ -723,7 +723,7 @@ impl<'a, W: Write> SerializedPageWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write + Send> PageWriter for SerializedPageWriter<'a, W> {
+impl<W: Write + Send> PageWriter for SerializedPageWriter<'_, W> {
     fn write_page(&mut self, page: CompressedPage) -> Result<PageWriteSpec> {
         let start_pos = self.sink.bytes_written() as u64;
         let mut spec = write_page(page, &mut self.sink)?;

--- a/crates/parquet/src/schema/parser.rs
+++ b/crates/parquet/src/schema/parser.rs
@@ -185,7 +185,7 @@ fn parse_timeunit(
         })
 }
 
-impl<'a> Parser<'a> {
+impl Parser<'_> {
     // Entry function to parse message type, uses internal tokenizer.
     fn parse_message_type(&mut self) -> Result<Type> {
         // Check that message type starts with "message".

--- a/crates/parquet/src/schema/printer.rs
+++ b/crates/parquet/src/schema/printer.rs
@@ -299,7 +299,7 @@ fn print_logical_and_converted(
 }
 
 #[allow(unused_must_use)]
-impl<'a> Printer<'a> {
+impl Printer<'_> {
     pub fn print(&mut self, tp: &Type) {
         self.print_indent();
         match *tp {

--- a/crates/parquet/src/schema/types.rs
+++ b/crates/parquet/src/schema/types.rs
@@ -745,7 +745,7 @@ impl From<Vec<String>> for ColumnPath {
     }
 }
 
-impl<'a> From<&'a str> for ColumnPath {
+impl From<&str> for ColumnPath {
     fn from(single_path: &str) -> Self {
         let s = String::from(single_path);
         ColumnPath::from(s)

--- a/crates/parquet/src/thrift.rs
+++ b/crates/parquet/src/thrift.rs
@@ -100,7 +100,7 @@ impl<'a> TCompactSliceInputProtocol<'a> {
     }
 }
 
-impl<'a> TInputProtocol for TCompactSliceInputProtocol<'a> {
+impl TInputProtocol for TCompactSliceInputProtocol<'_> {
     fn read_message_begin(&mut self) -> thrift::Result<TMessageIdentifier> {
         unimplemented!()
     }

--- a/crates/parquet/src/util/bit_util.rs
+++ b/crates/parquet/src/util/bit_util.rs
@@ -598,7 +598,7 @@ impl BitReader {
     /// `T` needs to be a little-endian native type. The value is assumed to be byte
     /// aligned so the bit reader will be advanced to the start of the next byte before
     /// reading the value.
-
+    ///
     /// Returns `Some` if there's enough bytes left to form a value of `T`.
     /// Otherwise `None`.
     pub fn get_aligned<T: FromBytes>(&mut self, num_bytes: usize) -> Option<T> {

--- a/crates/rayexec_bullet/src/array/mod.rs
+++ b/crates/rayexec_bullet/src/array/mod.rs
@@ -249,7 +249,7 @@ impl Array {
     pub fn physical_type(&self) -> PhysicalType {
         match self.data.physical_type() {
             PhysicalType::Binary => match self.datatype {
-                DataType::Utf8 | DataType::LargeUtf8 => PhysicalType::Utf8,
+                DataType::Utf8 => PhysicalType::Utf8,
                 _ => PhysicalType::Binary,
             },
             other => other,
@@ -549,7 +549,7 @@ impl Array {
                 ArrayData::Interval(arr) => arr.as_ref().as_ref()[idx].into(),
                 _other => return Err(array_not_valid_for_type_err(&self.datatype)),
             },
-            DataType::Utf8 | DataType::LargeUtf8 => {
+            DataType::Utf8 => {
                 let v = match &self.data {
                     ArrayData::Binary(BinaryData::Binary(arr)) => arr
                         .get(idx)
@@ -565,7 +565,7 @@ impl Array {
                 let s = std::str::from_utf8(v).context("binary data not valid utf8")?;
                 s.into()
             }
-            DataType::Binary | DataType::LargeBinary => {
+            DataType::Binary => {
                 let v = match &self.data {
                     ArrayData::Binary(BinaryData::Binary(arr)) => arr
                         .get(idx)

--- a/crates/rayexec_bullet/src/bitmap/mod.rs
+++ b/crates/rayexec_bullet/src/bitmap/mod.rs
@@ -332,7 +332,7 @@ impl<'a> BitmapIter<'a> {
     }
 }
 
-impl<'a> Iterator for BitmapIter<'a> {
+impl Iterator for BitmapIter<'_> {
     type Item = bool;
 
     #[inline]
@@ -367,7 +367,7 @@ impl<'a> Iterator for BitmapIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for BitmapIter<'a> {}
+impl ExactSizeIterator for BitmapIter<'_> {}
 
 /// Iterator over all "valid" indexes in the bitmap.
 #[derive(Debug)]
@@ -377,7 +377,7 @@ pub struct BitmapIndexIter<'a> {
     bitmap: &'a Bitmap,
 }
 
-impl<'a> Iterator for BitmapIndexIter<'a> {
+impl Iterator for BitmapIndexIter<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -398,7 +398,7 @@ impl<'a> Iterator for BitmapIndexIter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for BitmapIndexIter<'a> {
+impl DoubleEndedIterator for BitmapIndexIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             if self.front >= self.back {

--- a/crates/rayexec_bullet/src/bitmap/zip.rs
+++ b/crates/rayexec_bullet/src/bitmap/zip.rs
@@ -44,7 +44,7 @@ impl<'a, const N: usize> ZipBitmapsIter<'a, N> {
     }
 }
 
-impl<'a, const N: usize> Iterator for ZipBitmapsIter<'a, N> {
+impl<const N: usize> Iterator for ZipBitmapsIter<'_, N> {
     type Item = bool;
 
     #[inline]
@@ -83,4 +83,4 @@ impl<'a, const N: usize> Iterator for ZipBitmapsIter<'a, N> {
     }
 }
 
-impl<'a, const N: usize> ExactSizeIterator for ZipBitmapsIter<'a, N> {}
+impl<const N: usize> ExactSizeIterator for ZipBitmapsIter<'_, N> {}

--- a/crates/rayexec_bullet/src/compute/cast/array.rs
+++ b/crates/rayexec_bullet/src/compute/cast/array.rs
@@ -89,7 +89,7 @@ pub fn cast_array(arr: &Array, to: DataType, behavior: CastFailBehavior) -> Resu
         }
 
         // String to anything else.
-        DataType::Utf8 | DataType::LargeUtf8 => cast_from_utf8(arr, to, behavior)?,
+        DataType::Utf8 => cast_from_utf8(arr, to, behavior)?,
 
         // Primitive numerics to other primitive numerics.
         DataType::Int8 if to.is_primitive_numeric() => {

--- a/crates/rayexec_bullet/src/compute/cast/scalar.rs
+++ b/crates/rayexec_bullet/src/compute/cast/scalar.rs
@@ -255,7 +255,6 @@ pub fn cast_scalar(scalar: ScalarValue, to: &DataType) -> Result<OwnedScalarValu
 
         // To Utf8
         (v, DataType::Utf8) => ScalarValue::Utf8(v.to_string().into()),
-        (v, DataType::LargeUtf8) => ScalarValue::Utf8(v.to_string().into()),
 
         (scalar, to) => {
             return Err(RayexecError::new(format!(

--- a/crates/rayexec_bullet/src/datatype.rs
+++ b/crates/rayexec_bullet/src/datatype.rs
@@ -8,6 +8,11 @@ use crate::executor::physical_type::PhysicalType;
 use crate::field::Field;
 use crate::scalar::decimal::{Decimal128Type, Decimal64Type, DecimalType};
 
+/// The 'type' of the dataype.
+///
+/// This is mostly used for determining the input and return types functions
+/// without needing to worry about extra type info (e.g. precision/scale for
+/// decimals).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DataTypeId {
     /// Any datatype.
@@ -40,9 +45,7 @@ pub enum DataTypeId {
     Date64,
     Interval,
     Utf8,
-    LargeUtf8,
     Binary,
-    LargeBinary,
     Struct,
     List,
 }
@@ -75,9 +78,7 @@ impl ProtoConv for DataTypeId {
             Self::Date64 => Self::ProtoType::Date64,
             Self::Interval => Self::ProtoType::Interval,
             Self::Utf8 => Self::ProtoType::Utf8,
-            Self::LargeUtf8 => Self::ProtoType::LargeUtf8,
             Self::Binary => Self::ProtoType::Binary,
-            Self::LargeBinary => Self::ProtoType::LargeBinary,
             Self::Struct => Self::ProtoType::Struct,
             Self::List => Self::ProtoType::List,
         })
@@ -109,9 +110,7 @@ impl ProtoConv for DataTypeId {
             Self::ProtoType::Date64 => Self::Date64,
             Self::ProtoType::Interval => Self::Interval,
             Self::ProtoType::Utf8 => Self::Utf8,
-            Self::ProtoType::LargeUtf8 => Self::LargeUtf8,
             Self::ProtoType::Binary => Self::Binary,
-            Self::ProtoType::LargeBinary => Self::LargeBinary,
             Self::ProtoType::Struct => Self::Struct,
             Self::ProtoType::List => Self::List,
         })
@@ -144,9 +143,7 @@ impl fmt::Display for DataTypeId {
             Self::Date64 => write!(f, "Date64"),
             Self::Interval => write!(f, "Interval"),
             Self::Utf8 => write!(f, "Utf8"),
-            Self::LargeUtf8 => write!(f, "LargeUtf8"),
             Self::Binary => write!(f, "Binary"),
-            Self::LargeBinary => write!(f, "LargeBinary"),
             Self::Struct => write!(f, "Struct"),
             Self::List => write!(f, "List"),
         }
@@ -353,9 +350,7 @@ pub enum DataType {
     /// Some time interval with nanosecond resolution.
     Interval,
     Utf8,
-    LargeUtf8,
     Binary,
-    LargeBinary,
     /// A struct of different types.
     Struct(StructTypeMeta),
     /// A list of values all of the same type.
@@ -403,9 +398,7 @@ impl DataType {
             DataTypeId::Date64 => DataType::Date64,
             DataTypeId::Interval => DataType::Interval,
             DataTypeId::Utf8 => DataType::Utf8,
-            DataTypeId::LargeUtf8 => DataType::LargeUtf8,
             DataTypeId::Binary => DataType::Binary,
-            DataTypeId::LargeBinary => DataType::LargeBinary,
             DataTypeId::Struct => {
                 return Err(RayexecError::new("Cannot create a default Struct datatype"))
             }
@@ -440,9 +433,7 @@ impl DataType {
             DataType::Date64 => DataTypeId::Date64,
             DataType::Interval => DataTypeId::Interval,
             DataType::Utf8 => DataTypeId::Utf8,
-            DataType::LargeUtf8 => DataTypeId::LargeUtf8,
             DataType::Binary => DataTypeId::Binary,
-            DataType::LargeBinary => DataTypeId::LargeBinary,
             DataType::Struct(_) => DataTypeId::Struct,
             DataType::List(_) => DataTypeId::List,
         }
@@ -472,9 +463,7 @@ impl DataType {
             DataType::Date64 => PhysicalType::Int64,
             DataType::Interval => PhysicalType::Interval,
             DataType::Utf8 => PhysicalType::Utf8,
-            DataType::LargeUtf8 => PhysicalType::Utf8,
             DataType::Binary => PhysicalType::Binary,
-            DataType::LargeBinary => PhysicalType::Binary,
             DataType::Struct(_) => not_implemented!("struct data type to physical type"),
             DataType::List(_) => PhysicalType::List,
         })
@@ -491,7 +480,7 @@ impl DataType {
     }
 
     pub const fn is_utf8(&self) -> bool {
-        matches!(self, DataType::Utf8 | DataType::LargeUtf8)
+        matches!(self, DataType::Utf8)
     }
 
     pub const fn is_primitive_numeric(&self) -> bool {
@@ -585,9 +574,7 @@ impl ProtoConv for DataType {
             DataType::Date64 => Value::TypeDate64(EmptyMeta {}),
             DataType::Interval => Value::TypeInterval(EmptyMeta {}),
             DataType::Utf8 => Value::TypeUtf8(EmptyMeta {}),
-            DataType::LargeUtf8 => Value::TypeLargeUtf8(EmptyMeta {}),
             DataType::Binary => Value::TypeBinary(EmptyMeta {}),
-            DataType::LargeBinary => Value::TypeLargeBinary(EmptyMeta {}),
             DataType::Struct(m) => Value::TypeStruct(m.to_proto()?),
             DataType::List(m) => Value::TypeList(Box::new(m.to_proto()?)),
         };
@@ -620,9 +607,7 @@ impl ProtoConv for DataType {
             Value::TypeDate64(_) => DataType::Date64,
             Value::TypeInterval(_) => DataType::Interval,
             Value::TypeUtf8(_) => DataType::Utf8,
-            Value::TypeLargeUtf8(_) => DataType::LargeUtf8,
             Value::TypeBinary(_) => DataType::Binary,
-            Value::TypeLargeBinary(_) => DataType::LargeBinary,
             Value::TypeStruct(m) => DataType::Struct(StructTypeMeta::from_proto(m)?),
             Value::TypeList(m) => DataType::List(ListTypeMeta::from_proto(*m)?),
         })
@@ -654,9 +639,7 @@ impl fmt::Display for DataType {
             Self::Date64 => write!(f, "Date64"),
             Self::Interval => write!(f, "Interval"),
             Self::Utf8 => write!(f, "Utf8"),
-            Self::LargeUtf8 => write!(f, "LargeUtf8"),
             Self::Binary => write!(f, "Binary"),
-            Self::LargeBinary => write!(f, "LargeBinary"),
             Self::Struct(meta) => {
                 write!(
                     f,

--- a/crates/rayexec_bullet/src/executor/scalar/unary.rs
+++ b/crates/rayexec_bullet/src/executor/scalar/unary.rs
@@ -185,7 +185,7 @@ mod tests {
             buffer: GermanVarlenBuffer::<str>::with_len(4),
         };
 
-        fn my_string_double<'a, B>(s: &str, buf: &mut OutputBuffer<B>)
+        fn my_string_double<B>(s: &str, buf: &mut OutputBuffer<B>)
         where
             B: ArrayDataBuffer<Type = str>,
         {

--- a/crates/rayexec_bullet/src/ipc/schema.rs
+++ b/crates/rayexec_bullet/src/ipc/schema.rs
@@ -16,7 +16,6 @@ use crate::ipc::gen::schema::{
     DecimalBuilder,
     FieldBuilder,
     IntBuilder,
-    LargeUtf8Builder,
     NullBuilder,
     SchemaBuilder,
     Utf8Builder,
@@ -102,10 +101,8 @@ pub fn ipc_to_field(field: IpcField, _conf: &IpcConfig) -> Result<Field> {
                 }
             }
         }
-        IpcType::Utf8 => DataType::Utf8,
-        IpcType::LargeUtf8 => DataType::LargeUtf8,
-        IpcType::Binary => DataType::Binary,
-        IpcType::LargeBinary => DataType::LargeBinary,
+        IpcType::Utf8 | IpcType::LargeUtf8 => DataType::Utf8,
+        IpcType::Binary | IpcType::LargeBinary => DataType::Binary,
         other => {
             return Err(RayexecError::new(format!(
                 "Unsupported ipc type: {:?}",
@@ -208,11 +205,6 @@ pub fn field_to_ipc<'a>(
         DataType::Utf8 => (
             IpcType::Utf8,
             Utf8Builder::new(builder).finish().as_union_value(),
-            empty_children.clone(),
-        ),
-        DataType::LargeUtf8 => (
-            IpcType::LargeUtf8,
-            LargeUtf8Builder::new(builder).finish().as_union_value(),
             empty_children.clone(),
         ),
 

--- a/crates/rayexec_bullet/src/scalar/mod.rs
+++ b/crates/rayexec_bullet/src/scalar/mod.rs
@@ -85,9 +85,9 @@ pub enum ScalarValue<'a> {
 
 // TODO: TBD if we want this. We may need to implement PartialEq to exact
 // equality semantics for floats.
-impl<'a> Eq for ScalarValue<'a> {}
+impl Eq for ScalarValue<'_> {}
 
-impl<'a> Hash for ScalarValue<'a> {
+impl Hash for ScalarValue<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             Self::Null => 0_u8.hash(state),
@@ -121,7 +121,7 @@ impl<'a> Hash for ScalarValue<'a> {
 
 pub type OwnedScalarValue = ScalarValue<'static>;
 
-impl<'a> ScalarValue<'a> {
+impl ScalarValue<'_> {
     pub fn datatype(&self) -> DataType {
         match self {
             ScalarValue::Null => DataType::Null,
@@ -407,79 +407,79 @@ impl fmt::Display for ScalarValue<'_> {
     }
 }
 
-impl<'a> From<bool> for ScalarValue<'a> {
+impl From<bool> for ScalarValue<'_> {
     fn from(value: bool) -> Self {
         ScalarValue::Boolean(value)
     }
 }
 
-impl<'a> From<f16> for ScalarValue<'a> {
+impl From<f16> for ScalarValue<'_> {
     fn from(value: f16) -> Self {
         ScalarValue::Float16(value)
     }
 }
 
-impl<'a> From<f32> for ScalarValue<'a> {
+impl From<f32> for ScalarValue<'_> {
     fn from(value: f32) -> Self {
         ScalarValue::Float32(value)
     }
 }
 
-impl<'a> From<f64> for ScalarValue<'a> {
+impl From<f64> for ScalarValue<'_> {
     fn from(value: f64) -> Self {
         ScalarValue::Float64(value)
     }
 }
 
-impl<'a> From<i8> for ScalarValue<'a> {
+impl From<i8> for ScalarValue<'_> {
     fn from(value: i8) -> Self {
         ScalarValue::Int8(value)
     }
 }
 
-impl<'a> From<i16> for ScalarValue<'a> {
+impl From<i16> for ScalarValue<'_> {
     fn from(value: i16) -> Self {
         ScalarValue::Int16(value)
     }
 }
 
-impl<'a> From<i32> for ScalarValue<'a> {
+impl From<i32> for ScalarValue<'_> {
     fn from(value: i32) -> Self {
         ScalarValue::Int32(value)
     }
 }
 
-impl<'a> From<i64> for ScalarValue<'a> {
+impl From<i64> for ScalarValue<'_> {
     fn from(value: i64) -> Self {
         ScalarValue::Int64(value)
     }
 }
 
-impl<'a> From<u8> for ScalarValue<'a> {
+impl From<u8> for ScalarValue<'_> {
     fn from(value: u8) -> Self {
         ScalarValue::UInt8(value)
     }
 }
 
-impl<'a> From<u16> for ScalarValue<'a> {
+impl From<u16> for ScalarValue<'_> {
     fn from(value: u16) -> Self {
         ScalarValue::UInt16(value)
     }
 }
 
-impl<'a> From<u32> for ScalarValue<'a> {
+impl From<u32> for ScalarValue<'_> {
     fn from(value: u32) -> Self {
         ScalarValue::UInt32(value)
     }
 }
 
-impl<'a> From<u64> for ScalarValue<'a> {
+impl From<u64> for ScalarValue<'_> {
     fn from(value: u64) -> Self {
         ScalarValue::UInt64(value)
     }
 }
 
-impl<'a> From<Interval> for ScalarValue<'a> {
+impl From<Interval> for ScalarValue<'_> {
     fn from(value: Interval) -> Self {
         ScalarValue::Interval(value)
     }

--- a/crates/rayexec_bullet/src/storage/boolean.rs
+++ b/crates/rayexec_bullet/src/storage/boolean.rs
@@ -33,7 +33,7 @@ impl From<Bitmap> for BooleanStorage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BooleanStorageRef<'a>(&'a Bitmap);
 
-impl<'a> AddressableStorage for BooleanStorageRef<'a> {
+impl AddressableStorage for BooleanStorageRef<'_> {
     type T = bool;
 
     fn len(&self) -> usize {

--- a/crates/rayexec_bullet/src/storage/german.rs
+++ b/crates/rayexec_bullet/src/storage/german.rs
@@ -242,7 +242,7 @@ impl<'a> Iterator for GermanVarlenIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for GermanVarlenIter<'a> {}
+impl ExactSizeIterator for GermanVarlenIter<'_> {}
 
 #[derive(Debug)]
 pub struct GermanVarlenStorageSlice<'a> {

--- a/crates/rayexec_bullet/src/storage/primitive.rs
+++ b/crates/rayexec_bullet/src/storage/primitive.rs
@@ -189,7 +189,7 @@ pub struct PrimitiveStorageSlice<'a, T> {
     slice: &'a [T],
 }
 
-impl<'a, T: Copy + Debug + Send> AddressableStorage for PrimitiveStorageSlice<'a, T> {
+impl<T: Copy + Debug + Send> AddressableStorage for PrimitiveStorageSlice<'_, T> {
     type T = T;
 
     fn len(&self) -> usize {

--- a/crates/rayexec_bullet/src/storage/varlen.rs
+++ b/crates/rayexec_bullet/src/storage/varlen.rs
@@ -153,7 +153,7 @@ impl<'a, O: OffsetIndex> Iterator for ContiguousVarlenIter<'a, O> {
     }
 }
 
-impl<'a, O: OffsetIndex> ExactSizeIterator for ContiguousVarlenIter<'a, O> {}
+impl<O: OffsetIndex> ExactSizeIterator for ContiguousVarlenIter<'_, O> {}
 
 #[derive(Debug)]
 pub struct ContiguousVarlenStorageSlice<'a, O> {

--- a/crates/rayexec_execution/src/execution/operators/hash_aggregate/hash_table.rs
+++ b/crates/rayexec_execution/src/execution/operators/hash_aggregate/hash_table.rs
@@ -545,7 +545,7 @@ mod tests {
         // 17 unique groups (> initial 16 capacity)
 
         let groups = [Array::from_iter(0..17)];
-        let inputs = [Array::from_iter(0 as i64..17 as i64)];
+        let inputs = [Array::from_iter(0_i64..17_i64)];
 
         let hashes = vec![44; 17]; // All hashes collide.
 
@@ -561,7 +561,7 @@ mod tests {
         // resize by doubling didn't increase capacity enough.
 
         let groups = [Array::from_iter(0..33)];
-        let inputs = [Array::from_iter(0 as i64..33 as i64)];
+        let inputs = [Array::from_iter(0_i64..33_i64)];
 
         let hashes = vec![44; 33]; // All hashes collide.
 

--- a/crates/rayexec_execution/src/execution/operators/sort/scatter_sort.rs
+++ b/crates/rayexec_execution/src/execution/operators/sort/scatter_sort.rs
@@ -368,9 +368,9 @@ mod tests {
     #[test]
     fn sort_single_partition_multiple_outputs() {
         let inputs = vec![
-            make_i32_batch(0..(DEFAULT_TARGET_BATCH_SIZE as i32 * 1)),
+            make_i32_batch(0..DEFAULT_TARGET_BATCH_SIZE as i32),
             make_i32_batch(
-                (DEFAULT_TARGET_BATCH_SIZE as i32 * 1)..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2),
+                DEFAULT_TARGET_BATCH_SIZE as i32..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2),
             ),
             make_i32_batch(
                 (DEFAULT_TARGET_BATCH_SIZE as i32 * 2)..(DEFAULT_TARGET_BATCH_SIZE as i32 * 3),
@@ -420,10 +420,10 @@ mod tests {
                     .rev(),
             ),
             make_i32_batch(
-                ((DEFAULT_TARGET_BATCH_SIZE as i32 * 1)..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2))
+                (DEFAULT_TARGET_BATCH_SIZE as i32..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2))
                     .rev(),
             ),
-            make_i32_batch((0..(DEFAULT_TARGET_BATCH_SIZE as i32 * 1)).rev()),
+            make_i32_batch((0..DEFAULT_TARGET_BATCH_SIZE as i32).rev()),
         ];
 
         assert_eq!(expected, outputs);

--- a/crates/rayexec_execution/src/execution/operators/sort/scatter_sort.rs
+++ b/crates/rayexec_execution/src/execution/operators/sort/scatter_sort.rs
@@ -420,8 +420,7 @@ mod tests {
                     .rev(),
             ),
             make_i32_batch(
-                (DEFAULT_TARGET_BATCH_SIZE as i32..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2))
-                    .rev(),
+                (DEFAULT_TARGET_BATCH_SIZE as i32..(DEFAULT_TARGET_BATCH_SIZE as i32 * 2)).rev(),
             ),
             make_i32_batch((0..DEFAULT_TARGET_BATCH_SIZE as i32).rev()),
         ];

--- a/crates/rayexec_execution/src/explain/context_display.rs
+++ b/crates/rayexec_execution/src/explain/context_display.rs
@@ -54,7 +54,7 @@ impl<'a, D> ContextDisplayWrapper<'a, D> {
     }
 }
 
-impl<'a, D: ContextDisplay> fmt::Display for ContextDisplayWrapper<'a, D> {
+impl<D: ContextDisplay> fmt::Display for ContextDisplayWrapper<'_, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.item.fmt_using_context(self.mode, f)
     }

--- a/crates/rayexec_execution/src/explain/explainable.rs
+++ b/crates/rayexec_execution/src/explain/explainable.rs
@@ -178,7 +178,7 @@ pub trait Explainable {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnIndexes<'a>(pub &'a [usize]);
 
-impl<'a> fmt::Display for ColumnIndexes<'a> {
+impl fmt::Display for ColumnIndexes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (idx, col) in self.0.iter().enumerate() {
             if idx > 0 {

--- a/crates/rayexec_execution/src/functions/aggregate/mod.rs
+++ b/crates/rayexec_execution/src/functions/aggregate/mod.rs
@@ -321,7 +321,7 @@ impl<'a> ChunkGroupAddressIter<'a> {
     }
 }
 
-impl<'a> Iterator for ChunkGroupAddressIter<'a> {
+impl Iterator for ChunkGroupAddressIter<'_> {
     type Item = RowToStateMapping;
 
     #[inline]

--- a/crates/rayexec_execution/src/functions/aggregate/string_agg.rs
+++ b/crates/rayexec_execution/src/functions/aggregate/string_agg.rs
@@ -58,7 +58,7 @@ impl AggregateFunction for StringAgg {
             .collect::<Result<Vec<_>>>()?;
 
         match &datatypes[0] {
-            DataType::Utf8 | DataType::LargeUtf8 => (),
+            DataType::Utf8 => (),
             _ => return Err(invalid_input_types_error(self, &datatypes)),
         }
 

--- a/crates/rayexec_execution/src/functions/implicit.rs
+++ b/crates/rayexec_execution/src/functions/implicit.rs
@@ -34,7 +34,7 @@ pub const fn implicit_cast_score(have: &DataType, want: DataTypeId) -> Option<u3
         DataType::Float64 => return float64_cast_score(want),
 
         // String casts
-        DataType::Utf8 | DataType::LargeUtf8 => match want {
+        DataType::Utf8 => match want {
             DataTypeId::Int8
             | DataTypeId::Int16
             | DataTypeId::Int32
@@ -50,7 +50,7 @@ pub const fn implicit_cast_score(have: &DataType, want: DataTypeId) -> Option<u3
 
             // Non-zero since it's a valid cast, just we would prefer something
             // else.
-            DataTypeId::Utf8 | DataTypeId::LargeUtf8 => return Some(1),
+            DataTypeId::Utf8 => return Some(1),
             _ => (),
         },
         _ => (),
@@ -233,10 +233,6 @@ mod tests {
         assert!(implicit_cast_score(&DataType::Utf8, DataTypeId::Int32).is_some());
         assert!(implicit_cast_score(&DataType::Utf8, DataTypeId::Timestamp).is_some());
         assert!(implicit_cast_score(&DataType::Utf8, DataTypeId::Interval).is_some());
-
-        assert!(implicit_cast_score(&DataType::LargeUtf8, DataTypeId::Int32).is_some());
-        assert!(implicit_cast_score(&DataType::LargeUtf8, DataTypeId::Timestamp).is_some());
-        assert!(implicit_cast_score(&DataType::LargeUtf8, DataTypeId::Interval).is_some());
     }
 
     #[test]

--- a/crates/rayexec_execution/src/functions/scalar/comparison.rs
+++ b/crates/rayexec_execution/src/functions/scalar/comparison.rs
@@ -119,17 +119,7 @@ const COMPARISON_SIGNATURES: &[Signature] = &[
         return_type: DataTypeId::Boolean,
     },
     Signature {
-        input: &[DataTypeId::LargeUtf8, DataTypeId::LargeUtf8],
-        variadic: None,
-        return_type: DataTypeId::Boolean,
-    },
-    Signature {
         input: &[DataTypeId::Binary, DataTypeId::Binary],
-        variadic: None,
-        return_type: DataTypeId::Boolean,
-    },
-    Signature {
-        input: &[DataTypeId::LargeBinary, DataTypeId::LargeBinary],
         variadic: None,
         return_type: DataTypeId::Boolean,
     },
@@ -474,9 +464,7 @@ impl ScalarFunction for Eq {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(EqImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(EqImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }
@@ -545,9 +533,7 @@ impl ScalarFunction for Neq {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(NeqImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(NeqImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }
@@ -612,9 +598,7 @@ impl ScalarFunction for Lt {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(LtImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(LtImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }
@@ -679,9 +663,7 @@ impl ScalarFunction for LtEq {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(LtEqImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(LtEqImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }
@@ -746,9 +728,7 @@ impl ScalarFunction for Gt {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(GtImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(GtImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }
@@ -813,9 +793,7 @@ impl ScalarFunction for GtEq {
             | (DataType::Date32, DataType::Date32)
             | (DataType::Date64, DataType::Date64)
             | (DataType::Utf8, DataType::Utf8)
-            | (DataType::LargeUtf8, DataType::LargeUtf8)
-            | (DataType::Binary, DataType::Binary)
-            | (DataType::LargeBinary, DataType::LargeBinary) => Ok(Box::new(GtEqImpl)),
+            | (DataType::Binary, DataType::Binary) => Ok(Box::new(GtEqImpl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }

--- a/crates/rayexec_execution/src/functions/scalar/like.rs
+++ b/crates/rayexec_execution/src/functions/scalar/like.rs
@@ -31,11 +31,6 @@ impl FunctionInfo for Like {
                 variadic: None,
                 return_type: DataTypeId::Boolean,
             },
-            Signature {
-                input: &[DataTypeId::LargeUtf8, DataTypeId::LargeUtf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
         ]
     }
 }
@@ -69,7 +64,6 @@ impl ScalarFunction for Like {
 
         match (&datatypes[0], &datatypes[1]) {
             (DataType::Utf8, DataType::Utf8) => (),
-            (DataType::LargeUtf8, DataType::LargeUtf8) => (),
             (a, b) => return Err(invalid_input_types_error(self, &[a, b])),
         }
 

--- a/crates/rayexec_execution/src/functions/scalar/string/contains.rs
+++ b/crates/rayexec_execution/src/functions/scalar/string/contains.rs
@@ -23,18 +23,11 @@ impl FunctionInfo for Contains {
     }
 
     fn signatures(&self) -> &[Signature] {
-        &[
-            Signature {
-                input: &[DataTypeId::Utf8, DataTypeId::Utf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-            Signature {
-                input: &[DataTypeId::LargeUtf8, DataTypeId::LargeUtf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-        ]
+        &[Signature {
+            input: &[DataTypeId::Utf8, DataTypeId::Utf8],
+            variadic: None,
+            return_type: DataTypeId::Boolean,
+        }]
     }
 }
 
@@ -62,7 +55,6 @@ impl ScalarFunction for Contains {
 
         match (&datatypes[0], &datatypes[1]) {
             (DataType::Utf8, DataType::Utf8) => (),
-            (DataType::LargeUtf8, DataType::LargeUtf8) => (),
             (a, b) => return Err(invalid_input_types_error(self, &[a, b])),
         }
 

--- a/crates/rayexec_execution/src/functions/scalar/string/ends_with.rs
+++ b/crates/rayexec_execution/src/functions/scalar/string/ends_with.rs
@@ -27,18 +27,11 @@ impl FunctionInfo for EndsWith {
     }
 
     fn signatures(&self) -> &[Signature] {
-        &[
-            Signature {
-                input: &[DataTypeId::Utf8, DataTypeId::Utf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-            Signature {
-                input: &[DataTypeId::LargeUtf8, DataTypeId::LargeUtf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-        ]
+        &[Signature {
+            input: &[DataTypeId::Utf8, DataTypeId::Utf8],
+            variadic: None,
+            return_type: DataTypeId::Boolean,
+        }]
     }
 }
 
@@ -66,7 +59,6 @@ impl ScalarFunction for EndsWith {
 
         match (&datatypes[0], &datatypes[1]) {
             (DataType::Utf8, DataType::Utf8) => (),
-            (DataType::LargeUtf8, DataType::LargeUtf8) => (),
             (a, b) => return Err(invalid_input_types_error(self, &[a, b])),
         }
 

--- a/crates/rayexec_execution/src/functions/scalar/string/regexp_replace.rs
+++ b/crates/rayexec_execution/src/functions/scalar/string/regexp_replace.rs
@@ -68,7 +68,7 @@ impl ScalarFunction for RegexpReplace {
             .collect::<Result<Vec<_>>>()?;
 
         for datatype in &datatypes {
-            if (datatype != &DataType::Utf8) && (datatype != &DataType::LargeUtf8) {
+            if datatype != &DataType::Utf8 {
                 return Err(invalid_input_types_error(self, &datatypes));
             }
         }

--- a/crates/rayexec_execution/src/functions/scalar/string/repeat.rs
+++ b/crates/rayexec_execution/src/functions/scalar/string/repeat.rs
@@ -20,18 +20,11 @@ impl FunctionInfo for Repeat {
     }
 
     fn signatures(&self) -> &[Signature] {
-        &[
-            Signature {
-                input: &[DataTypeId::Utf8, DataTypeId::Int64],
-                variadic: None,
-                return_type: DataTypeId::Utf8,
-            },
-            Signature {
-                input: &[DataTypeId::LargeUtf8, DataTypeId::Int64],
-                variadic: None,
-                return_type: DataTypeId::LargeUtf8,
-            },
-        ]
+        &[Signature {
+            input: &[DataTypeId::Utf8, DataTypeId::Int64],
+            variadic: None,
+            return_type: DataTypeId::Utf8,
+        }]
     }
 }
 
@@ -44,7 +37,6 @@ impl ScalarFunction for Repeat {
         plan_check_num_args(self, inputs, 2)?;
         match (&inputs[0], &inputs[1]) {
             (DataType::Utf8, DataType::Int64) => Ok(Box::new(RepeatUtf8Impl)),
-            (DataType::LargeUtf8, DataType::Int64) => Ok(Box::new(RepeatUtf8Impl)),
             (a, b) => Err(invalid_input_types_error(self, &[a, b])),
         }
     }

--- a/crates/rayexec_execution/src/functions/scalar/string/starts_with.rs
+++ b/crates/rayexec_execution/src/functions/scalar/string/starts_with.rs
@@ -27,18 +27,11 @@ impl FunctionInfo for StartsWith {
     }
 
     fn signatures(&self) -> &[Signature] {
-        &[
-            Signature {
-                input: &[DataTypeId::Utf8, DataTypeId::Utf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-            Signature {
-                input: &[DataTypeId::LargeUtf8, DataTypeId::LargeUtf8],
-                variadic: None,
-                return_type: DataTypeId::Boolean,
-            },
-        ]
+        &[Signature {
+            input: &[DataTypeId::Utf8, DataTypeId::Utf8],
+            variadic: None,
+            return_type: DataTypeId::Boolean,
+        }]
     }
 }
 
@@ -66,7 +59,6 @@ impl ScalarFunction for StartsWith {
 
         match (&datatypes[0], &datatypes[1]) {
             (DataType::Utf8, DataType::Utf8) => (),
-            (DataType::LargeUtf8, DataType::LargeUtf8) => (),
             (a, b) => return Err(invalid_input_types_error(self, &[a, b])),
         }
 

--- a/crates/rayexec_execution/src/logical/binder/bind_query/bind_group_by.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_query/bind_group_by.rs
@@ -84,7 +84,7 @@ pub struct GroupByColumnBinder<'a> {
     select_list: &'a mut SelectList,
 }
 
-impl<'a> ExpressionColumnBinder for GroupByColumnBinder<'a> {
+impl ExpressionColumnBinder for GroupByColumnBinder<'_> {
     fn bind_from_root_literal(
         &mut self,
         _bind_scope: BindScopeRef,

--- a/crates/rayexec_execution/src/logical/binder/bind_query/bind_modifier.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_query/bind_modifier.rs
@@ -195,7 +195,7 @@ pub struct OrderByColumnBinder<'a> {
     did_bind_to_select: bool,
 }
 
-impl<'a> ExpressionColumnBinder for OrderByColumnBinder<'a> {
+impl ExpressionColumnBinder for OrderByColumnBinder<'_> {
     fn bind_from_root_literal(
         &mut self,
         _bind_scope: BindScopeRef,

--- a/crates/rayexec_execution/src/logical/binder/bind_statement.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_statement.rs
@@ -55,7 +55,7 @@ pub struct StatementBinder<'a> {
     pub resolve_context: &'a ResolveContext,
 }
 
-impl<'a> StatementBinder<'a> {
+impl StatementBinder<'_> {
     pub fn bind(
         &self,
         statement: Statement<ResolvedMeta>,

--- a/crates/rayexec_execution/src/optimizer/column_prune.rs
+++ b/crates/rayexec_execution/src/optimizer/column_prune.rs
@@ -73,7 +73,7 @@ struct MagicScanColumnReplacer<'a> {
     updated: &'a HashMap<ColumnExpr, Expression>,
 }
 
-impl<'a> MagicScanColumnReplacer<'a> {
+impl MagicScanColumnReplacer<'_> {
     fn walk_plan(&self, plan: &mut LogicalOperator) -> Result<()> {
         match plan {
             LogicalOperator::MagicMaterializationScan(scan) if scan.node.mat == self.mat => {

--- a/crates/rayexec_io/src/s3/credentials.rs
+++ b/crates/rayexec_io/src/s3/credentials.rs
@@ -40,7 +40,7 @@ pub struct AwsRequestAuthorizer<'a> {
     pub region: &'a str,
 }
 
-impl<'a> AwsRequestAuthorizer<'a> {
+impl AwsRequestAuthorizer<'_> {
     /// Authorizes a request for s3 with a set of credentials.
     ///
     /// See <https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html>

--- a/crates/rayexec_parquet/src/schema.rs
+++ b/crates/rayexec_parquet/src/schema.rs
@@ -145,12 +145,10 @@ fn to_parquet_type(field: &Field) -> Result<Type> {
                 .with_logical_type(logical_type)
                 .build()
         }
-        DataType::Utf8 | DataType::LargeUtf8 => {
-            Type::primitive_type_builder(&field.name, PhysicalType::BYTE_ARRAY)
-                .with_repetition(rep)
-                .with_logical_type(Some(LogicalType::String))
-                .build()
-        }
+        DataType::Utf8 => Type::primitive_type_builder(&field.name, PhysicalType::BYTE_ARRAY)
+            .with_repetition(rep)
+            .with_logical_type(Some(LogicalType::String))
+            .build(),
         other => {
             return Err(RayexecError::new(format!(
                 "Unimplemented type conversion to parquet type: {other}"

--- a/crates/rayexec_parquet/src/writer/mod.rs
+++ b/crates/rayexec_parquet/src/writer/mod.rs
@@ -158,8 +158,7 @@ impl RowGroupWriter {
                 | DataType::Timestamp(_)
                 | DataType::Decimal64(_)
                 | DataType::Decimal128(_)
-                | DataType::Utf8
-                | DataType::LargeUtf8 => {
+                | DataType::Utf8 => {
                     let page_writer = BufferedPageWriter {
                         buf: ColumnBuffer(Vec::new()), // TODO: Could reuse across row groups.
                     };

--- a/crates/rayexec_proto/proto/schema.proto
+++ b/crates/rayexec_proto/proto/schema.proto
@@ -27,11 +27,9 @@ enum DataTypeId {
     DATE64              = 21;
     INTERVAL            = 22;
     UTF8                = 23;
-    LARGE_UTF8          = 24;
-    BINARY              = 25;
-    LARGE_BINARY        = 26;
-    STRUCT              = 27;
-    LIST                = 28;
+    BINARY              = 24;
+    STRUCT              = 25;
+    LIST                = 26;
 }
 
 enum TimeUnit {
@@ -63,33 +61,31 @@ message EmptyMeta {}
 
 message DataType {
     oneof value {
-        EmptyMeta         type_null         = 2;
-        EmptyMeta         type_boolean      = 3;
-        EmptyMeta         type_int8         = 4;
-        EmptyMeta         type_int16        = 5;
-        EmptyMeta         type_int32        = 6;
-        EmptyMeta         type_int64        = 7;
-        EmptyMeta         type_int128       = 8;
-        EmptyMeta         type_uint8        = 9;
-        EmptyMeta         type_uint16       = 10;
-        EmptyMeta         type_uint32       = 11;
-        EmptyMeta         type_uint64       = 12;
-        EmptyMeta         type_uint128      = 13;
-        EmptyMeta         type_float16      = 14;
-        EmptyMeta         type_float32      = 15;
-        EmptyMeta         type_float64      = 16;
-        DecimalTypeMeta   type_decimal64    = 17;
-        DecimalTypeMeta   type_decimal128   = 18;
-        TimestampTypeMeta type_timestamp    = 19;
-        EmptyMeta         type_date32       = 20;
-        EmptyMeta         type_date64       = 21;
-        EmptyMeta         type_interval     = 22;
-        EmptyMeta         type_utf8         = 23;
-        EmptyMeta         type_large_utf8   = 24;
-        EmptyMeta         type_binary       = 25;
-        EmptyMeta         type_large_binary = 26;
-        StructTypeMeta    type_struct       = 27;
-        ListTypeMeta      type_list         = 28;
+        EmptyMeta         type_null       = 2;
+        EmptyMeta         type_boolean    = 3;
+        EmptyMeta         type_int8       = 4;
+        EmptyMeta         type_int16      = 5;
+        EmptyMeta         type_int32      = 6;
+        EmptyMeta         type_int64      = 7;
+        EmptyMeta         type_int128     = 8;
+        EmptyMeta         type_uint8      = 9;
+        EmptyMeta         type_uint16     = 10;
+        EmptyMeta         type_uint32     = 11;
+        EmptyMeta         type_uint64     = 12;
+        EmptyMeta         type_uint128    = 13;
+        EmptyMeta         type_float16    = 14;
+        EmptyMeta         type_float32    = 15;
+        EmptyMeta         type_float64    = 16;
+        DecimalTypeMeta   type_decimal64  = 17;
+        DecimalTypeMeta   type_decimal128 = 18;
+        TimestampTypeMeta type_timestamp  = 19;
+        EmptyMeta         type_date32     = 20;
+        EmptyMeta         type_date64     = 21;
+        EmptyMeta         type_interval   = 22;
+        EmptyMeta         type_utf8       = 23;
+        EmptyMeta         type_binary     = 24;
+        StructTypeMeta    type_struct     = 25;
+        ListTypeMeta      type_list       = 26;
     }
 }
 

--- a/crates/rayexec_shell/src/lineedit.rs
+++ b/crates/rayexec_shell/src/lineedit.rs
@@ -265,7 +265,7 @@ impl<W: io::Write> LineEditor<W> {
 
     /// Compute number of rows of the current buffer.
     const fn rows(&self) -> usize {
-        (self.prompt.len() + self.len + self.cols - 1) / self.cols
+        (self.prompt.len() + self.len).div_ceil(self.cols)
     }
 
     /// Get the current row relative to the cursor.

--- a/crates/rayexec_shell/src/raw.rs
+++ b/crates/rayexec_shell/src/raw.rs
@@ -13,7 +13,7 @@ impl<'a, W: io::Write> RawTerminalWriter<'a, W> {
     }
 }
 
-impl<'a, W: io::Write> io::Write for RawTerminalWriter<'a, W> {
+impl<W: io::Write> io::Write for RawTerminalWriter<'_, W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mut current = buf;
         let mut n = 0;

--- a/crates/rayexec_slt/src/convert.rs
+++ b/crates/rayexec_slt/src/convert.rs
@@ -43,7 +43,7 @@ pub fn schema_to_types(schema: &Schema) -> Vec<DefaultColumnType> {
             | DataType::UInt32
             | DataType::UInt64 => DefaultColumnType::Integer,
             DataType::Float32 | DataType::Float64 => DefaultColumnType::FloatingPoint,
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Boolean => DefaultColumnType::Text,
+            DataType::Utf8 | DataType::Boolean => DefaultColumnType::Text,
             _ => DefaultColumnType::Any,
         };
         typs.push(typ);

--- a/test_bin/integration_slt_tpcds.rs
+++ b/test_bin/integration_slt_tpcds.rs
@@ -43,7 +43,7 @@ pub fn main() -> Result<()> {
 async fn create_views(
     session: &SingleUserSession<ThreadedNativeExecutor, NativeRuntime>,
 ) -> Result<()> {
-    const TABLES: &'static [&'static str] = &[
+    const TABLES: &[&str] = &[
         "call_center",
         "catalog_page",
         "catalog_returns",


### PR DESCRIPTION
Utf8/Binary already covers both, there's no difference when executing on the physical types.