### PR TITLE
feat: More info in `list_functions` output

### DIFF
--- a/crates/rayexec_bullet/src/datatype.rs
+++ b/crates/rayexec_bullet/src/datatype.rs
@@ -50,6 +50,39 @@ pub enum DataTypeId {
     List,
 }
 
+impl DataTypeId {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Any => "Any",
+            Self::Null => "Null",
+            Self::Boolean => "Boolean",
+            Self::Int8 => "Int8",
+            Self::Int16 => "Int16",
+            Self::Int32 => "Int32",
+            Self::Int64 => "Int64",
+            Self::Int128 => "Int128",
+            Self::UInt8 => "UInt8",
+            Self::UInt16 => "UInt16",
+            Self::UInt32 => "UInt32",
+            Self::UInt64 => "UInt64",
+            Self::UInt128 => "UInt128",
+            Self::Float16 => "Float16",
+            Self::Float32 => "Float32",
+            Self::Float64 => "Float64",
+            Self::Decimal64 => "Decimal64",
+            Self::Decimal128 => "Decimal128",
+            Self::Timestamp => "Timestamp",
+            Self::Date32 => "Date32",
+            Self::Date64 => "Date64",
+            Self::Interval => "Interval",
+            Self::Utf8 => "Utf8",
+            Self::Binary => "Binary",
+            Self::Struct => "Struct",
+            Self::List => "List",
+        }
+    }
+}
+
 impl ProtoConv for DataTypeId {
     type ProtoType = rayexec_proto::generated::schema::DataTypeId;
 
@@ -119,34 +152,7 @@ impl ProtoConv for DataTypeId {
 
 impl fmt::Display for DataTypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Any => write!(f, "Any"),
-            Self::Null => write!(f, "Null"),
-            Self::Boolean => write!(f, "Boolean"),
-            Self::Int8 => write!(f, "Int8"),
-            Self::Int16 => write!(f, "Int16"),
-            Self::Int32 => write!(f, "Int32"),
-            Self::Int64 => write!(f, "Int64"),
-            Self::Int128 => write!(f, "Int128"),
-            Self::UInt8 => write!(f, "UInt8"),
-            Self::UInt16 => write!(f, "UInt16"),
-            Self::UInt32 => write!(f, "UInt32"),
-            Self::UInt64 => write!(f, "UInt64"),
-            Self::UInt128 => write!(f, "UInt128"),
-            Self::Float16 => write!(f, "Float16"),
-            Self::Float32 => write!(f, "Float32"),
-            Self::Float64 => write!(f, "Float64"),
-            Self::Decimal64 => write!(f, "Decimal64"),
-            Self::Decimal128 => write!(f, "Decimal128"),
-            Self::Timestamp => write!(f, "Timestamp"),
-            Self::Date32 => write!(f, "Date32"),
-            Self::Date64 => write!(f, "Date64"),
-            Self::Interval => write!(f, "Interval"),
-            Self::Utf8 => write!(f, "Utf8"),
-            Self::Binary => write!(f, "Binary"),
-            Self::Struct => write!(f, "Struct"),
-            Self::List => write!(f, "List"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 


### PR DESCRIPTION
```
>> select * from list_functions() where function_name like '%trim';
┌───────────────┬───────────────┬───────────────┬───────────────┬────────────────┬──────────────────────┬─────────────┬─────────────────────────────────────────────────────────────┬──────────────────────────┬────────────────┐
│ database_name │ schema_name   │ function_name │ function_type │ argument_types │ argument_names       │ return_type │ description                                                 │ example                  │ example_output │
│ Utf8          │ Utf8          │ Utf8          │ Utf8          │ List[Utf8]     │ List[Utf8]           │ Utf8        │ Utf8                                                        │ Utf8                     │ Utf8           │
├───────────────┼───────────────┼───────────────┼───────────────┼────────────────┼──────────────────────┼─────────────┼─────────────────────────────────────────────────────────────┼──────────────────────────┼────────────────┤
│ system        │ glare_catalog │ trim          │ scalar        │ [Utf8]         │ [string]             │ Utf8        │ Trim whitespace from both sides of the string.              │ trim('  hello ')         │ hello          │
│ system        │ glare_catalog │ trim          │ scalar        │ [Utf8, Utf8]   │ [string, characters] │ Utf8        │ Trim matching characters from both sides of the string.     │ trim('->hello<', '<>-')  │ hello          │
│ system        │ glare_catalog │ rtrim         │ scalar        │ [Utf8]         │ [string]             │ Utf8        │ Trim whitespace from the right side of the string.          │ rtrim('  hello ')        │   hello        │
│ system        │ glare_catalog │ rtrim         │ scalar        │ [Utf8, Utf8]   │ [string, characters] │ Utf8        │ Trim matching characters from the right side of the string. │ rtrim('->hello<', '<>-') │ ->hello        │
│ system        │ glare_catalog │ ltrim         │ scalar        │ [Utf8]         │ [string]             │ Utf8        │ Trim whitespace from the left side of the string.           │ ltrim('  hello ')        │ hello          │
│ system        │ glare_catalog │ ltrim         │ scalar        │ [Utf8, Utf8]   │ [string, characters] │ Utf8        │ Trim matching characters from the left side of the string.  │ ltrim('->hello<', '<>-') │ hello<         │
│ system        │ glare_catalog │ btrim         │ scalar        │ [Utf8]         │ [string]             │ Utf8        │ Trim whitespace from both sides of the string.              │ trim('  hello ')         │ hello          │
│ system        │ glare_catalog │ btrim         │ scalar        │ [Utf8, Utf8]   │ [string, characters] │ Utf8        │ Trim matching characters from both sides of the string.     │ trim('->hello<', '<>-')  │ hello          │
└───────────────┴───────────────┴───────────────┴───────────────┴────────────────┴──────────────────────┴─────────────┴─────────────────────────────────────────────────────────────┴──────────────────────────┴────────────────┘
```