### PR TITLE
fix: Handle parsing object store paths manually when determining glob segments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ lto = "fat"
 opt-level = 3
 codegen-units = 1
 
+[workspace.lints.clippy]
+literal_string_with_formatting_args = "warn"
+
 [workspace.dependencies]
 ahash = { version = "0.8.12", default-features = false }
 chrono = { version = "0.4.41" }

--- a/crates/docgen/Cargo.toml
+++ b/crates/docgen/Cargo.toml
@@ -3,6 +3,9 @@ name = "docgen"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 logutil = { path = '../logutil' }
 glaredb_error = { path = '../glaredb_error' }

--- a/crates/ext_csv/Cargo.toml
+++ b/crates/ext_csv/Cargo.toml
@@ -3,6 +3,9 @@ name = "ext_csv"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_proto = { path = '../glaredb_proto' }
 glaredb_core = { path = '../glaredb_core' }

--- a/crates/ext_delta/Cargo.toml
+++ b/crates/ext_delta/Cargo.toml
@@ -3,6 +3,9 @@ name = "ext_delta"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_proto = { path = '../glaredb_proto' }
 glaredb_core = { path = '../glaredb_core' }

--- a/crates/ext_iceberg/Cargo.toml
+++ b/crates/ext_iceberg/Cargo.toml
@@ -3,6 +3,9 @@ name = "ext_iceberg"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_proto = { path = '../glaredb_proto' }
 glaredb_core = { path = '../glaredb_core' }

--- a/crates/ext_parquet/Cargo.toml
+++ b/crates/ext_parquet/Cargo.toml
@@ -23,6 +23,9 @@ keywords = ["arrow", "parquet", "hadoop"]
 readme = "README.md"
 edition = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = "../glaredb_error" }
 glaredb_core = { path = "../glaredb_core" }

--- a/crates/ext_parquet/src/schema/convert.rs
+++ b/crates/ext_parquet/src/schema/convert.rs
@@ -102,9 +102,9 @@ fn convert_primitive(prim: &PrimitiveType) -> Result<DataType> {
                     (8, false) => Ok(DataType::uint8()),
                     (16, false) => Ok(DataType::uint16()),
                     (32, false) => Ok(DataType::uint32()),
-                    _ => Err(DbError::new(
+                    _ => Err(DbError::new(format!(
                         "Cannot convert from INT32 with width {bit_width}",
-                    )),
+                    ))),
                 },
                 (Some(basic::LogicalType::Decimal { scale, precision }), _) => {
                     let meta = decimal_type_meta(precision, scale)?;
@@ -151,9 +151,9 @@ fn convert_primitive(prim: &PrimitiveType) -> Result<DataType> {
                     (16, false) => Ok(DataType::uint16()),
                     (32, false) => Ok(DataType::uint32()),
                     (64, false) => Ok(DataType::uint64()),
-                    _ => Err(DbError::new(
+                    _ => Err(DbError::new(format!(
                         "Cannot convert from INT32 with width {bit_width}",
-                    )),
+                    ))),
                 },
                 (Some(basic::LogicalType::Decimal { scale, precision }), _) => {
                     let meta = decimal_type_meta(precision, scale)?;

--- a/crates/ext_spark/Cargo.toml
+++ b/crates/ext_spark/Cargo.toml
@@ -3,6 +3,9 @@ name = "ext_spark"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_core = { path = '../glaredb_core' }
 glaredb_error = { path = '../glaredb_error' }

--- a/crates/ext_tpch_gen/Cargo.toml
+++ b/crates/ext_tpch_gen/Cargo.toml
@@ -3,6 +3,9 @@ name = "ext_tpch_gen"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_core = { path = '../glaredb_core' }
 glaredb_error = { path = '../glaredb_error' }

--- a/crates/glaredb/Cargo.toml
+++ b/crates/glaredb/Cargo.toml
@@ -4,7 +4,8 @@ version.workspace = true
 edition.workspace = true
 description = "GlareDB CLI"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 logutil = { path = '../logutil' }

--- a/crates/glaredb_bench/Cargo.toml
+++ b/crates/glaredb_bench/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_bench"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = '../glaredb_error' }
 glaredb_core = { path = '../glaredb_core' }

--- a/crates/glaredb_core/Cargo.toml
+++ b/crates/glaredb_core/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_core"
 version = { workspace = true }
 edition = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = "../glaredb_error" }
 glaredb_proto = { path = "../glaredb_proto" }

--- a/crates/glaredb_core/src/runtime/filesystem/directory.rs
+++ b/crates/glaredb_core/src/runtime/filesystem/directory.rs
@@ -21,7 +21,8 @@ pub struct DirEntry {
 
 impl DirEntry {
     /// Create a new dir entry with the given path and file type.
-    pub fn new(mut path: String, file_type: FileType) -> Self {
+    pub fn new(path: impl Into<String>, file_type: FileType) -> Self {
+        let mut path = path.into();
         if path.ends_with('/') {
             path.pop();
         }
@@ -29,11 +30,11 @@ impl DirEntry {
         DirEntry { path, file_type }
     }
 
-    pub fn new_file(path: String) -> Self {
+    pub fn new_file(path: impl Into<String>) -> Self {
         Self::new(path, FileType::File)
     }
 
-    pub fn new_dir(path: String) -> Self {
+    pub fn new_dir(path: impl Into<String>) -> Self {
         Self::new(path, FileType::Directory)
     }
 }

--- a/crates/glaredb_error/Cargo.toml
+++ b/crates/glaredb_error/Cargo.toml
@@ -3,4 +3,7 @@ name = "glaredb_error"
 version = { workspace = true }
 edition = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/crates/glaredb_http/Cargo.toml
+++ b/crates/glaredb_http/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_http"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = '../glaredb_error' }
 glaredb_core = { path = '../glaredb_core' }

--- a/crates/glaredb_http/src/gcs/directory.rs
+++ b/crates/glaredb_http/src/gcs/directory.rs
@@ -66,10 +66,10 @@ impl List for GcsList {
 
         // "prefixes" are common prefixes, treat them as subdirs.
         if let Some(prefixes) = list_resp.prefixes {
-            entries.extend(prefixes.into_iter().map(DirEntry::new_dir));
+            entries.extend(prefixes.into_iter().map(|prefix| DirEntry::new_dir(prefix)));
         }
 
-        Ok(list_resp.next_page_token)
+        Ok(list_resp.next_page_token.map(|s| s.to_string()))
     }
 }
 

--- a/crates/glaredb_http/src/gcs/directory.rs
+++ b/crates/glaredb_http/src/gcs/directory.rs
@@ -66,7 +66,7 @@ impl List for GcsList {
 
         // "prefixes" are common prefixes, treat them as subdirs.
         if let Some(prefixes) = list_resp.prefixes {
-            entries.extend(prefixes.into_iter().map(|prefix| DirEntry::new_dir(prefix)));
+            entries.extend(prefixes.into_iter().map(DirEntry::new_dir));
         }
 
         Ok(list_resp.next_page_token.map(|s| s.to_string()))

--- a/crates/glaredb_http/src/gcs/filesystem.rs
+++ b/crates/glaredb_http/src/gcs/filesystem.rs
@@ -203,24 +203,31 @@ where
     }
 
     fn glob_segments(glob: &str) -> Result<GlobSegments> {
-        // TODO: Copy pasted from s3.
-        let url = Url::parse(glob).context_fn(|| format!("Failed to parse '{glob}' as a URL"))?;
-
-        // Assumes gsutil format: 'gs://bucket/file.csv'
-        let bucket = match url.host().required("Missing host on url")? {
-            url::Host::Domain(host) => host,
-            other => return Err(DbError::new(format!("Expected domain, got {other:?}"))),
+        // TODO: Duplicated with s3
+        let trimmed = match glob.strip_prefix("gs://") {
+            Some(trimmed) => trimmed,
+            None => return Err(DbError::new("Glob missing 'gs://' scheme: {glob}")),
         };
 
-        // Now we parse the segments from the the path.
-        let mut segments: Vec<_> = url
-            .path()
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|s| !s.is_empty())
-            .collect();
+        // Now we parse the segments from the trimmed string
+        //
+        // First segment is the bucket.
+        let mut segments = trimmed.split('/').filter(|s| !s.is_empty());
+        let bucket = match segments.next() {
+            Some(bucket) => {
+                if is_glob(bucket) {
+                    return Err(DbError::new("Cannot have a glob in the bucket name"));
+                }
+                bucket
+            }
+            None => return Err(DbError::new("Cannot create glob from no segments")),
+        };
+
+        let mut segments: Vec<_> = segments.collect();
         if segments.is_empty() {
-            return Err(DbError::new("Missing segments for glob"));
+            return Err(DbError::new(
+                "Cannot have zero segments after parsing bucket",
+            ));
         }
 
         // Find the root dir relative to the bucket to use.

--- a/crates/glaredb_http/src/gcs/filesystem.rs
+++ b/crates/glaredb_http/src/gcs/filesystem.rs
@@ -206,7 +206,7 @@ where
         // TODO: Duplicated with s3
         let trimmed = match glob.strip_prefix("gs://") {
             Some(trimmed) => trimmed,
-            None => return Err(DbError::new("Glob missing 'gs://' scheme: {glob}")),
+            None => return Err(DbError::new(format!("Glob missing 'gs://' scheme: {glob}"))),
         };
 
         // Now we parse the segments from the trimmed string

--- a/crates/glaredb_http/src/gcs/list.rs
+++ b/crates/glaredb_http/src/gcs/list.rs
@@ -5,17 +5,17 @@ use serde::{Deserialize, Serialize};
 // <https://cloud.google.com/storage/docs/json_api/v1/objects/list>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GcsListResponse {
+pub struct GcsListResponse<'a> {
     /// Always "storage#objects".
-    pub kind: String,
-    pub next_page_token: Option<String>,
-    pub prefixes: Option<Vec<String>>,
-    pub items: Option<Vec<GcsObjectResource>>,
+    pub kind: &'a str,
+    pub next_page_token: Option<&'a str>,
+    pub prefixes: Option<Vec<&'a str>>,
+    pub items: Option<Vec<GcsObjectResource<'a>>>,
 }
 
 // TODO: More fields, see <https://cloud.google.com/storage/docs/json_api/v1/objects#resource>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GcsObjectResource {
-    pub name: String,
+pub struct GcsObjectResource<'a> {
+    pub name: &'a str,
 }

--- a/crates/glaredb_http/src/s3/filesystem.rs
+++ b/crates/glaredb_http/src/s3/filesystem.rs
@@ -198,7 +198,7 @@ where
     fn glob_segments(glob: &str) -> Result<GlobSegments> {
         let trimmed = match glob.strip_prefix("s3://") {
             Some(trimmed) => trimmed,
-            None => return Err(DbError::new("Glob missing 's3://' scheme: {glob}")),
+            None => return Err(DbError::new(format!("Glob missing 's3://' scheme: {glob}"))),
         };
 
         // Now we parse the segments from the trimmed string

--- a/crates/glaredb_http/src/s3/filesystem.rs
+++ b/crates/glaredb_http/src/s3/filesystem.rs
@@ -196,26 +196,30 @@ where
     }
 
     fn glob_segments(glob: &str) -> Result<GlobSegments> {
-        // I _believe_ that by parsing a url, we would end up erroring on glob
-        // characters in the bucket name. But need to test (erroring is good,
-        // just need to make it reasonable).
-        let url = Url::parse(glob).context_fn(|| format!("Failed to parse '{glob}' as a URL"))?;
-
-        // Assumes s3 format: 's3://bucket/file.csv'
-        let bucket = match url.host().required("Missing host on url")? {
-            url::Host::Domain(host) => host,
-            other => return Err(DbError::new(format!("Expected domain, got {other:?}"))),
+        let trimmed = match glob.strip_prefix("s3://") {
+            Some(trimmed) => trimmed,
+            None => return Err(DbError::new("Glob missing 's3://' scheme: {glob}")),
         };
 
-        // Now we parse the segments from the the path.
-        let mut segments: Vec<_> = url
-            .path()
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|s| !s.is_empty())
-            .collect();
+        // Now we parse the segments from the trimmed string
+        //
+        // First segment is the bucket.
+        let mut segments = trimmed.split('/').filter(|s| !s.is_empty());
+        let bucket = match segments.next() {
+            Some(bucket) => {
+                if is_glob(bucket) {
+                    return Err(DbError::new("Cannot have a glob in the bucket name"));
+                }
+                bucket
+            }
+            None => return Err(DbError::new("Cannot create glob from no segments")),
+        };
+
+        let mut segments: Vec<_> = segments.collect();
         if segments.is_empty() {
-            return Err(DbError::new("Missing segments for glob"));
+            return Err(DbError::new(
+                "Cannot have zero segments after parsing bucket",
+            ));
         }
 
         // Find the root dir relative to the bucket to use.

--- a/crates/glaredb_http/src/s3/list.rs
+++ b/crates/glaredb_http/src/s3/list.rs
@@ -3,25 +3,25 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct S3ListResponse {
+pub struct S3ListResponse<'a> {
     pub is_truncated: bool,
-    pub next_continuation_token: Option<String>,
-    pub contents: Option<Vec<S3ListContents>>,
-    pub common_prefixes: Option<Vec<S3Prefix>>,
+    pub next_continuation_token: Option<&'a str>,
+    pub contents: Option<Vec<S3ListContents<'a>>>,
+    pub common_prefixes: Option<Vec<S3Prefix<'a>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct S3ListContents {
-    pub key: String,
+pub struct S3ListContents<'a> {
+    pub key: &'a str,
     pub last_modified: DateTime<Utc>,
     pub size: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct S3Prefix {
-    pub prefix: String,
+pub struct S3Prefix<'a> {
+    pub prefix: &'a str,
 }
 
 #[cfg(test)]
@@ -53,7 +53,7 @@ mod tests {
             is_truncated: false,
             next_continuation_token: None,
             contents: Some(vec![S3ListContents {
-                key: "my-image.jpg".to_string(),
+                key: "my-image.jpg",
                 last_modified: DateTime::parse_from_rfc3339("2009-10-12T17:50:30.000Z")
                     .unwrap()
                     .to_utc(),
@@ -89,11 +89,9 @@ mod tests {
 
         let expected = S3ListResponse {
             is_truncated: true,
-            next_continuation_token: Some(
-                "1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=".to_string(),
-            ),
+            next_continuation_token: Some("1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM="),
             contents: Some(vec![S3ListContents {
-                key: "my-image.jpg".to_string(),
+                key: "my-image.jpg",
                 last_modified: DateTime::parse_from_rfc3339("2009-10-12T17:50:30.000Z")
                     .unwrap()
                     .to_utc(),

--- a/crates/glaredb_parser/Cargo.toml
+++ b/crates/glaredb_parser/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_parser"
 version = { workspace = true }
 edition = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = '../glaredb_error' }
 glaredb_proto = { path = '../glaredb_proto' }

--- a/crates/glaredb_proto/Cargo.toml
+++ b/crates/glaredb_proto/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_proto"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = "../glaredb_error" }
 prost = "0.13"

--- a/crates/glaredb_python/Cargo.toml
+++ b/crates/glaredb_python/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_python"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "glaredb"
 crate-type = ["cdylib"]

--- a/crates/glaredb_rt_native/Cargo.toml
+++ b/crates/glaredb_rt_native/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_rt_native"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 glaredb_error = { path = "../glaredb_error" }
 glaredb_core = { path = "../glaredb_core" }

--- a/crates/glaredb_slt/Cargo.toml
+++ b/crates/glaredb_slt/Cargo.toml
@@ -3,7 +3,8 @@ name = "glaredb_slt"
 version.workspace = true
 edition.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 glaredb_error = { path = '../glaredb_error' }

--- a/crates/glaredb_wasm/Cargo.toml
+++ b/crates/glaredb_wasm/Cargo.toml
@@ -3,6 +3,9 @@ name = "glaredb_wasm"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/crates/logutil/Cargo.toml
+++ b/crates/logutil/Cargo.toml
@@ -3,6 +3,9 @@ name = "logutil"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tracing = { workspace = true }
 tracing-subscriber = {version = "0.3", features = ["std", "fmt", "json", "env-filter"] }

--- a/slt/gcs/public/glob.slt
+++ b/slt/gcs/public/glob.slt
@@ -53,39 +53,55 @@ gs://glaredb-public/testdata/csv/glob_numbers/300.csv
 gs://glaredb-public/testdata/csv/glob_numbers/400.csv
 gs://glaredb-public/testdata/csv/glob_numbers/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/{200,300}.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/{200,300}.csv') ORDER BY 1;
+----
+gs://glaredb-public/testdata/csv/glob_numbers/200.csv
+gs://glaredb-public/testdata/csv/glob_numbers/300.csv
 
-# TODO: Panic
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/?00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/?00.csv') ORDER BY 1;
+----
+gs://glaredb-public/testdata/csv/glob_numbers/100.csv
+gs://glaredb-public/testdata/csv/glob_numbers/200.csv
+gs://glaredb-public/testdata/csv/glob_numbers/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/400.csv
+gs://glaredb-public/testdata/csv/glob_numbers/500.csv
 
-# TODO: Panic
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/?.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/?.csv') ORDER BY 1;
+----
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/{3,5}00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/{3,5}00.csv') ORDER BY 1;
+----
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested2/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested2/500.csv
+gs://glaredb-public/testdata/csv/glob_numbers/nested1/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/nested1/500.csv
+gs://glaredb-public/testdata/csv/glob_numbers/nested2/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/nested2/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/{3,5}00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/{3,5}00.csv') ORDER BY 1;
+----
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/**') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/**') ORDER BY 1;
+----
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/100.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/200.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/400.csv
+gs://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
 
 # TODO: Not matching the readme.
 # query T
-# SELECT * FROM glob('../testdata/csv/glob_numbers/**/*.md') ORDER BY 1;
+# SELECT * FROM glob('gs://glaredb-public/testdata/csv/glob_numbers/**/*.md') ORDER BY 1;
 # ----
 
 query T

--- a/slt/s3/public/glob.slt
+++ b/slt/s3/public/glob.slt
@@ -53,39 +53,55 @@ s3://glaredb-public/testdata/csv/glob_numbers/300.csv
 s3://glaredb-public/testdata/csv/glob_numbers/400.csv
 s3://glaredb-public/testdata/csv/glob_numbers/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/{200,300}.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/{200,300}.csv') ORDER BY 1;
+----
+s3://glaredb-public/testdata/csv/glob_numbers/200.csv
+s3://glaredb-public/testdata/csv/glob_numbers/300.csv
 
-# TODO: Panic
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/?00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/?00.csv') ORDER BY 1;
+----
+s3://glaredb-public/testdata/csv/glob_numbers/100.csv
+s3://glaredb-public/testdata/csv/glob_numbers/200.csv
+s3://glaredb-public/testdata/csv/glob_numbers/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/400.csv
+s3://glaredb-public/testdata/csv/glob_numbers/500.csv
 
-# TODO: Panic
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/?.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/?.csv') ORDER BY 1;
+----
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/{3,5}00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/{3,5}00.csv') ORDER BY 1;
+----
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested2/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested2/500.csv
+s3://glaredb-public/testdata/csv/glob_numbers/nested1/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/nested1/500.csv
+s3://glaredb-public/testdata/csv/glob_numbers/nested2/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/nested2/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/{3,5}00.csv') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/{3,5}00.csv') ORDER BY 1;
+----
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
 
-# TODO: Returns nothing
-# query T
-# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/**') ORDER BY 1;
-# ----
+query T
+SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/nested{1,4}/**') ORDER BY 1;
+----
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/100.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/200.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/400.csv
+s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv
 
 # TODO: Not matching the readme.
 # query T
-# SELECT * FROM glob('../testdata/csv/glob_numbers/**/*.md') ORDER BY 1;
+# SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/*.md') ORDER BY 1;
 # ----
 
 query T


### PR DESCRIPTION
```
glaredb> SELECT * FROM glob('s3://glaredb-public/testdata/csv/glob_numbers/**/{3,5}00.csv') ORDER BY 1;
┌────────────────────────────────────────────────────────────────────┐
│ filename                                                           │
│ Utf8                                                               │
├────────────────────────────────────────────────────────────────────┤
│ s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/300.csv │
│ s3://glaredb-public/testdata/csv/glob_numbers/deep/nested1/500.csv │
│ s3://glaredb-public/testdata/csv/glob_numbers/deep/nested2/300.csv │
│ s3://glaredb-public/testdata/csv/glob_numbers/deep/nested2/500.csv │
│ s3://glaredb-public/testdata/csv/glob_numbers/nested1/300.csv      │
│ s3://glaredb-public/testdata/csv/glob_numbers/nested1/500.csv      │
│ s3://glaredb-public/testdata/csv/glob_numbers/nested2/300.csv      │
│ s3://glaredb-public/testdata/csv/glob_numbers/nested2/500.csv      │
└────────────────────────────────────────────────────────────────────┘
```