### PR TITLE
fix: Properly handle definition levels in some parquet decoders

### DIFF
--- a/crates/ext_parquet/src/column/encoding/byte_stream_split.rs
+++ b/crates/ext_parquet/src/column/encoding/byte_stream_split.rs
@@ -43,6 +43,8 @@ where
     ) -> Result<()> {
         let read_count = match definitions {
             Definitions::HasDefinitions { levels, max } => {
+                debug_assert_eq!(levels.len(), count);
+
                 levels.iter().filter(|&&def| def == max).count()
             }
             Definitions::NoDefinitions => count,

--- a/crates/ext_parquet/src/column/encoding/delta_binary_packed.rs
+++ b/crates/ext_parquet/src/column/encoding/delta_binary_packed.rs
@@ -59,6 +59,8 @@ where
     ) -> Result<()> {
         let read_count = match definitions {
             Definitions::HasDefinitions { levels, max } => {
+                debug_assert_eq!(levels.len(), count);
+
                 levels.iter().filter(|&&def| def == max).count()
             }
             Definitions::NoDefinitions => count,

--- a/crates/ext_parquet/src/column/encoding/delta_byte_array.rs
+++ b/crates/ext_parquet/src/column/encoding/delta_byte_array.rs
@@ -87,10 +87,14 @@ impl DeltaByteArrayDecoder {
 
         match definitions {
             Definitions::HasDefinitions { levels, max } => {
-                for (output_idx, &level) in levels.iter().enumerate().skip(offset).take(count) {
+                debug_assert_eq!(levels.len(), count);
+
+                for idx in 0..count {
+                    let level = levels[idx];
+                    let write_idx = offset + idx;
                     if level < max {
                         // Value is null.
-                        validity.set_invalid(output_idx);
+                        validity.set_invalid(write_idx);
                         continue;
                     }
 
@@ -110,7 +114,7 @@ impl DeltaByteArrayDecoder {
                             .context("Did not read valid utf8")?;
                     }
 
-                    data.put(output_idx, &self.val_buf);
+                    data.put(write_idx, &self.val_buf);
                 }
 
                 Ok(())

--- a/crates/ext_parquet/src/column/encoding/delta_byte_array.rs
+++ b/crates/ext_parquet/src/column/encoding/delta_byte_array.rs
@@ -89,8 +89,7 @@ impl DeltaByteArrayDecoder {
             Definitions::HasDefinitions { levels, max } => {
                 debug_assert_eq!(levels.len(), count);
 
-                for idx in 0..count {
-                    let level = levels[idx];
+                for (idx, &level) in levels.iter().enumerate() {
                     let write_idx = offset + idx;
                     if level < max {
                         // Value is null.

--- a/crates/ext_parquet/src/column/encoding/delta_length_byte_array.rs
+++ b/crates/ext_parquet/src/column/encoding/delta_length_byte_array.rs
@@ -66,10 +66,14 @@ impl DeltaLengthByteArrayDecoder {
 
         match definitions {
             Definitions::HasDefinitions { levels, max } => {
-                for (output_idx, &level) in levels.iter().enumerate().skip(offset).take(count) {
+                debug_assert_eq!(levels.len(), count);
+
+                for idx in 0..count {
+                    let level = levels[idx];
+                    let write_idx = offset + idx;
                     if level < max {
                         // Value is null.
-                        validity.set_invalid(output_idx);
+                        validity.set_invalid(write_idx);
                         continue;
                     }
 
@@ -81,7 +85,7 @@ impl DeltaLengthByteArrayDecoder {
                         let _ = std::str::from_utf8(bs).context("Did not read valid utf8")?;
                     }
 
-                    data.put(output_idx, bs);
+                    data.put(write_idx, bs);
                 }
 
                 Ok(())

--- a/crates/ext_parquet/src/column/encoding/delta_length_byte_array.rs
+++ b/crates/ext_parquet/src/column/encoding/delta_length_byte_array.rs
@@ -68,8 +68,7 @@ impl DeltaLengthByteArrayDecoder {
             Definitions::HasDefinitions { levels, max } => {
                 debug_assert_eq!(levels.len(), count);
 
-                for idx in 0..count {
-                    let level = levels[idx];
+                for (idx, &level) in levels.iter().enumerate() {
                     let write_idx = offset + idx;
                     if level < max {
                         // Value is null.

--- a/crates/ext_parquet/src/column/encoding/mod.rs
+++ b/crates/ext_parquet/src/column/encoding/mod.rs
@@ -20,10 +20,12 @@ use super::value_reader::ValueReader;
 pub enum Definitions<'a> {
     /// This column has definitions.
     HasDefinitions {
-        /// Definitions levels. When passing to a column reader, this should be
-        /// the exact number of values we expect to read.
+        /// Definitions levels.
+        ///
+        /// When passing to a page decoder, this should be the exact number of
+        /// values we expect to read from that decoder.
         levels: &'a [i16],
-        /// Max definition level. Used to determine nullibility.
+        /// Max definition level. Used to determine nullability.
         max: i16,
     },
     /// This column does not have any definitions.

--- a/crates/ext_parquet/src/column/encoding/plain.rs
+++ b/crates/ext_parquet/src/column/encoding/plain.rs
@@ -46,11 +46,15 @@ where
 
         match definitions {
             Definitions::HasDefinitions { levels, max } => {
+                debug_assert_eq!(levels.len(), count);
+
                 let mut error_state = ReaderErrorState::default();
-                for (idx, &level) in levels.iter().enumerate().skip(offset).take(count) {
+                for idx in 0..count {
+                    let level = levels[idx];
+                    let write_idx = offset + idx;
                     if level < max {
                         // Value is null.
-                        validity.set_invalid(idx);
+                        validity.set_invalid(write_idx);
                         continue;
                     }
 
@@ -58,7 +62,7 @@ where
                     unsafe {
                         self.value_reader.read_next_unchecked(
                             &mut self.buffer,
-                            idx,
+                            write_idx,
                             &mut data,
                             &mut error_state,
                         )
@@ -69,12 +73,13 @@ where
             }
             Definitions::NoDefinitions => {
                 let mut error_state = ReaderErrorState::default();
-                for idx in offset..(offset + count) {
+                for idx in 0..count {
+                    let write_idx = idx + offset;
                     // Value is valid, read it and put into output.
                     unsafe {
                         self.value_reader.read_next_unchecked(
                             &mut self.buffer,
-                            idx,
+                            write_idx,
                             &mut data,
                             &mut error_state,
                         )

--- a/crates/ext_parquet/src/column/encoding/plain.rs
+++ b/crates/ext_parquet/src/column/encoding/plain.rs
@@ -49,8 +49,7 @@ where
                 debug_assert_eq!(levels.len(), count);
 
                 let mut error_state = ReaderErrorState::default();
-                for idx in 0..count {
-                    let level = levels[idx];
+                for (idx, &level) in levels.iter().enumerate() {
                     let write_idx = offset + idx;
                     if level < max {
                         // Value is null.

--- a/crates/ext_parquet/src/column/encoding/rle_bit_packed.rs
+++ b/crates/ext_parquet/src/column/encoding/rle_bit_packed.rs
@@ -45,6 +45,7 @@ impl RleBoolDecoder {
         // Only read valid values.
         let read_count = match definitions {
             Definitions::HasDefinitions { levels, max } => {
+                debug_assert_eq!(levels.len(), count);
                 levels.iter().filter(|&&def| def == max).count()
             }
             Definitions::NoDefinitions => count,

--- a/crates/ext_parquet/src/column/struct_reader.rs
+++ b/crates/ext_parquet/src/column/struct_reader.rs
@@ -78,6 +78,22 @@ impl StructReader {
         Ok(StructReader { readers })
     }
 
+    pub fn prepare_scan_unit(
+        &mut self,
+        projections: &Projections,
+        parquet_schema: &SchemaDescriptor,
+    ) -> Result<()> {
+        debug_assert_eq!(projections.data_indices().len(), self.readers.len());
+
+        for (idx, reader) in self.readers.iter_mut().enumerate() {
+            let col_idx = projections.data_indices()[idx];
+            let col_descr = parquet_schema.leaves[col_idx].clone();
+            reader.prepare_scan_unit(col_descr)?;
+        }
+
+        Ok(())
+    }
+
     /// Checks to see if we can prune this row group by looking at the stats for
     /// each column.
     ///

--- a/crates/ext_parquet/src/functions/scan.rs
+++ b/crates/ext_parquet/src/functions/scan.rs
@@ -276,7 +276,7 @@ impl TableScanFunction for ReadParquet {
                         Poll::Pending => return Ok(PollPull::Pending),
                     };
 
-                    state.reader.prepare(scan_unit);
+                    state.reader.prepare(scan_unit)?;
                     state.state = ReadState::Scanning;
                     // Continue...
                 }

--- a/crates/ext_parquet/src/reader.rs
+++ b/crates/ext_parquet/src/reader.rs
@@ -154,7 +154,11 @@ impl Reader {
     }
 
     /// Preprates this reader to begin reading from a new scan unit.
-    pub fn prepare(&mut self, unit: ScanUnit) {
+    pub fn prepare(&mut self, unit: ScanUnit) -> Result<()> {
+        // Reset the readers.
+        self.root
+            .prepare_scan_unit(&self.projections, &unit.metadata.file_metadata.schema_descr)?;
+
         self.unit = Some(unit);
         self.state = RowGroupState {
             current_group: ScanRowGroup {
@@ -165,6 +169,8 @@ impl Reader {
             relative_scan_offset: 0,
         };
         self.fetch_state = FetchState::NeedsFetch { column_idx: 0 };
+
+        Ok(())
     }
 
     /// Scan rows into the output batch.

--- a/slt/parquet/binary_rle_dict_defs.slt
+++ b/slt/parquet/binary_rle_dict_defs.slt
@@ -1,0 +1,29 @@
+# Test that we can properly read RLE_DICTIONARY encoded BINARY columns with
+# definitition levels.
+#
+# This uses a hits (partitioned, hits_74) file from clickbench that's been
+# truncated down to 10_000 rows using an older version of glaredb.
+#
+# All columns are non-null, but all columns are encoded with definition levels,
+# with the max being 1.
+#
+# The problematic column was 'URL'. There might've been more, but solving that
+# issue let us read the file without errors.
+
+statement ok
+SET verify_optimized_plan TO true;
+
+# When running the unoptimized plan, this will read everything from the file.
+query I
+SELECT count(*) FROM '../submodules/testdata/hits_truncated_url_dict_def.parquet';
+----
+10000
+
+query IT
+SELECT _rowid, URL::TEXT
+  FROM '../submodules/testdata/hits_truncated_url_dict_def.parquet'
+  WHERE _rowid = 3 OR _rowid = 9987;
+----
+3     http://tienskaia-moda
+9987  http://tienskaia-moda-zhienskaia-moda
+


### PR DESCRIPTION
Some were erroneously viewing `levels` as _all_ levels we're reading across all pages for a single batch, and not just the levels we're reading for a single page.