### PR TITLE
feat: Lateral unnest + additional list array logic

### DIFF
--- a/crates/rayexec_bullet/src/executor/scalar/list.rs
+++ b/crates/rayexec_bullet/src/executor/scalar/list.rs
@@ -1,22 +1,37 @@
 use rayexec_error::{not_implemented, RayexecError, Result};
 
 use crate::array::{Array, ArrayData};
+use crate::bitmap::Bitmap;
 use crate::executor::builder::{ArrayBuilder, ArrayDataBuffer};
 use crate::executor::physical_type::{PhysicalList, PhysicalStorage};
-use crate::executor::scalar::{can_skip_validity_check, validate_logical_len};
+use crate::executor::scalar::{can_skip_validity_check, check_validity, validate_logical_len};
 use crate::selection::{self, SelectionVector};
-use crate::storage::AddressableStorage;
+use crate::storage::{AddressableStorage, ListItemMetadata};
 
-pub trait BinaryListReducer<T, O>: Default {
+pub trait BinaryListReducer<T, O> {
+    fn new(left_len: i32, right_len: i32) -> Self;
     fn put_values(&mut self, v1: T, v2: T);
     fn finish(self) -> O;
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct ListExecutor;
+/// List executor that allows for different list lengths, and nulls inside of
+/// lists.
+pub type FlexibleListExecutor = ListExecutor<true, true>;
 
-impl ListExecutor {
-    pub fn execute_binary_reduce<'a, S, B, R>(
+/// Execute reductions on lists.
+///
+/// `ALLOW_DIFFERENT_LENS` controls whether or not this allows for reducing
+/// lists of different lengths.
+///
+/// `ALLOW_NULLS` controls if this allows nulls in lists.
+#[derive(Debug, Clone, Copy)]
+pub struct ListExecutor<const ALLOW_DIFFERENT_LENS: bool, const ALLOW_NULLS: bool>;
+
+impl<const ALLOW_DIFFERENT_LENS: bool, const ALLOW_NULLS: bool>
+    ListExecutor<ALLOW_DIFFERENT_LENS, ALLOW_NULLS>
+{
+    /// Execute a reducer on two list arrays.
+    pub fn binary_reduce<'a, S, B, R>(
         array1: &'a Array,
         array2: &'a Array,
         mut builder: ArrayBuilder<B>,
@@ -40,72 +55,124 @@ impl ListExecutor {
             let metadata1 = PhysicalList::get_storage(array1.array_data())?;
             let metadata2 = PhysicalList::get_storage(array2.array_data())?;
 
-            let values1 = get_inner_array_storage::<S>(array1)?;
-            let values2 = get_inner_array_storage::<S>(array2)?;
+            let (values1, inner_validity1) = get_inner_array_storage::<S>(array1)?;
+            let (values2, inner_validity2) = get_inner_array_storage::<S>(array2)?;
 
             let inner_sel1 = get_inner_array_selection(array1)?;
             let inner_sel2 = get_inner_array_selection(array2)?;
 
-            for idx in 0..len {
-                let sel1 = unsafe { selection::get_unchecked(selection1, idx) };
-                let sel2 = unsafe { selection::get_unchecked(selection2, idx) };
+            if can_skip_validity_check([inner_validity1, inner_validity2]) {
+                for idx in 0..len {
+                    let sel1 = unsafe { selection::get_unchecked(selection1, idx) };
+                    let sel2 = unsafe { selection::get_unchecked(selection2, idx) };
 
-                let m1 = unsafe { metadata1.get_unchecked(sel1) };
-                let m2 = unsafe { metadata2.get_unchecked(sel2) };
+                    let m1 = unsafe { metadata1.get_unchecked(sel1) };
+                    let m2 = unsafe { metadata2.get_unchecked(sel2) };
 
-                if m1.len != m2.len {
-                    return Err(RayexecError::new(format!(
-                        "Cannot reduce arrays with differing lengths, got {} and {}",
-                        m1.len, m2.len
-                    )));
+                    let len = Self::item_iter_len(m1, m2)?;
+
+                    let mut reducer = R::new(m1.len, m2.len);
+
+                    for inner_idx in 0..len {
+                        let idx1 = m1.offset + inner_idx;
+                        let idx2 = m2.offset + inner_idx;
+
+                        let sel1 = unsafe { selection::get_unchecked(inner_sel1, idx1 as usize) };
+                        let sel2 = unsafe { selection::get_unchecked(inner_sel2, idx2 as usize) };
+
+                        let v1 = unsafe { values1.get_unchecked(sel1) };
+                        let v2 = unsafe { values2.get_unchecked(sel2) };
+
+                        reducer.put_values(v1, v2);
+                    }
+
+                    let out = reducer.finish();
+
+                    builder.buffer.put(idx, &out);
                 }
 
-                let mut reducer = R::default();
-
-                for inner_idx in 0..m1.len {
-                    let idx1 = m1.offset + inner_idx;
-                    let idx2 = m2.offset + inner_idx;
-
-                    let sel1 = unsafe { selection::get_unchecked(inner_sel1, idx1 as usize) };
-                    let sel2 = unsafe { selection::get_unchecked(inner_sel2, idx2 as usize) };
-
-                    let v1 = unsafe { values1.get_unchecked(sel1) };
-                    let v2 = unsafe { values2.get_unchecked(sel2) };
-
-                    reducer.put_values(v1, v2);
+                Ok(Array {
+                    datatype: builder.datatype,
+                    selection: None,
+                    validity: None,
+                    data: builder.buffer.into_data(),
+                })
+            } else {
+                if !ALLOW_NULLS {
+                    return Err(RayexecError::new("Cannot reduce list containing NULLs"));
                 }
 
-                let out = reducer.finish();
+                for idx in 0..len {
+                    let sel1 = unsafe { selection::get_unchecked(selection1, idx) };
+                    let sel2 = unsafe { selection::get_unchecked(selection2, idx) };
 
-                builder.buffer.put(idx, &out);
+                    let m1 = unsafe { metadata1.get_unchecked(sel1) };
+                    let m2 = unsafe { metadata2.get_unchecked(sel2) };
+
+                    let len = Self::item_iter_len(m1, m2)?;
+
+                    let mut reducer = R::new(m1.len, m2.len);
+
+                    for inner_idx in 0..len {
+                        let idx1 = m1.offset + inner_idx;
+                        let idx2 = m2.offset + inner_idx;
+
+                        let sel1 = unsafe { selection::get_unchecked(inner_sel1, idx1 as usize) };
+                        let sel2 = unsafe { selection::get_unchecked(inner_sel2, idx2 as usize) };
+
+                        if check_validity(sel1, inner_validity1)
+                            && check_validity(sel2, inner_validity2)
+                        {
+                            let v1 = unsafe { values1.get_unchecked(sel1) };
+                            let v2 = unsafe { values2.get_unchecked(sel2) };
+
+                            reducer.put_values(v1, v2);
+                        }
+                    }
+
+                    let out = reducer.finish();
+
+                    builder.buffer.put(idx, &out);
+                }
+
+                Ok(Array {
+                    datatype: builder.datatype,
+                    selection: None,
+                    validity: None,
+                    data: builder.buffer.into_data(),
+                })
             }
-
-            Ok(Array {
-                datatype: builder.datatype,
-                selection: None,
-                validity: None,
-                data: builder.buffer.into_data(),
-            })
         } else {
             // let mut out_validity = None;
             not_implemented!("list validity execute")
+        }
+    }
+
+    fn item_iter_len(m1: ListItemMetadata, m2: ListItemMetadata) -> Result<i32> {
+        if m1.len == m2.len {
+            Ok(m1.len)
+        } else if ALLOW_DIFFERENT_LENS {
+            Ok(std::cmp::min(m1.len, m2.len))
+        } else {
+            Err(RayexecError::new(format!(
+                "Cannot reduce arrays with differing lengths, got {} and {}",
+                m1.len, m2.len
+            )))
         }
     }
 }
 
 /// Gets the inner array storage. Checks to ensure the inner array does not
 /// contain NULLs.
-fn get_inner_array_storage<S>(array: &Array) -> Result<S::Storage<'_>>
+fn get_inner_array_storage<S>(array: &Array) -> Result<(S::Storage<'_>, Option<&Bitmap>)>
 where
     S: PhysicalStorage,
 {
     match array.array_data() {
         ArrayData::List(d) => {
-            if !can_skip_validity_check([d.array.validity()]) {
-                return Err(RayexecError::new("Cannot reduce list containing NULLs"));
-            }
-
-            S::get_storage(d.array.array_data())
+            let storage = S::get_storage(d.array.array_data())?;
+            let validity = d.array.validity();
+            Ok((storage, validity))
         }
         _ => Err(RayexecError::new("Expected list array data")),
     }

--- a/crates/rayexec_error/src/lib.rs
+++ b/crates/rayexec_error/src/lib.rs
@@ -68,7 +68,7 @@ impl RayexecError {
         }
     }
 
-    pub fn with_field<K, V>(mut self, (key, value): (K, V)) -> Self
+    pub fn with_field<K, V>(mut self, key: K, value: V) -> Self
     where
         K: Into<String>,
         V: ErrorFieldValue + 'static,

--- a/crates/rayexec_execution/src/execution/operators/unnest.rs
+++ b/crates/rayexec_execution/src/execution/operators/unnest.rs
@@ -304,7 +304,7 @@ impl Explainable for PhysicalUnnest {
     }
 }
 
-fn unnest(child: &Array, longest_len: usize, meta: ListItemMetadata) -> Result<Array> {
+pub(crate) fn unnest(child: &Array, longest_len: usize, meta: ListItemMetadata) -> Result<Array> {
     let datatype = child.datatype().clone();
 
     match child.physical_type() {

--- a/crates/rayexec_execution/src/functions/scalar/builtin/comparison.rs
+++ b/crates/rayexec_execution/src/functions/scalar/builtin/comparison.rs
@@ -29,12 +29,7 @@ use rayexec_bullet::executor::physical_type::{
     PhysicalUntypedNull,
     PhysicalUtf8,
 };
-use rayexec_bullet::executor::scalar::{
-    BinaryExecutor,
-    BinaryListReducer,
-    FlexibleListExecutor,
-    ListExecutor,
-};
+use rayexec_bullet::executor::scalar::{BinaryExecutor, BinaryListReducer, FlexibleListExecutor};
 use rayexec_bullet::scalar::decimal::{Decimal128Type, Decimal64Type, DecimalType};
 use rayexec_bullet::storage::PrimitiveStorage;
 use rayexec_error::{RayexecError, Result};

--- a/crates/rayexec_execution/src/functions/scalar/builtin/similarity/l2_distance.rs
+++ b/crates/rayexec_execution/src/functions/scalar/builtin/similarity/l2_distance.rs
@@ -109,7 +109,7 @@ where
             buffer: PrimitiveBuffer::with_len(a.logical_len()),
         };
 
-        ListExecutor::execute_binary_reduce::<S, _, L2DistanceReducer<_>>(a, b, builder)
+        ListExecutor::<false, false>::binary_reduce::<S, _, L2DistanceReducer<_>>(a, b, builder)
     }
 }
 
@@ -122,6 +122,11 @@ impl<F> BinaryListReducer<F, f64> for L2DistanceReducer<F>
 where
     F: Float + AddAssign + AsPrimitive<f64> + Default,
 {
+    fn new(left_len: i32, right_len: i32) -> Self {
+        debug_assert_eq!(left_len, right_len);
+        Self::default()
+    }
+
     fn put_values(&mut self, v1: F, v2: F) {
         let diff = v1 - v2;
         self.distance += diff * diff;

--- a/crates/rayexec_execution/src/functions/table/builtin/mod.rs
+++ b/crates/rayexec_execution/src/functions/table/builtin/mod.rs
@@ -1,16 +1,19 @@
 pub mod series;
 pub mod system;
+pub mod unnest;
 
 use std::sync::LazyLock;
 
 use series::GenerateSeries;
 use system::{ListDatabases, ListFunctions, ListSchemas, ListTables};
+use unnest::Unnest;
 
 use super::TableFunction;
 
 pub static BUILTIN_TABLE_FUNCTIONS: LazyLock<Vec<Box<dyn TableFunction>>> = LazyLock::new(|| {
     vec![
         Box::new(GenerateSeries),
+        Box::new(Unnest),
         // Various list system object functions.
         Box::new(ListDatabases::new()),
         Box::new(ListSchemas::new()),

--- a/crates/rayexec_execution/src/functions/table/builtin/unnest.rs
+++ b/crates/rayexec_execution/src/functions/table/builtin/unnest.rs
@@ -51,7 +51,7 @@ impl FunctionInfo for Unnest {
 
 impl TableFunction for Unnest {
     fn planner(&self) -> TableFunctionPlanner {
-        unimplemented!()
+        TableFunctionPlanner::InOut(self)
     }
 }
 

--- a/crates/rayexec_execution/src/functions/table/builtin/unnest.rs
+++ b/crates/rayexec_execution/src/functions/table/builtin/unnest.rs
@@ -1,0 +1,244 @@
+use std::collections::HashMap;
+use std::task::{Context, Waker};
+
+use rayexec_bullet::array::{Array, ArrayData};
+use rayexec_bullet::batch::Batch;
+use rayexec_bullet::datatype::{DataType, DataTypeId};
+use rayexec_bullet::executor::physical_type::{PhysicalList, PhysicalType};
+use rayexec_bullet::executor::scalar::UnaryExecutor;
+use rayexec_bullet::field::{Field, Schema};
+use rayexec_bullet::scalar::OwnedScalarValue;
+use rayexec_error::{RayexecError, Result};
+
+use crate::execution::operators::unnest::unnest;
+use crate::execution::operators::{PollFinalize, PollPush};
+use crate::expr::Expression;
+use crate::functions::table::inout::{InOutPollPull, TableInOutFunction, TableInOutPartitionState};
+use crate::functions::table::{
+    InOutPlanner,
+    PlannedTableFunction,
+    TableFunction,
+    TableFunctionImpl,
+    TableFunctionPlanner,
+};
+use crate::functions::{invalid_input_types_error, plan_check_num_args, FunctionInfo, Signature};
+use crate::logical::binder::table_list::TableList;
+use crate::logical::statistics::StatisticsValue;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Unnest;
+
+impl FunctionInfo for Unnest {
+    fn name(&self) -> &'static str {
+        "unnest"
+    }
+
+    fn signatures(&self) -> &[Signature] {
+        &[
+            Signature {
+                positional_args: &[DataTypeId::List],
+                variadic_arg: None,
+                return_type: DataTypeId::Any,
+            },
+            Signature {
+                positional_args: &[DataTypeId::Null],
+                variadic_arg: None,
+                return_type: DataTypeId::Null,
+            },
+        ]
+    }
+}
+
+impl TableFunction for Unnest {
+    fn planner(&self) -> TableFunctionPlanner {
+        unimplemented!()
+    }
+}
+
+impl InOutPlanner for Unnest {
+    fn plan(
+        &self,
+        table_list: &TableList,
+        positional_inputs: Vec<Expression>,
+        named_inputs: HashMap<String, OwnedScalarValue>,
+    ) -> Result<PlannedTableFunction> {
+        plan_check_num_args(self, &positional_inputs, 1)?;
+        if !named_inputs.is_empty() {
+            return Err(RayexecError::new(
+                "UNNEST does not yet accept named arguments",
+            ));
+        }
+
+        let datatype = positional_inputs[0].datatype(table_list)?;
+
+        let return_type = match datatype {
+            DataType::List(m) => *m.datatype,
+            DataType::Null => DataType::Null,
+            other => return Err(invalid_input_types_error(self, &[other])),
+        };
+
+        let schema = Schema::new([Field::new("unnest", return_type, true)]);
+
+        Ok(PlannedTableFunction {
+            function: Box::new(*self),
+            positional_inputs,
+            named_inputs,
+            function_impl: TableFunctionImpl::InOut(Box::new(UnnestInOutImpl)),
+            cardinality: StatisticsValue::Unknown,
+            schema,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnnestInOutImpl;
+
+impl TableInOutFunction for UnnestInOutImpl {
+    fn create_states(
+        &self,
+        num_partitions: usize,
+    ) -> Result<Vec<Box<dyn TableInOutPartitionState>>> {
+        let states: Vec<_> = (0..num_partitions)
+            .map(|_| {
+                Box::new(UnnestInOutPartitionState {
+                    input: None,
+                    input_num_rows: 0,
+                    current_row: 0,
+                    finished: false,
+                    push_waker: None,
+                    pull_waker: None,
+                }) as _
+            })
+            .collect();
+
+        Ok(states)
+    }
+}
+
+// TODO: A lot of this is duplicated with the Unnest operator.
+//
+// Ideally we'd have a more generic operator for handling table funcs in the
+// select list at some point.
+//
+// Nearer term we should look at combining the logic a bit more.
+#[derive(Debug)]
+pub struct UnnestInOutPartitionState {
+    /// The array we're unnesting.
+    input: Option<Array>,
+    /// Number of rows in the input batch.
+    input_num_rows: usize,
+    /// Current row we're processing.
+    current_row: usize,
+    /// If we're finished receiving inputs.
+    finished: bool,
+    /// Push side waker.
+    ///
+    /// Set if we still have rows to process.
+    push_waker: Option<Waker>,
+    /// Pull side waker.
+    ///
+    /// Set if we've processed all rows and need more input.
+    pull_waker: Option<Waker>,
+}
+
+impl TableInOutPartitionState for UnnestInOutPartitionState {
+    fn poll_push(&mut self, cx: &mut Context, inputs: Batch) -> Result<PollPush> {
+        if self.current_row < self.input_num_rows {
+            // Still processing inputs, come back later.
+            self.push_waker = Some(cx.waker().clone());
+            if let Some(waker) = self.pull_waker.take() {
+                waker.wake();
+            }
+
+            return Ok(PollPush::Pending(inputs));
+        }
+
+        self.input_num_rows = inputs.num_rows();
+        self.current_row = 0;
+
+        match inputs.columns().len() {
+            1 => self.input = inputs.into_arrays().pop(),
+            other => {
+                return Err(RayexecError::new("Invalid number of arrays").with_field("len", other))
+            }
+        }
+
+        if let Some(waker) = self.pull_waker.take() {
+            waker.wake();
+        }
+
+        Ok(PollPush::Pushed)
+    }
+
+    fn poll_finalize_push(&mut self, _cx: &mut Context) -> Result<PollFinalize> {
+        self.finished = true;
+
+        if let Some(waker) = self.pull_waker.take() {
+            waker.wake();
+        }
+
+        Ok(PollFinalize::Finalized)
+    }
+
+    fn poll_pull(&mut self, cx: &mut Context) -> Result<InOutPollPull> {
+        if self.current_row >= self.input_num_rows {
+            if self.finished {
+                return Ok(InOutPollPull::Exhausted);
+            }
+
+            // We're done with these inputs. Come back later.
+            self.pull_waker = Some(cx.waker().clone());
+            if let Some(waker) = self.push_waker.take() {
+                waker.wake();
+            }
+
+            return Ok(InOutPollPull::Pending);
+        }
+
+        let input = self.input.as_ref().unwrap();
+        let output = match input.physical_type() {
+            PhysicalType::List => {
+                let child = match input.array_data() {
+                    ArrayData::List(list) => list.inner_array(),
+                    _other => return Err(RayexecError::new("Unexpected storage type")),
+                };
+
+                match UnaryExecutor::value_at::<PhysicalList>(input, self.current_row)? {
+                    Some(meta) => {
+                        // Row is a list, unnest.
+                        unnest(child, meta.len as usize, meta)?
+                    }
+                    None => {
+                        // Row is null, produce as single null
+                        Array::new_typed_null_array(child.datatype().clone(), 1)?
+                    }
+                }
+            }
+            PhysicalType::UntypedNull => {
+                // Just produce null array of length 1.
+                Array::new_untyped_null_array(1)
+            }
+            other => {
+                return Err(RayexecError::new(format!(
+                    "Unexpected physical type in unnest: {other:?}"
+                )))
+            }
+        };
+
+        let row_nums = vec![self.current_row; output.logical_len()];
+
+        // Next pull works on the next row.
+        self.current_row += 1;
+
+        // If these inputs are done, go ahead and let the push side know.
+        if self.current_row >= self.input_num_rows {
+            if let Some(waker) = self.push_waker.take() {
+                waker.wake()
+            }
+        }
+
+        let batch = Batch::try_new([output])?;
+
+        Ok(InOutPollPull::Batch { batch, row_nums })
+    }
+}

--- a/crates/rayexec_execution/src/optimizer/column_prune.rs
+++ b/crates/rayexec_execution/src/optimizer/column_prune.rs
@@ -6,7 +6,6 @@ use super::OptimizeRule;
 use crate::expr::column_expr::ColumnExpr;
 use crate::expr::Expression;
 use crate::logical::binder::bind_context::{BindContext, MaterializationRef};
-use crate::logical::logical_join::JoinType;
 use crate::logical::logical_project::LogicalProject;
 use crate::logical::operator::{LogicalNode, LogicalOperator, Node};
 

--- a/crates/rayexec_execution/src/optimizer/column_prune.rs
+++ b/crates/rayexec_execution/src/optimizer/column_prune.rs
@@ -6,6 +6,7 @@ use super::OptimizeRule;
 use crate::expr::column_expr::ColumnExpr;
 use crate::expr::Expression;
 use crate::logical::binder::bind_context::{BindContext, MaterializationRef};
+use crate::logical::logical_join::JoinType;
 use crate::logical::logical_project::LogicalProject;
 use crate::logical::operator::{LogicalNode, LogicalOperator, Node};
 
@@ -157,6 +158,57 @@ impl PruneState {
         bind_context: &mut BindContext,
         plan: &mut LogicalOperator,
     ) -> Result<()> {
+        // TODO: Implement this. It'd let us remove lateral joins from the plan in cases
+        // where only the output of the right side is projected out.
+        //
+        // E.g. `SELECT u.* FROM my_table t, unnest(t.a) u` would let us remove
+        // the left side as it would only be feeding into the `unnest`.
+        //
+        // // Check if this is a magic join first, as we might be able to remove it
+        // // entirely.
+        // //
+        // // We can remove the join if:
+        // //
+        // // - We're not referencing anything from the left side in any of the
+        // //   parent nodes.
+        // // - Join type is INNER
+        // if let LogicalOperator::MagicJoin(join) = plan {
+        //     if join.node.join_type == JoinType::Inner && !self.implicit_reference {
+        //         match join.get_nth_child(0)? {
+        //             LogicalOperator::MaterializationScan(scan) => {
+        //                 let mat_plan = bind_context.get_materialization_mut(scan.node.mat)?;
+
+        //                 let plan_references_left = self
+        //                     .current_references
+        //                     .iter()
+        //                     .any(|col_expr| mat_plan.table_refs.contains(&col_expr.table_scope));
+
+        //                 if !plan_references_left {
+        //                     // We can remove the left! Update the plan the
+        //                     // just be the right child and continue pruning.
+        //                     let [_left, right] = join.take_two_children_exact()?;
+        //                     *plan = right;
+
+        //                     // Decrement scan count. We should be able to
+        //                     // remove it entirely if count == 1.
+        //                     mat_plan.scan_count -= 1;
+
+        //                     // And now just walk the updated plan.
+        //                     self.walk_plan(bind_context, plan)?;
+        //                     self.apply_updated_expressions(plan)?;
+
+        //                     return Ok(());
+        //                 }
+        //             }
+        //             other => {
+        //                 return Err(RayexecError::new(format!(
+        //                     "unexpected left child for magic join: {other:?}"
+        //                 )))
+        //             }
+        //         }
+        //     }
+        // }
+
         // Extract columns reference in this plan.
         //
         // Note that this may result in references tracked that we don't care
@@ -180,6 +232,8 @@ impl PruneState {
             LogicalOperator::MagicJoin(join) => {
                 // Left child is materialization, right child is normal plan
                 // with some number of magic scans.
+                //
+                // Push down on both sides:
                 //
                 // 1. Extract all column references to the materialized plan on
                 //    the right. This should get us the complete set of column

--- a/slt/standard/functions/scalars/list_comparisons.slt
+++ b/slt/standard/functions/scalars/list_comparisons.slt
@@ -1,0 +1,89 @@
+# Comparisons between lists
+
+query T
+SELECT [] = [];
+----
+true
+
+query T
+SELECT [] <= [];
+----
+true
+
+query T
+SELECT [] < [];
+----
+false
+
+# TODO: Cast
+# query T
+# SELECT [] < [3];
+# ----
+# true
+
+query T
+SELECT [3] = [3];
+----
+true
+
+query T
+SELECT [3] != [3];
+----
+false
+
+query T
+SELECT [NULL] = [NULL];
+----
+true
+
+# TODO: Cast
+# query T
+# SELECT [NULL] = [4];
+# ----
+# true
+
+query T
+SELECT [3, 4] = [4];
+----
+false
+
+query T
+SELECT [3, 4] > [4];
+----
+false
+
+query T
+SELECT [3] < [3, 4];
+----
+true
+
+query T
+SELECT [3, 4, 5] < [3, 4];
+----
+false
+
+query T
+SELECT [5] < [3, 4];
+----
+false
+
+query T
+SELECT [3, 4] < [4];
+----
+true
+
+query T
+SELECT [NULL, 4] = [4];
+----
+false
+
+query T
+SELECT [NULL, 4] > [4];
+----
+true
+
+query T
+SELECT [NULL, 4] = [NULL, 4];
+----
+true
+

--- a/slt/standard/functions/table/unnest_list.slt
+++ b/slt/standard/functions/table/unnest_list.slt
@@ -28,6 +28,11 @@ SELECT * FROM unnest([]);
 
 # Lateral
 
-query ?I
-SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) ORDER BY 2;
+query ?
+SELECT u.* FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) u ORDER BY 1;
 ----
+
+# query ?I
+# SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) ORDER BY 2;
+# ----
+

--- a/slt/standard/functions/table/unnest_list.slt
+++ b/slt/standard/functions/table/unnest_list.slt
@@ -28,9 +28,9 @@ SELECT * FROM unnest([]);
 
 # Lateral
 
-query ?
-SELECT u.* FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) u ORDER BY 1;
-----
+# query ?
+# SELECT u.* FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) u ORDER BY 1;
+# ----
 
 # query ?I
 # SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) ORDER BY 2;

--- a/slt/standard/functions/table/unnest_list.slt
+++ b/slt/standard/functions/table/unnest_list.slt
@@ -1,5 +1,33 @@
 # UNNEST as a table function operating on lists.
 
+query TT
+DESCRIBE SELECT * FROM unnest([3,4,5]) ORDER BY 1;
+----
+unnest  Int32
+
 query I
-SELECT * FROM unnest([3,4,5]);
+SELECT * FROM unnest([3,4,5]) ORDER BY 1;
+----
+3
+4
+5
+
+query TT
+DESCRIBE SELECT * FROM unnest(NULL);
+----
+unnest  Null
+
+query ?
+SELECT * FROM unnest(NULL);
+----
+NULL
+
+query ?
+SELECT * FROM unnest([]);
+----
+
+# Lateral
+
+query ?I
+SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) ORDER BY 2;
 ----

--- a/slt/standard/functions/table/unnest_list.slt
+++ b/slt/standard/functions/table/unnest_list.slt
@@ -1,5 +1,5 @@
 # UNNEST as a table function operating on lists.
 
-# query I
-# SELECT * FROM unnest([3,4,5]);
-# ----
+query I
+SELECT * FROM unnest([3,4,5]);
+----

--- a/slt/standard/functions/table/unnest_list.slt
+++ b/slt/standard/functions/table/unnest_list.slt
@@ -28,11 +28,23 @@ SELECT * FROM unnest([]);
 
 # Lateral
 
-# query ?
-# SELECT u.* FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) u ORDER BY 1;
-# ----
+query ?
+SELECT u.* FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) u ORDER BY 1;
+----
+1
+2
+3
+8
+9
 
-# query ?I
-# SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a) ORDER BY 2;
-# ----
+# TODO: Allow order by list (need to implement interleave on lists)
+query ?I rowsort
+SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a);
+----
+[1, 2, 3]   1
+[1, 2, 3]   2
+[1, 2, 3]   3
+[8, 9]      8
+[8, 9]      9
+
 


### PR DESCRIPTION
```
GlareDB Shell
Preview (0.0.91) - There will be bugs!

>> SELECT * FROM (VALUES ([1,2,3]), ([8,9])) v(a), unnest(v.a);
┌─────────────┬────────┐
│ a           │ unnest │
│ List[Int32] │ Int32  │
├─────────────┼────────┤
│ [1, 2, 3]   │      1 │
│ [1, 2, 3]   │      2 │
│ [1, 2, 3]   │      3 │
│ [8, 9]      │      8 │
│ [8, 9]      │      9 │
└─────────────┴────────┘
```