### PR TITLE
chore: Use IS NOT DISTINCT FROM to assert array equality in tests

### DIFF
--- a/crates/glaredb_core/src/testutil/mod.rs
+++ b/crates/glaredb_core/src/testutil/mod.rs
@@ -9,6 +9,7 @@
 //! attempts to group these in some manner while also keeping the file structure
 //! flat. This should help with discoverability and reduce duplicated helpers.
 
+#![cfg(debug_assertions)]
 #![allow(unused)]
 
 /// Array helpers.


### PR DESCRIPTION
Example

```
thread 'testutil::array_assert::tests::assert_i32_arrays_eq_simple' panicked at crates/glaredb_core/src/testutil/array_assert.rs:155:9:
Arrays not equal! Difference found at row index 2
┌────────┬────────┐
│ array0 │ array1 │
│ Int32  │ Int32  │
├────────┼────────┤
│      4 │      4 │
│      5 │      5 │
│      6 │      7 │
└────────┴────────┘
```