### PR TITLE
chore: Trim trailing newline in explain strings

### DIFF
--- a/crates/glaredb_execution/src/explain/formatter.rs
+++ b/crates/glaredb_execution/src/explain/formatter.rs
@@ -60,6 +60,11 @@ impl ExplainFormatter {
                 let mut buf = String::new();
                 fmt(node, 0, &mut buf)?;
 
+                // Remove trailing newline.
+                if buf.ends_with('\n') {
+                    buf.pop();
+                }
+
                 Ok(buf)
             }
             ExplainFormat::Json => {


### PR DESCRIPTION
```
glaredb> EXPLAIN SELECT 5 = ANY(SELECT * FROM ints);
┌───────────┬──────────────────────────────────────────────────────────────────────────────────────────────┐
│ plan_type │ plan                                                                                         │
│ Utf8      │ Utf8                                                                                         │
├───────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ unoptimi… │ Project                                                                                    + │
│           │   ├ location: Any                                                                          + │
│           │   └ projections: [__generated_visited_bool]                                                + │
│           │   ComparisonJoin                                                                           + │
│           │     ├ conditions: [CAST(5 TO Int32) = i]                                                   + │
│           │     ├ join_type: LEFT MARK (ref = #10)                                                     + │
│           │     └ location: Any                                                                        + │
│           │     Empty                                                                                  + │
│           │       └ location: Any                                                                      + │
│           │     Project                                                                                + │
│           │       ├ location: Any                                                                      + │
│           │       └ projections: [i]                                                                   + │
│           │       Scan                                                                                 + │
│           │         ├ column_names: [i]                                                                + │
│           │         ├ column_types: [Int32]                                                            + │
│           │         ├ location: ClientLocal                                                            + │
│           │         └ table: temp.temp.ints                                                              │
│ optimized │ Project                                                                                    + │
│           │   ├ location: Any                                                                          + │
│           │   └ projections: [__generated_visited_bool]                                                + │
│           │   ComparisonJoin                                                                           + │
│           │     ├ conditions: [5 = i]                                                                  + │
│           │     ├ join_type: LEFT MARK (ref = #10)                                                     + │
│           │     └ location: Any                                                                        + │
│           │     Empty                                                                                  + │
│           │       └ location: Any                                                                      + │
│           │     Scan                                                                                   + │
│           │       ├ column_names: [i]                                                                  + │
│           │       ├ column_types: [Int32]                                                              + │
│           │       ├ location: ClientLocal                                                              + │
│           │       └ table: temp.temp.ints                                                                │
│ physical  │ Project                                                                                    + │
│           │   └ projections: [@0]                                                                      + │
│           │   NestedLoopJoin                                                                           + │
│           │     Empty                                                                                  + │
│           │     Scan                                                                                   + │
│           │       └ source: memory_scan                                                                  │
└───────────┴──────────────────────────────────────────────────────────────────────────────────────────────┘
```