### PR TITLE
fix: Ensure filters pushed through semi joins during reorder are on correct side

### DIFF
--- a/slt/standard/join/in_semi_join_with_filter.slt
+++ b/slt/standard/join/in_semi_join_with_filter.slt
@@ -1,0 +1,41 @@
+# Test that a semi join (IN) containing a filter (HAVING) doesn't get messed up
+# during join reorder.
+
+statement ok
+SET verify_optimized_plan TO true;
+
+statement ok
+CREATE TEMP TABLE lineitem (orderkey INT, quantity INT);
+
+statement ok
+INSERT INTO lineitem VALUES
+  (1, 100),
+  (1, 400),
+  (2, 100),
+  (3, 300),
+  (3, 500),
+  (4, 400);
+
+statement ok
+CREATE TEMP TABLE orders (orderkey INT, orderdate DATE);
+
+statement ok
+INSERT INTO orders VALUES
+  (1, '2022-02-01'),
+  (2, '2022-02-08'),
+  (3, '2023-06-02'),
+  (4, '2021-04-08');
+
+query ITI
+SELECT o.orderkey, o.orderdate, sum(l.quantity)
+  FROM orders o, lineitem l
+  WHERE
+    o.orderkey IN (SELECT orderkey FROM lineitem GROUP BY orderkey HAVING sum(quantity) > 300)
+    AND o.orderkey = l.orderkey
+  GROUP BY o.orderkey, o.orderdate
+  ORDER BY o.orderdate;
+----
+4  2021-04-08  400
+1  2022-02-01  500
+3  2023-06-02  800
+

--- a/slt/tpchbench/q18.slt
+++ b/slt/tpchbench/q18.slt
@@ -1,9 +1,3 @@
-# Failed to run SLT
-# Error source: query failed: Failed to plan expressions for filter
-# Error source: Column expr not referencing a valid table ref, column: #29.0, valid tables: [#37]
-
-halt
-
 query TT
 DESCRIBE SELECT
     c_name,
@@ -44,7 +38,7 @@ c_custkey     Int32
 o_orderkey    Int32
 o_orderdate   Date32
 o_totalprice  Decimal64(15,2)
-sum           Decimal64(15,2)
+sum           Decimal128(38,2)
 
 query ??????
 SELECT


### PR DESCRIPTION
We currently support only "left" semi joins and thus can't freely flip them. During join reordering, we correctly reordered the child nodes after rebuilding the graph to to ensure that they're on the right side, but omitted reordering the associated filters that were pushed down, causing a planning error.