### PR TITLE
feat: Add `category` column for `list_functions`

### DIFF
--- a/crates/glaredb_core/src/arrays/row/row_layout.rs
+++ b/crates/glaredb_core/src/arrays/row/row_layout.rs
@@ -258,7 +258,8 @@ pub(crate) const fn row_width_for_physical_type(phys_type: PhysicalType) -> usiz
         PhysicalType::Interval => std::mem::size_of::<Interval>(),
         PhysicalType::Binary => std::mem::size_of::<StringPtr>(),
         PhysicalType::Utf8 => std::mem::size_of::<StringPtr>(),
-        _ => unimplemented!(),
+        PhysicalType::List => 0,   // TODO: Probably metadata
+        PhysicalType::Struct => 0, // TODO: Probaby metadata
     }
 }
 

--- a/crates/glaredb_core/src/functions/documentation.rs
+++ b/crates/glaredb_core/src/functions/documentation.rs
@@ -15,6 +15,25 @@ pub enum Category {
     System,
 }
 
+impl Category {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::General => "general",
+            Self::Aggregate => "aggregate",
+            Self::Numeric => "numeric",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::Interval => "interval",
+            Self::List => "list",
+            Self::String => "string",
+            Self::Regexp => "regexp",
+            Self::Binary => "binary",
+            Self::Table => "table",
+            Self::System => "system",
+        }
+    }
+}
+
 /// Documentation for a single function variant.
 // TODO: Allow multiple arguments+example pairs for different arity functions.
 //

--- a/crates/glaredb_core/src/functions/table/builtin/list_entries.rs
+++ b/crates/glaredb_core/src/functions/table/builtin/list_entries.rs
@@ -442,6 +442,7 @@ impl TableScanFunction for ListFunctions {
                 Field::new("schema_name", DataType::Utf8, false),
                 Field::new("function_name", DataType::Utf8, false),
                 Field::new("function_type", DataType::Utf8, false),
+                Field::new("category", DataType::Utf8, false),
                 Field::new(
                     "arguments",
                     DataType::List(ListTypeMeta::new(DataType::Utf8)),
@@ -569,6 +570,18 @@ impl TableScanFunction for ListFunctions {
                     Ok(())
                 }
                 4 => {
+                    // Category
+                    let (data, validity) = output.data_and_validity_mut();
+                    let mut categories = PhysicalUtf8::get_addressable_mut(data)?;
+                    for idx in 0..count {
+                        match state.entries[idx + state.offset].doc.as_ref() {
+                            Some(doc) => categories.put(idx, doc.category.as_str()),
+                            None => validity.set_invalid(idx),
+                        }
+                    }
+                    Ok(())
+                }
+                5 => {
                     // Arguments
                     for idx in 0..count {
                         let ent = &state.entries[idx + state.offset];
@@ -595,7 +608,7 @@ impl TableScanFunction for ListFunctions {
 
                     Ok(())
                 }
-                5 => {
+                6 => {
                     // Argument types
                     for idx in 0..count {
                         let mut types = Vec::new(); // TODO: No need to allocate every time.
@@ -614,7 +627,7 @@ impl TableScanFunction for ListFunctions {
 
                     Ok(())
                 }
-                6 => {
+                7 => {
                     // Return type
                     let mut ret_types = PhysicalUtf8::get_addressable_mut(&mut output.data)?;
                     let mut s_buf = String::new();
@@ -629,7 +642,7 @@ impl TableScanFunction for ListFunctions {
                     }
                     Ok(())
                 }
-                7 => {
+                8 => {
                     // Description
                     let (data, validity) = output.data_and_validity_mut();
                     let mut descriptions = PhysicalUtf8::get_addressable_mut(data)?;
@@ -641,7 +654,7 @@ impl TableScanFunction for ListFunctions {
                     }
                     Ok(())
                 }
-                8 => {
+                9 => {
                     // Example
                     let (data, validity) = output.data_and_validity_mut();
                     let mut examples = PhysicalUtf8::get_addressable_mut(data)?;
@@ -656,7 +669,7 @@ impl TableScanFunction for ListFunctions {
                     }
                     Ok(())
                 }
-                9 => {
+                10 => {
                     // Example output
                     let (data, validity) = output.data_and_validity_mut();
                     let mut example_outputs = PhysicalUtf8::get_addressable_mut(data)?;


### PR DESCRIPTION
```
glaredb> select distinct function_name, category from list_functions();
┌───────────────┬──────────┐
│ function_name │ category │
│ Utf8          │ Utf8     │
├───────────────┼──────────┤
│ csc           │ numeric  │
│ expm1         │ numeric  │
│ supplier      │ table    │
│ orders        │ table    │
│ lineitem      │ table    │
│ nation        │ table    │
│ nation        │ NULL     │
│ region        │ table    │
│ region        │ NULL     │
│ part          │ table    │
│ customer      │ table    │
│ partsupp      │ table    │
│ -             │ NULL     │
│ /             │ NULL     │
│ <             │ general  │
│ <=            │ general  │
│ >             │ general  │
│ >=            │ general  │
│ asin          │ numeric  │
│ tan           │ numeric  │
│ radians       │ numeric  │
│ isfinite      │ numeric  │
│ rtrim         │ NULL     │
│ rtrim         │ string   │
│ reverse       │ string   │
│ …             │ …        │
│ like          │ string   │
│ epoch_s       │ date     │
│ array_distan… │ list     │
│ min           │ aggrega… │
│ max           │ aggrega… │
│ var_pop       │ aggrega… │
│ every         │ aggrega… │
│ bit_and       │ aggrega… │
│ unnest        │ list     │
│ list_functio… │ system   │
│ optimizer_pr… │ system   │
│ optimizer_pr… │ NULL     │
│ execution_pr… │ system   │
│ execution_pr… │ NULL     │
│ query_info    │ system   │
│ query_info    │ NULL     │
│ generate_ser… │ table    │
│ generate_ser… │ NULL     │
│ list_databas… │ system   │
│ list_schemas  │ system   │
│ list_tables   │ system   │
│ list_views    │ system   │
│ planning_pro… │ system   │
│ planning_pro… │ NULL     │
│ memory_scan   │ table    │
├───────────────┴──────────┤
│ 156 rows, 50 shown       │
└──────────────────────────┘
```