### PR TITLE
fix: Use u64 for file lengths

### DIFF
--- a/crates/ext_parquet/src/metadata/mod.rs
+++ b/crates/ext_parquet/src/metadata/mod.rs
@@ -45,7 +45,7 @@ use crate::schema::types::{ColumnDescriptor, ColumnPath, GroupType, SchemaDescri
 pub const FOOTER_SIZE: usize = 8;
 
 /// Minimum file size for a valid parquet file.
-pub const MIN_FILE_SIZE: usize = 12;
+pub const MIN_FILE_SIZE: u64 = 12;
 
 /// Magic value for parquet files.
 pub const PARQUET_MAGIC: &[u8; 4] = b"PAR1";

--- a/crates/glaredb_core/src/functions/table/builtin/read_text.rs
+++ b/crates/glaredb_core/src/functions/table/builtin/read_text.rs
@@ -183,7 +183,11 @@ impl TableScanFunction for ReadText {
                     };
 
                     if op_state.projections.has_data_column(0) {
-                        state.buf.resize(file.call_size(), 0);
+                        let size: usize = file
+                            .call_size()
+                            .try_into()
+                            .context("File size exceeded max memory buffer size")?;
+                        state.buf.resize(size, 0);
                     }
 
                     state.state = ReadState::Scanning {

--- a/crates/glaredb_core/src/runtime/filesystem/memory.rs
+++ b/crates/glaredb_core/src/runtime/filesystem/memory.rs
@@ -119,8 +119,8 @@ impl FileHandle for MemoryFileHandle {
         &self.path
     }
 
-    fn size(&self) -> usize {
-        self.buffer.len()
+    fn size(&self) -> u64 {
+        self.buffer.len() as u64
     }
 
     fn poll_read(&mut self, _cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize>> {

--- a/crates/glaredb_core/src/runtime/filesystem/mod.rs
+++ b/crates/glaredb_core/src/runtime/filesystem/mod.rs
@@ -30,8 +30,7 @@ pub trait FileHandle: Debug + Sync + Send + 'static {
     fn path(&self) -> &str;
 
     /// Get the size in bytes of this file.
-    // TODO: Probably u64
-    fn size(&self) -> usize;
+    fn size(&self) -> u64;
 
     /// Read from the current position into the buffer, returning the number of
     /// bytes read.
@@ -71,7 +70,7 @@ impl AnyFile {
         (self.vtable.path_fn)(self.file.as_ref())
     }
 
-    pub fn call_size(&self) -> usize {
+    pub fn call_size(&self) -> u64 {
         // TODO: We could probably just stick the size on the struct.
         (self.vtable.size_fn)(self.file.as_ref())
     }
@@ -111,7 +110,7 @@ impl AnyFile {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RawFileVTable {
     path_fn: fn(&dyn Any) -> &str,
-    size_fn: fn(&dyn Any) -> usize,
+    size_fn: fn(&dyn Any) -> u64,
     poll_read_fn: fn(&mut dyn Any, cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize>>,
     poll_seek_fn: fn(&mut dyn Any, cx: &mut Context, seek: io::SeekFrom) -> Poll<Result<()>>,
     read_fn: for<'a> fn(&'a mut dyn Any, buf: &'a mut [u8]) -> FileSystemFuture<'a, Result<usize>>,

--- a/crates/glaredb_http/src/filesystem.rs
+++ b/crates/glaredb_http/src/filesystem.rs
@@ -69,7 +69,7 @@ where
             Some(v) => v
                 .to_str()
                 .context("Failed convert Content-Length header to string")?
-                .parse::<usize>()
+                .parse::<u64>()
                 .context("Failed to parse Content-Length")?,
             None => return Err(DbError::new("Missing Content-Length header for file")),
         };

--- a/crates/glaredb_http/src/gcs/filesystem.rs
+++ b/crates/glaredb_http/src/gcs/filesystem.rs
@@ -142,7 +142,7 @@ where
             Some(v) => v
                 .to_str()
                 .context("Failed convert Content-Length header to string")?
-                .parse::<usize>()
+                .parse::<u64>()
                 .context("Failed to parse Content-Length")?,
             None => return Err(DbError::new("Missing Content-Length header for file")),
         };
@@ -269,7 +269,7 @@ where
         self.handle.url.as_str()
     }
 
-    fn size(&self) -> usize {
+    fn size(&self) -> u64 {
         self.handle.len
     }
 

--- a/crates/glaredb_http/src/s3/filesystem.rs
+++ b/crates/glaredb_http/src/s3/filesystem.rs
@@ -146,7 +146,7 @@ where
             Some(v) => v
                 .to_str()
                 .context("Failed convert Content-Length header to string")?
-                .parse::<usize>()
+                .parse::<u64>()
                 .context("Failed to parse Content-Length")?,
             None => return Err(DbError::new("Missing Content-Length header for file")),
         };
@@ -281,7 +281,7 @@ where
         self.handle.url.as_str()
     }
 
-    fn size(&self) -> usize {
+    fn size(&self) -> u64 {
         self.handle.len
     }
 

--- a/crates/glaredb_rt_native/src/filesystem.rs
+++ b/crates/glaredb_rt_native/src/filesystem.rs
@@ -18,7 +18,7 @@ use glaredb_error::{DbError, Result, ResultExt};
 #[derive(Debug)]
 pub struct LocalFileHandle {
     path: String,
-    len: usize,
+    len: u64,
     file: StdFile,
 }
 
@@ -27,7 +27,7 @@ impl FileHandle for LocalFileHandle {
         &self.path
     }
 
-    fn size(&self) -> usize {
+    fn size(&self) -> u64 {
         self.len
     }
 
@@ -78,7 +78,7 @@ impl FileSystem for LocalFileSystem {
 
         Ok(LocalFileHandle {
             path: path.to_string(),
-            len: metadata.len() as usize,
+            len: metadata.len(),
             file,
         })
     }


### PR DESCRIPTION
Enables reading larger files on 32-bit systems (wasm).