### PR TITLE
fix: Handle out of order relative join keys correctly

### DIFF
--- a/crates/glaredb_core/src/execution/operators/hash_join/hash_table/mod.rs
+++ b/crates/glaredb_core/src/execution/operators/hash_join/hash_table/mod.rs
@@ -187,14 +187,20 @@ impl JoinHashTable {
             build_side_exprs.push(condition.left);
             probe_side_exprs.push(condition.right);
 
+            // Push the type to current set of columns we're encoding.
             let encode_idx = encoded_types.len();
             encoded_types.push(datatype);
-            encoded_key_columns.push(encode_idx);
 
             if condition.op == ComparisonOperator::Eq {
-                let equality_idx = equality_columns.len();
-                equality_columns.push(equality_idx);
+                // If this is an equality comparison, get the key index
+                // _relative to the join keys_.
+                let rel_key_idx = encoded_key_columns.len();
+                equality_columns.push(rel_key_idx);
             }
+
+            // Now add the column idx relative to all encoded columns to the
+            // list of join keys.
+            encoded_key_columns.push(encode_idx);
 
             matcher_conditions.push((phys_type, condition.op));
         }

--- a/slt/standard/join/inner_join_eq_neq.slt
+++ b/slt/standard/join/inner_join_eq_neq.slt
@@ -1,0 +1,72 @@
+# Inner join with mixed condition types (EQ, NEQ)
+
+statement ok
+SET verify_optimized_plan TO true;
+
+statement ok
+CREATE TEMP TABLE t1 (a INT, b TEXT, c INT);
+
+statement ok
+CREATE TEMP TABLE t2 (d INT, e TEXT, f INT);
+
+statement ok
+INSERT INTO t1 VALUES
+  (4, 'aaa', 44),
+  (5, 'bbb', 55),
+  (6, 'ccc', 66),
+  (7, 'ddd', 77);
+
+statement ok
+INSERT INTO t2 VALUES
+  (4, 'eee', 44),
+  (9, 'fff', 55),
+  (6, 'ggg', 88),
+  (7, 'hhh', 99);
+
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE a = d AND c <> f;
+----
+6  ccc  66  6  ggg  88
+7  ddd  77  7  hhh  99
+
+# Same but conditions moved.
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE c <> f AND a = d;
+----
+6  ccc  66  6  ggg  88
+7  ddd  77  7  hhh  99
+
+# Last condition always true.
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE c <> f AND a = d AND b <> e;
+----
+6  ccc  66  6  ggg  88
+7  ddd  77  7  hhh  99
+
+# Last condition always false.
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE c <> f AND a = d AND b = e;
+----
+
+# Conditions inverted.
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE a <> d AND c = f;
+----
+5  bbb  55  9  fff  55
+
+query ITIITI
+SELECT *
+  FROM t1, t2
+  WHERE c = f AND a <> d;
+----
+5  bbb  55  9  fff  55


### PR DESCRIPTION
Previously assumed that join keys were provided with equalities coming in first, but that's not actually guaranteed.