### PR TITLE
feat: Function dot syntax

### DIFF
--- a/crates/rayexec_execution/src/config/session.rs
+++ b/crates/rayexec_execution/src/config/session.rs
@@ -15,6 +15,7 @@ pub struct SessionConfig {
     pub partitions: u64,
     pub batch_size: u64,
     pub verify_optimized_plan: bool,
+    pub enable_function_chaining: bool,
 }
 
 impl SessionConfig {
@@ -30,6 +31,7 @@ impl SessionConfig {
             partitions: executor.default_partitions() as u64,
             batch_size: 4096,
             verify_optimized_plan: false,
+            enable_function_chaining: true,
         }
     }
 
@@ -103,6 +105,7 @@ static GET_SET_FUNCTIONS: LazyLock<HashMap<&'static str, SettingFunctions>> = La
     insert_setting::<AllowNestedLoopJoin>(&mut map);
     insert_setting::<Partitions>(&mut map);
     insert_setting::<BatchSize>(&mut map);
+    insert_setting::<EnableFunctionChaining>(&mut map);
 
     map
 });
@@ -218,6 +221,23 @@ impl SessionSetting for VerifyOptimizedPlan {
     }
 }
 
+pub struct EnableFunctionChaining;
+
+impl SessionSetting for EnableFunctionChaining {
+    const NAME: &'static str = "enable_function_chaining";
+    const DESCRIPTION: &'static str = "If function chaining syntax is enabled.";
+
+    fn set_from_scalar(scalar: ScalarValue, conf: &mut SessionConfig) -> Result<()> {
+        let val = scalar.try_as_bool()?;
+        conf.enable_function_chaining = val;
+        Ok(())
+    }
+
+    fn get_as_scalar(conf: &SessionConfig) -> OwnedScalarValue {
+        conf.enable_function_chaining.into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,6 +250,7 @@ mod tests {
             partitions: 8,
             batch_size: 4096,
             verify_optimized_plan: false,
+            enable_function_chaining: true,
         }
     }
 

--- a/crates/rayexec_execution/src/engine/session.rs
+++ b/crates/rayexec_execution/src/engine/session.rs
@@ -30,7 +30,7 @@ use crate::logical::logical_set::VariableOrAll;
 use crate::logical::operator::{LogicalOperator, Node};
 use crate::logical::planner::plan_statement::StatementPlanner;
 use crate::logical::resolver::resolve_context::ResolveContext;
-use crate::logical::resolver::{ResolveMode, ResolvedStatement, Resolver};
+use crate::logical::resolver::{ResolveConfig, ResolveMode, ResolvedStatement, Resolver};
 use crate::optimizer::Optimizer;
 use crate::runtime::time::Timer;
 use crate::runtime::{PipelineExecutor, Runtime};
@@ -243,6 +243,9 @@ where
             &tx,
             &self.context,
             self.registry.get_file_handlers(),
+            ResolveConfig {
+                enable_function_chaining: self.config.enable_function_chaining,
+            },
         )
         .resolve_statement(stmt.statement.clone())
         .await?;

--- a/crates/rayexec_execution/src/logical/binder/bind_query/bind_select_list.rs
+++ b/crates/rayexec_execution/src/logical/binder/bind_query/bind_select_list.rs
@@ -268,7 +268,7 @@ struct SelectAliasColumnBinder<'a> {
     previous_exprs: &'a [Expression],
 }
 
-impl<'a> ExpressionColumnBinder for SelectAliasColumnBinder<'a> {
+impl ExpressionColumnBinder for SelectAliasColumnBinder<'_> {
     fn bind_from_root_literal(
         &mut self,
         bind_scope: BindScopeRef,

--- a/crates/rayexec_execution/src/logical/binder/column_binder.rs
+++ b/crates/rayexec_execution/src/logical/binder/column_binder.rs
@@ -89,7 +89,11 @@ impl ExpressionColumnBinder for DefaultColumnBinder {
 }
 
 impl DefaultColumnBinder {
-    fn bind_column(
+    /// Binds a column with the given name and optional table alias.
+    ///
+    /// This will handle appending correlated columns to the bind context as
+    /// necessary.
+    pub fn bind_column(
         &self,
         bind_scope: BindScopeRef,
         bind_context: &mut BindContext,

--- a/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
+++ b/crates/rayexec_execution/src/logical/resolver/expr_resolver.rs
@@ -17,19 +17,6 @@ pub struct ExpressionResolver<'a> {
     resolver: &'a Resolver<'a>,
 }
 
-/// Change behavior with how 'reference.function()' is resolved.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FunctionResolveMode {
-    /// Assume that any references prefixing the function call are
-    /// catalog/scheme qualifications.
-    Qualified,
-    /// Assume any references prefixing the function call are a reference to a
-    /// column.
-    ///
-    /// This will then lookup the function from the builting catalogs.
-    Chained,
-}
-
 impl<'a> ExpressionResolver<'a> {
     pub fn new(resolver: &'a Resolver) -> Self {
         ExpressionResolver { resolver }
@@ -575,18 +562,72 @@ impl<'a> ExpressionResolver<'a> {
 
     async fn resolve_scalar_or_aggregate_function(
         &self,
-        func: Box<ast::Function<Raw>>,
+        mut func: Box<ast::Function<Raw>>,
         resolve_context: &mut ResolveContext,
     ) -> Result<ast::Expr<ResolvedMeta>> {
         // TODO: Search path (with system being the first to check)
-        if func.reference.0.len() != 1 {
-            return Err(RayexecError::new(
-                "Qualified function names not yet supported",
-            ));
+        let (catalog, schema, func_name) = match func.reference.0.len() {
+            0 => return Err(RayexecError::new("Missing idents for function reference")), // Shouldn't happen.
+            1 => (
+                "system".to_string(),
+                "glare_catalog".to_string(),
+                func.reference.0[0].as_normalized_string(),
+            ),
+            2 => (
+                "system".to_string(),
+                func.reference.0[0].as_normalized_string(),
+                func.reference.0[1].as_normalized_string(),
+            ),
+            3 => (
+                func.reference.0[0].as_normalized_string(),
+                func.reference.0[1].as_normalized_string(),
+                func.reference.0[2].as_normalized_string(),
+            ),
+            _ => {
+                // TODO: This could technically be from chained syntax on a
+                // fully qualified column.
+                return Err(RayexecError::new("Too many idents for function reference")
+                    .with_field("idents", func.reference.to_string()));
+            }
+        };
+
+        let context = self.resolver.context;
+
+        // See if we can resolve the catalog & schema. If we can't assume we're
+        // using chained function syntax.
+        //
+        // TODO: Make `get_database` return Option.
+        // TODO: We should be exhaustive about what's part of the qualified
+        //       function call vs what's part of the column.
+        let is_qualified = func.reference.0.len() > 1;
+        if is_qualified
+            && (!context.database_exists(&catalog)
+                || context
+                    .get_database(&catalog)?
+                    .catalog
+                    .get_schema(self.resolver.tx, &schema)?
+                    .is_none())
+        {
+            let unqualified_name = func.reference.0.pop().unwrap(); // Length checked above.
+            let unqualified_ref = ast::ObjectReference(vec![unqualified_name]);
+
+            let prefix_ref = std::mem::replace(&mut func.reference, unqualified_ref);
+
+            // Now add the prefix we took from the reference as the first
+            // argument to the function.
+            func.args.insert(
+                0,
+                ast::FunctionArg::Unnamed {
+                    arg: ast::FunctionArgExpr::Expr(ast::Expr::CompoundIdent(prefix_ref.0)),
+                },
+            );
+
+            // Now try to resolve with just the unqualified reference.
+            let resolved =
+                Box::pin(self.resolve_scalar_or_aggregate_function(func, resolve_context)).await?;
+
+            return Ok(resolved);
         }
-        let func_name = &func.reference.0[0].as_normalized_string();
-        let catalog = "system";
-        let schema = "glare_catalog";
 
         let filter = self
             .resolve_optional_expression(func.filter.map(|e| *e), resolve_context)
@@ -599,16 +640,14 @@ impl<'a> ExpressionResolver<'a> {
         };
         let args = Box::pin(self.resolve_function_args(func.args, resolve_context)).await?;
 
-        let schema_ent = self
-            .resolver
-            .context
-            .get_database(catalog)?
+        let schema_ent = context
+            .get_database(&catalog)?
             .catalog
-            .get_schema(self.resolver.tx, schema)?
+            .get_schema(self.resolver.tx, &schema)?
             .ok_or_else(|| RayexecError::new(format!("Missing schema: {schema}")))?;
 
         // Check if this is a special function.
-        if let Some(special) = SpecialBuiltinFunction::try_from_name(func_name) {
+        if let Some(special) = SpecialBuiltinFunction::try_from_name(&func_name) {
             let resolve_idx = resolve_context
                 .functions
                 .push_resolved(ResolvedFunction::Special(special), LocationRequirement::Any);
@@ -623,7 +662,7 @@ impl<'a> ExpressionResolver<'a> {
         }
 
         // Now check scalars.
-        if let Some(scalar) = schema_ent.get_scalar_function(self.resolver.tx, func_name)? {
+        if let Some(scalar) = schema_ent.get_scalar_function(self.resolver.tx, &func_name)? {
             // TODO: Allow unresolved scalars?
             // TODO: This also assumes scalars (and aggs) are the same everywhere, which
             // they probably should be for now.
@@ -641,7 +680,7 @@ impl<'a> ExpressionResolver<'a> {
         }
 
         // Now check aggregates.
-        if let Some(aggregate) = schema_ent.get_aggregate_function(self.resolver.tx, func_name)? {
+        if let Some(aggregate) = schema_ent.get_aggregate_function(self.resolver.tx, &func_name)? {
             // TODO: Allow unresolved aggregates?
             let resolve_idx = resolve_context.functions.push_resolved(
                 ResolvedFunction::Aggregate(
@@ -668,7 +707,7 @@ impl<'a> ExpressionResolver<'a> {
                 CatalogEntryType::ScalarFunction,
                 CatalogEntryType::AggregateFunction,
             ],
-            func_name,
+            &func_name,
         ))
     }
 

--- a/crates/rayexec_execution/src/logical/resolver/mod.rs
+++ b/crates/rayexec_execution/src/logical/resolver/mod.rs
@@ -112,6 +112,11 @@ impl ResolveMode {
     }
 }
 
+#[derive(Debug)]
+pub struct ResolveConfig {
+    pub enable_function_chaining: bool,
+}
+
 /// Resolves references in a raw SQL AST with entries in the catalog.
 #[derive(Debug)]
 pub struct Resolver<'a> {
@@ -119,6 +124,7 @@ pub struct Resolver<'a> {
     pub tx: &'a CatalogTx,
     pub context: &'a DatabaseContext,
     pub file_handlers: &'a FileHandlers,
+    pub config: ResolveConfig,
 }
 
 impl<'a> Resolver<'a> {
@@ -127,12 +133,14 @@ impl<'a> Resolver<'a> {
         tx: &'a CatalogTx,
         context: &'a DatabaseContext,
         file_handlers: &'a FileHandlers,
+        config: ResolveConfig,
     ) -> Self {
         Resolver {
             resolve_mode,
             tx,
             context,
             file_handlers,
+            config,
         }
     }
 

--- a/crates/rayexec_execution/src/logical/resolver/resolve_hybrid.rs
+++ b/crates/rayexec_execution/src/logical/resolver/resolve_hybrid.rs
@@ -13,7 +13,7 @@ use crate::database::{Database, DatabaseContext};
 use crate::datasource::{DataSourceRegistry, FileHandlers};
 use crate::functions::table::TableFunctionPlanner;
 use crate::logical::operator::LocationRequirement;
-use crate::logical::resolver::ResolveMode;
+use crate::logical::resolver::{ResolveConfig, ResolveMode};
 
 /// Extends a context by attaching additional databases using information
 /// provided by partially bound objects supplied by the client.
@@ -139,7 +139,15 @@ impl<'a> HybridResolver<'a> {
         // Note we're using bindmode normal here since everything we attempt to
         // bind in this resolver should succeed.
         HybridResolver {
-            resolver: Resolver::new(ResolveMode::Normal, tx, context, EMPTY_FILE_HANDLER_REF),
+            resolver: Resolver::new(
+                ResolveMode::Normal,
+                tx,
+                context,
+                EMPTY_FILE_HANDLER_REF,
+                ResolveConfig {
+                    enable_function_chaining: true, // TODO: We'll need to get this from the client.
+                },
+            ),
         }
     }
 

--- a/slt/standard/functions/chaining.slt
+++ b/slt/standard/functions/chaining.slt
@@ -10,6 +10,11 @@ INSERT INTO t VALUES
   (NULL, 'mouse'),
   (5, NULL);
 
-# query T
-# SELECT b.upper() FROM t ORDER BY 1;
-# ----
+query T
+SELECT b.upper() FROM t ORDER BY 1;
+----
+CAT
+DOG
+MOUSE
+NULL
+

--- a/slt/standard/functions/chaining.slt
+++ b/slt/standard/functions/chaining.slt
@@ -1,0 +1,15 @@
+# Function chaining.
+
+statement ok
+CREATE TEMP TABLE t (a INT, b TEXT);
+
+statement ok
+INSERT INTO t VALUES
+  (3, 'cat'),
+  (4, 'dog'),
+  (NULL, 'mouse'),
+  (5, NULL);
+
+# query T
+# SELECT b.upper() FROM t ORDER BY 1;
+# ----

--- a/slt/standard/functions/chaining.slt
+++ b/slt/standard/functions/chaining.slt
@@ -18,3 +18,72 @@ DOG
 MOUSE
 NULL
 
+query T
+SELECT t.b.upper() FROM t ORDER BY 1;
+----
+CAT
+DOG
+MOUSE
+NULL
+
+statement error Cannot resolve scalar function or aggregate function with name 'missing_function'
+SELECT t.b.missing_function() FROM t ORDER BY 1;
+
+statement error Invalid inputs to 'upper'
+SELECT t.b.upper(4) FROM t ORDER BY 1;
+
+query T
+SELECT b.repeat(a) FROM t ORDER BY 1;
+----
+catcatcat
+dogdogdogdog
+NULL
+NULL
+
+query TTT
+SELECT
+    t.b.upper() AS my_upper,
+    my_upper.repeat(t.a) AS my_repeat,
+    my_repeat.lower() AS my_lower
+  FROM t
+  ORDER BY 1;
+----
+CAT    CATCATCAT     catcatcat
+DOG    DOGDOGDOGDOG  dogdogdogdog
+MOUSE  NULL          NULL
+NULL   NULL          NULL
+
+# Should work on aggregates too.
+query I
+SELECT a.sum() FROM t;
+----
+12
+
+# TODO: Literals
+# query T
+# SELECT 'hello'.repeat(3);
+# ----
+
+query T
+SELECT 'hello' AS s, s.repeat(3);
+----
+hello  hellohellohello
+
+# Ensure we can disable the behavior.
+statement ok
+SET enable_function_chaining TO false;
+
+statement error Missing schema
+SELECT b.upper() FROM t ORDER BY 1;
+
+statement error Missing catalog
+SELECT t.b.upper() FROM t ORDER BY 1;
+
+query T
+SELECT system.glare_catalog.upper(t.b) FROM t ORDER BY 1;
+----
+CAT
+DOG
+MOUSE
+NULL
+

--- a/slt/standard/functions/qualified.slt
+++ b/slt/standard/functions/qualified.slt
@@ -1,0 +1,11 @@
+# Ensure we can call functions partially and fully qualified.
+
+query I
+SELECT glare_catalog.abs(-48);
+----
+48
+
+query I
+SELECT system.glare_catalog.abs(-48);
+----
+48

--- a/slt/standard/select/reference_alias_in_select.slt
+++ b/slt/standard/select/reference_alias_in_select.slt
@@ -32,3 +32,7 @@ SELECT a, 'select' AS a FROM (VALUES (1), (2)) v(a);
 1  select
 2  select
 
+query TT
+SELECT 'select' AS a, upper(a);
+----
+select  SELECT

--- a/slt/standard/select/reference_alias_in_select.slt
+++ b/slt/standard/select/reference_alias_in_select.slt
@@ -1,0 +1,34 @@
+# Allow referencing previously defined aliases in later select items.
+
+query II
+SELECT 1 AS a, a + 2;
+----
+1  3
+
+statement error 'a' can only be referenced after it's been defined in the SELECT list
+SELECT a + 2, 1 AS a;
+
+# TODO: Unsure if this is even wanted.
+# query II
+# SELECT 3 AS a, (SELECT a + 5);
+# ----
+
+query III
+SELECT 1 AS a, 2 AS a, a + 3;
+----
+1  2  5
+
+# Prefer unaliased columns.
+query TI rowsort
+SELECT 'select' AS a, a FROM (VALUES (1), (2)) v(a);
+----
+select  1
+select  2
+
+# Prefer unaliased columns.
+query TI rowsort
+SELECT a, 'select' AS a FROM (VALUES (1), (2)) v(a);
+----
+1  select
+2  select
+


### PR DESCRIPTION
```
>> CREATE TEMP TABLE t (a INT, b TEXT);
┌─────────────────────┐
│ Query success       │
│ No columns returned │
└─────────────────────┘

>> INSERT INTO t VALUES (3, 'cat'), (4, 'dog'), (NULL, 'mouse'), (5, NULL);
┌───────────────┐
│ rows_inserted │
│ UInt64        │
├───────────────┤
│             4 │
└───────────────┘

>> SELECT b.upper() FROM t;
┌───────┐
│ upper │
│ Utf8  │
├───────┤
│ CAT   │
│ NULL  │
│ MOUSE │
│ DOG   │
└───────┘

>> SELECT t.b.upper() AS my_upper, my_upper.repeat(t.a) AS my_repeat, my_repeat.lower() AS my_lower FROM t;
┌──────────┬───────────┬──────────┐
│ my_upper │ my_repeat │ my_lower │
│ Utf8     │ Utf8      │ Utf8     │
├──────────┼───────────┼──────────┤
│ MOUSE    │ NULL      │ NULL     │
│ NULL     │ NULL      │ NULL     │
│ CAT      │ CATCATCAT │ catcatc… │
│ DOG      │ DOGDOGDO… │ dogdogd… │
└──────────┴───────────┴──────────┘
```

Actual chaining later.