### PR TITLE
feat: Better error for incorrect args to function

### DIFF
--- a/crates/glaredb_core/src/expr/mod.rs
+++ b/crates/glaredb_core/src/expr/mod.rs
@@ -59,7 +59,6 @@ use crate::functions::table::{
     TableFunctionType,
 };
 use crate::logical::binder::table_list::TableRef;
-use crate::util::fmt::displayable::IntoDisplayableSlice;
 
 /// A logical expression.
 ///
@@ -820,12 +819,8 @@ where
             let mut candidates = function.candidates(&datatypes);
 
             if candidates.is_empty() {
-                // TODO: Better error.
-                return Err(DbError::new(format!(
-                    "Invalid inputs to '{}': {}",
-                    function.name,
-                    datatypes.display_with_brackets(),
-                )));
+                let no_matches = function.no_function_matches(&datatypes);
+                return Err(DbError::new(no_matches.to_string()));
             }
 
             // TODO: Maybe more sophisticated candidate selection.

--- a/slt/standard/functions/aggregate/string_agg.slt
+++ b/slt/standard/functions/aggregate/string_agg.slt
@@ -13,7 +13,7 @@ SELECT string_agg(NULL, ',');
 ----
 NULL
 
-statement error Invalid inputs
+statement error No function matches 'string_agg\(Utf8\)'. You may need to add explicit type casts.
 SELECT string_agg('hello');
 
 query T

--- a/slt/standard/functions/chaining.slt
+++ b/slt/standard/functions/chaining.slt
@@ -32,7 +32,7 @@ NULL
 statement error Cannot resolve scalar function or aggregate function with name 'missing_function'
 SELECT t.b.missing_function() FROM t ORDER BY 1;
 
-statement error Invalid inputs to 'upper'
+statement error No function matches 'upper\(Utf8, Int32\)'. You may need to add explicit type casts.
 SELECT t.b.upper(4) FROM t ORDER BY 1;
 
 query T

--- a/slt/standard/functions/scalars/boolean.slt
+++ b/slt/standard/functions/scalars/boolean.slt
@@ -53,7 +53,7 @@ select and(true, true, false);
 ----
 false
 
-statement error  Invalid inputs to 'and'
+statement error No function matches 'and\(\)'. You may need to add explicit type casts.
 select and();
 
 query B
@@ -71,8 +71,8 @@ select or(false, false, false);
 ----
 false
 
-statement error  Invalid inputs to 'or'
+statement error No function matches 'or\(\)'. You may need to add explicit type casts.
 select or();
 
-statement error  Invalid inputs to 'or'
+statement error No function matches 'or\(\)'. You may need to add explicit type casts.
 select or() from (values (1), (1), (1));

--- a/slt/standard/functions/scalars/string/string_concat.slt
+++ b/slt/standard/functions/scalars/string/string_concat.slt
@@ -3,7 +3,7 @@
 statement ok
 SET verify_optimized_plan TO true;
 
-statement error  Invalid inputs to 'concat'
+statement error  No function matches 'concat\(\)'. You may need to add explicit type casts.
 select concat();
 
 query T


### PR DESCRIPTION
```
glaredb> select repeat(1,2,3);
No function matches 'repeat(Int32, Int32, Int32)'. You may need to add explicit type casts.
Candidate functions:
    repeat(Utf8, Int64) -> Utf8
glaredb> select add(4,5,6);
No function matches '+(Int32, Int32, Int32)'. You may need to add explicit type casts.
Candidate functions:
    +(Float16, Float16) -> Float16
    +(Float32, Float32) -> Float32
    +(Float64, Float64) -> Float64
    +(Int8, Int8) -> Int8
    +(Int16, Int16) -> Int16
    +(Int32, Int32) -> Int32
    +(Int64, Int64) -> Int64
    +(Int128, Int128) -> Int128
    ...
   23 not shown. View the full list of functions in the catalog.
```