### PR TITLE
feat: Extension example (spark functions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ext_spark"
+version = "0.0.98"
+dependencies = [
+ "glaredb_error",
+ "glaredb_execution",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1008,7 @@ version = "0.0.98"
 dependencies = [
  "clap",
  "crossterm",
+ "ext_spark",
  "futures",
  "glaredb_error",
  "glaredb_execution",
@@ -1125,6 +1134,7 @@ dependencies = [
  "ext_csv",
  "ext_delta",
  "ext_iceberg",
+ "ext_spark",
  "futures",
  "getrandom 0.2.14",
  "glaredb_error",

--- a/crates/ext_spark/Cargo.toml
+++ b/crates/ext_spark/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ext_spark"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+glaredb_execution = { path = '../glaredb_execution' }
+glaredb_error = { path = '../glaredb_error' }
+

--- a/crates/ext_spark/src/functions/csc.rs
+++ b/crates/ext_spark/src/functions/csc.rs
@@ -1,0 +1,52 @@
+use glaredb_error::Result;
+use glaredb_execution::arrays::array::Array;
+use glaredb_execution::arrays::array::physical_type::PhysicalF64;
+use glaredb_execution::arrays::batch::Batch;
+use glaredb_execution::arrays::datatype::{DataType, DataTypeId};
+use glaredb_execution::arrays::executor::OutBuffer;
+use glaredb_execution::arrays::executor::scalar::UnaryExecutor;
+use glaredb_execution::expr::Expression;
+use glaredb_execution::functions::Signature;
+use glaredb_execution::functions::bind_state::BindState;
+use glaredb_execution::functions::documentation::{Category, Documentation};
+use glaredb_execution::functions::function_set::ScalarFunctionSet;
+use glaredb_execution::functions::scalar::{RawScalarFunction, ScalarFunction};
+
+pub const FUNCTION_SET_CSC: ScalarFunctionSet = ScalarFunctionSet {
+    name: "csc",
+    aliases: &[],
+    doc: Some(&Documentation {
+        category: Category::Numeric,
+        description: "Computes the cosecant of the input",
+        arguments: &["value"],
+        example: None,
+    }),
+    functions: &[RawScalarFunction::new(
+        &Signature::new(&[DataTypeId::Float64], DataTypeId::Float64),
+        &Csc,
+    )],
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Csc;
+
+impl ScalarFunction for Csc {
+    type State = ();
+
+    fn bind(&self, inputs: Vec<Expression>) -> Result<BindState<Self::State>> {
+        Ok(BindState {
+            state: (),
+            return_type: DataType::Float64,
+            inputs,
+        })
+    }
+
+    fn execute(_: &Self::State, input: &Batch, output: &mut Array) -> Result<()> {
+        UnaryExecutor::execute::<PhysicalF64, PhysicalF64, _>(
+            &input.arrays()[0],
+            input.selection(),
+            OutBuffer::from_array(output)?,
+            |v, buf| buf.put(&(1.0 / v.sin())),
+        )
+    }
+}

--- a/crates/ext_spark/src/functions/expm1.rs
+++ b/crates/ext_spark/src/functions/expm1.rs
@@ -1,0 +1,52 @@
+use glaredb_error::Result;
+use glaredb_execution::arrays::array::Array;
+use glaredb_execution::arrays::array::physical_type::PhysicalF64;
+use glaredb_execution::arrays::batch::Batch;
+use glaredb_execution::arrays::datatype::{DataType, DataTypeId};
+use glaredb_execution::arrays::executor::OutBuffer;
+use glaredb_execution::arrays::executor::scalar::UnaryExecutor;
+use glaredb_execution::expr::Expression;
+use glaredb_execution::functions::Signature;
+use glaredb_execution::functions::bind_state::BindState;
+use glaredb_execution::functions::documentation::{Category, Documentation};
+use glaredb_execution::functions::function_set::ScalarFunctionSet;
+use glaredb_execution::functions::scalar::{RawScalarFunction, ScalarFunction};
+
+pub const FUNCTION_SET_EXPM1: ScalarFunctionSet = ScalarFunctionSet {
+    name: "expm1",
+    aliases: &[],
+    doc: Some(&Documentation {
+        category: Category::Numeric,
+        description: "Computes the exponential of the given value minus one",
+        arguments: &["value"],
+        example: None,
+    }),
+    functions: &[RawScalarFunction::new(
+        &Signature::new(&[DataTypeId::Float64], DataTypeId::Float64),
+        &Expm1,
+    )],
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Expm1;
+
+impl ScalarFunction for Expm1 {
+    type State = ();
+
+    fn bind(&self, inputs: Vec<Expression>) -> Result<BindState<Self::State>> {
+        Ok(BindState {
+            state: (),
+            return_type: DataType::Float64,
+            inputs,
+        })
+    }
+
+    fn execute(_: &Self::State, input: &Batch, output: &mut Array) -> Result<()> {
+        UnaryExecutor::execute::<PhysicalF64, PhysicalF64, _>(
+            &input.arrays()[0],
+            input.selection(),
+            OutBuffer::from_array(output)?,
+            |v, buf| buf.put(&(v.exp_m1())),
+        )
+    }
+}

--- a/crates/ext_spark/src/functions/mod.rs
+++ b/crates/ext_spark/src/functions/mod.rs
@@ -1,0 +1,5 @@
+mod csc;
+pub use csc::*;
+
+mod expm1;
+pub use expm1::*;

--- a/crates/ext_spark/src/lib.rs
+++ b/crates/ext_spark/src/lib.rs
@@ -1,0 +1,17 @@
+//! Simple example extension adding in some spark functions.
+pub mod functions;
+
+use functions::{FUNCTION_SET_CSC, FUNCTION_SET_EXPM1};
+use glaredb_execution::extension::Extension;
+use glaredb_execution::functions::function_set::ScalarFunctionSet;
+
+pub struct SparkExtension;
+
+impl Extension for SparkExtension {
+    const NAME: &str = "spark";
+    const FUNCTION_NAMESPACE: Option<&str> = Some("spark");
+
+    fn scalar_functions(&self) -> &[ScalarFunctionSet] {
+        &[FUNCTION_SET_CSC, FUNCTION_SET_EXPM1]
+    }
+}

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -10,6 +10,9 @@ logutil = { path = '../logutil' }
 glaredb_error = { path = '../glaredb_error' }
 glaredb_execution = { path = '../glaredb_execution' }
 glaredb_rt_native = { path = '../glaredb_rt_native' }
+
+ext_spark = { path = '../ext_spark' }
+
 tracing = { workspace = true }
 tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json", "env-filter"] }
 futures = { workspace = true }

--- a/crates/glaredb/src/main.rs
+++ b/crates/glaredb/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use crossterm::event::{self, Event, KeyModifiers};
+use ext_spark::SparkExtension;
 use glaredb_error::Result;
 use glaredb_execution::arrays::format::pretty::table::PrettyTable;
 use glaredb_execution::engine::single_user::SingleUserEngine;
@@ -105,6 +106,7 @@ async fn inner(
     runtime: impl Runtime,
 ) -> Result<()> {
     let engine = SingleUserEngine::try_new(executor, runtime)?;
+    engine.register_extension(SparkExtension)?;
 
     let (cols, _rows) = crossterm::terminal::size()?;
     let mut stdout = BufWriter::new(std::io::stdout());

--- a/crates/glaredb_execution/src/engine/single_user.rs
+++ b/crates/glaredb_execution/src/engine/single_user.rs
@@ -9,6 +9,7 @@ use glaredb_parser::statement::RawStatement;
 use super::Engine;
 use super::query_result::QueryResult;
 use super::session::Session;
+use crate::extension::Extension;
 use crate::runtime::{PipelineExecutor, Runtime};
 
 /// A wrapper around a session and an engine for when running the database in a
@@ -41,6 +42,13 @@ where
 
     pub fn session(&self) -> &SingleUserSession<P, R> {
         &self.session
+    }
+
+    pub fn register_extension<E>(&self, ext: E) -> Result<()>
+    where
+        E: Extension,
+    {
+        self.engine.register_extension(ext)
     }
 }
 

--- a/crates/glaredb_execution/src/extension/mod.rs
+++ b/crates/glaredb_execution/src/extension/mod.rs
@@ -5,7 +5,16 @@ use file_reference_handler::FileReferenceHandler;
 use crate::functions::function_set::{AggregateFunctionSet, ScalarFunctionSet, TableFunctionSet};
 
 pub trait Extension {
+    /// The name of the extension.
     const NAME: &str;
+
+    /// An optional namespace for functions in this extension.
+    ///
+    /// This will create a schema in the system catalog with this name. It must
+    /// be unique.
+    ///
+    /// If None, functions will be placed in the default schema.
+    const FUNCTION_NAMESPACE: Option<&str>;
 
     fn scalar_functions(&self) -> &[ScalarFunctionSet] {
         &[]

--- a/crates/glaredb_execution/src/shell/shell.rs
+++ b/crates/glaredb_execution/src/shell/shell.rs
@@ -5,7 +5,7 @@ use tracing::trace;
 
 use super::lineedit::{KeyEvent, LineEditor, Signal, TermSize};
 use super::raw::RawTerminalWriter;
-use super::vt100::{MODES_OFF, MODE_BOLD};
+use super::vt100::{MODE_BOLD, MODES_OFF};
 use crate::arrays::format::pretty::table::PrettyTable;
 use crate::engine::single_user::SingleUserEngine;
 use crate::runtime::{PipelineExecutor, Runtime};

--- a/crates/glaredb_wasm/Cargo.toml
+++ b/crates/glaredb_wasm/Cargo.toml
@@ -17,9 +17,12 @@ web-sys = { version = "0.3.69", features = [
 
 glaredb_execution = { path = '../glaredb_execution' }
 glaredb_error = { path = '../glaredb_error' }
+
 ext_csv = { path = '../ext_csv' }
 ext_delta = { path = '../ext_delta' }
 ext_iceberg = { path = '../ext_iceberg' }
+ext_spark = { path = '../ext_spark' }
+
 rayexec_io = { path = '../rayexec_io' }
 futures = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/glaredb_wasm/src/session.rs
+++ b/crates/glaredb_wasm/src/session.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use ext_spark::SparkExtension;
 use glaredb_error::DbError;
 use glaredb_execution::arrays::batch::Batch;
 use glaredb_execution::arrays::field::ColumnSchema;
@@ -24,6 +25,7 @@ impl WasmSession {
     pub fn try_new() -> Result<WasmSession> {
         let runtime = WasmRuntime::try_new()?;
         let engine = SingleUserEngine::try_new(WasmExecutor, runtime.clone())?;
+        engine.register_extension(SparkExtension)?;
 
         Ok(WasmSession { runtime, engine })
     }
@@ -77,4 +79,21 @@ impl WasmQueryResults {}
 pub struct WasmQueryResult {
     pub(crate) schema: ColumnSchema,
     pub(crate) batches: Vec<Batch>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_session() {
+        // Ensure we can create a session.
+        //
+        // The reason for this test case is to ensure we can create the system
+        // catalog and registery any extensions without erroring.
+        //
+        // It does not test that we can actually run anything (since running
+        // would attempt to create promises).
+        let _ = WasmSession::try_new().unwrap();
+    }
 }

--- a/crates/glaredb_wasm/src/shell.rs
+++ b/crates/glaredb_wasm/src/shell.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::io;
 use std::rc::Rc;
 
-use glaredb_execution::engine::single_user::SingleUserEngine;
 use glaredb_execution::shell::lineedit::{KeyEvent, TermSize};
 use glaredb_execution::shell::shell::{RawModeGuard, RawModeTerm, Shell, ShellSignal};
 use js_sys::Function;
@@ -13,6 +12,7 @@ use web_sys::KeyboardEvent;
 
 use crate::errors::Result;
 use crate::runtime::{WasmExecutor, WasmRuntime};
+use crate::session::WasmSession;
 
 #[wasm_bindgen]
 extern "C" {
@@ -137,13 +137,12 @@ impl RawModeTerm for NopRawMode {
 impl WasmShell {
     /// Create a new shell that writes its output to the provided terminal.
     pub fn try_new(terminal: Terminal) -> Result<WasmShell> {
-        let runtime = WasmRuntime::try_new()?;
-        let engine = SingleUserEngine::try_new(WasmExecutor, runtime)?;
+        let session = WasmSession::try_new()?;
 
         let terminal = TerminalBuffer::new(terminal);
         let mut shell = Shell::new(terminal, NopRawMode);
 
-        shell.attach(engine, "GlareDB WASM Shell")?;
+        shell.attach(session.engine, "GlareDB WASM Shell")?;
 
         let edit_guard = shell.edit_start()?;
 


### PR DESCRIPTION
```
GlareDB Shell
Preview (0.0.98)
glaredb> select spark.expm1(a) from generate_series(0, 5) g(a);
┌────────────────────┐
│ expm1              │
│ Float64            │
├────────────────────┤
│                  0 │
│ 1.7182818284590453 │
│   6.38905609893065 │
│ 19.085536923187668 │
│ 53.598150033144236 │
│  147.4131591025766 │
└────────────────────┘
glaredb> select spark.csc(a) from generate_series(0, 5) g(a);
┌─────────────────────┐
│ csc                 │
│ Float64             │
├─────────────────────┤
│                 inf │
│  1.1883951057781212 │
│  1.0997501702946164 │
│   7.086167395737187 │
│ -1.3213487088109022 │
│ -1.0428352127714058 │
└─────────────────────┘
```

```
glaredb> select * from list_functions() where schema_name = 'spark';
┌───────────────┬─────────────┬───────────────┬───┬─────────┬────────────────┐
│ database_name │ schema_name │ function_name │ … │ example │ example_output │
│ Utf8          │ Utf8        │ Utf8          │   │ Utf8    │ Utf8           │
├───────────────┼─────────────┼───────────────┼───┼─────────┼────────────────┤
│ system        │ spark       │ csc           │ … │ NULL    │ NULL           │
│ system        │ spark       │ expm1         │ … │ NULL    │ NULL           │
└───────────────┴─────────────┴───────────────┴───┴─────────┴────────────────┘
```