### PR TITLE
chore: Use libtest mimic for bench runner

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -19,14 +19,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Compile standard
-      #   run: |
-      #     cargo build \
-      #        --release \
-      #        --bin bench_standard
+      - name: Benchmark (micro)
+        run: |
+          cargo bench \
+             --bench bench_runner \
+             -- bench/micro
 
-      # - name: Run standard
-      #   run: |
-      #     ./target/release/bench_standard \
-      #        --print-results \
-      #        --print-explain

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ lineedit.log
 
 # Scratch dir for tests queries and stuff.
 /scratch
+
+# Results output for bench runner benchmarks
+/bench_bin/results.tsv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "glaredb_core",
  "glaredb_error",
  "glaredb_rt_native",
+ "libtest-mimic",
  "logutil",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,13 +1078,13 @@ dependencies = [
 name = "glaredb_bench"
 version = "25.5.11"
 dependencies = [
- "clap",
  "futures",
  "glaredb_core",
  "glaredb_error",
  "glaredb_rt_native",
  "libtest-mimic",
  "logutil",
+ "parking_lot",
  "tokio",
 ]
 

--- a/bench_bin/Cargo.toml
+++ b/bench_bin/Cargo.toml
@@ -17,6 +17,8 @@ ext_parquet = { path = '../crates/ext_parquet' }
 ext_tpch_gen = { path = '../crates/ext_tpch_gen' }
 ext_iceberg = { path = '../crates/ext_iceberg' }
 
-[[bin]]
+[[bench]]
+harness = false
 name = "bench_runner"
 path = "bench_runner.rs"
+

--- a/bench_bin/bench_runner.rs
+++ b/bench_bin/bench_runner.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use ext_csv::extension::CsvExtension;
 use ext_iceberg::extension::IcebergExtension;
@@ -16,7 +16,11 @@ use glaredb_rt_native::runtime::{
     new_tokio_runtime_for_io,
 };
 
+/// Environment variable for dropping cache before every engine/session create.
+pub const BENCH_DROP_CACHE_VAR: &str = "BENCH_DROP_CACHE";
+
 pub fn main() -> Result<()> {
+    // TODO: Allow providing these via args.
     let run_args = RunArgs {
         print_explain: false,
         print_profile_data: false,
@@ -27,7 +31,10 @@ pub fn main() -> Result<()> {
     let writer = TsvWriter::try_new(Some("./results.tsv".into()))?;
     writer.write_header()?;
 
-    run_with_setup::<DefaultSetup>(writer.clone(), run_args, "../bench/micro", false)?;
+    let drop_cache = std::env::var(BENCH_DROP_CACHE_VAR).is_ok();
+    println!("Drop cache: {drop_cache}");
+
+    run_with_setup::<DefaultSetup>(writer.clone(), run_args, "../bench/micro", drop_cache)?;
 
     writer.flush()?;
 

--- a/bench_bin/bench_runner.rs
+++ b/bench_bin/bench_runner.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ext_csv::extension::CsvExtension;
 use ext_iceberg::extension::IcebergExtension;
 use ext_parquet::extension::ParquetExtension;
 use ext_spark::SparkExtension;
 use ext_tpch_gen::TpchGenExtension;
-use glaredb_bench::{Arguments, RunArgs, RunConfig, TsvWriter, pagecache};
+use glaredb_bench::{RunArgs, RunConfig, TsvWriter, pagecache};
 use glaredb_core::engine::single_user::SingleUserEngine;
 use glaredb_core::runtime::pipeline::PipelineRuntime;
 use glaredb_core::runtime::system::SystemRuntime;
@@ -17,19 +17,17 @@ use glaredb_rt_native::runtime::{
 };
 
 pub fn main() -> Result<()> {
-    let args = Arguments::parse();
-
     let run_args = RunArgs {
-        print_explain: args.print_explain,
-        print_profile_data: args.print_profile_data,
-        print_results: args.print_results,
-        count: args.count,
+        print_explain: false,
+        print_profile_data: false,
+        print_results: false,
+        count: 3,
     };
 
-    let mut writer = TsvWriter::try_new(args.save)?;
+    let mut writer = TsvWriter::try_new(None)?;
     writer.write_header()?;
 
-    run_with_setup::<DefaultSetup>(&mut writer, run_args, args.path, args.drop_page_cache)?;
+    run_with_setup::<DefaultSetup>(&mut writer, run_args, "../bench/micros", false)?;
 
     writer.flush()?;
 
@@ -68,15 +66,15 @@ where
 fn run_with_setup<S>(
     writer: &mut TsvWriter,
     run_args: RunArgs,
-    path: PathBuf,
+    path: &str,
     drop_page_cache: bool,
 ) -> Result<()>
 where
     S: EngineSetup<ThreadedNativeExecutor, NativeSystemRuntime>,
 {
-    let paths = glaredb_bench::find_files(&path).unwrap();
+    let paths = glaredb_bench::find_files(Path::new(path)).unwrap();
 
-    glaredb_bench::run(writer, run_args, paths, || {
+    glaredb_bench::run(writer, run_args, paths, move || {
         if drop_page_cache {
             pagecache::drop_page_cache()?;
         }

--- a/bench_bin/bench_runner.rs
+++ b/bench_bin/bench_runner.rs
@@ -24,10 +24,10 @@ pub fn main() -> Result<()> {
         count: 3,
     };
 
-    let mut writer = TsvWriter::try_new(None)?;
+    let writer = TsvWriter::try_new(Some("./results.tsv".into()))?;
     writer.write_header()?;
 
-    run_with_setup::<DefaultSetup>(&mut writer, run_args, "../bench/micros", false)?;
+    run_with_setup::<DefaultSetup>(writer.clone(), run_args, "../bench/micro", false)?;
 
     writer.flush()?;
 
@@ -64,7 +64,7 @@ where
 }
 
 fn run_with_setup<S>(
-    writer: &mut TsvWriter,
+    writer: TsvWriter,
     run_args: RunArgs,
     path: &str,
     drop_page_cache: bool,

--- a/crates/glaredb_bench/Cargo.toml
+++ b/crates/glaredb_bench/Cargo.toml
@@ -13,5 +13,5 @@ glaredb_rt_native = { path = '../glaredb_rt_native' }
 libtest-mimic = "0.7.3"
 logutil = { path = '../logutil' }
 futures = { workspace = true }
-clap = { version = "4.5.38", features = ["derive", "env"] }
 tokio = { workspace = true }
+parking_lot = { workspace = true }

--- a/crates/glaredb_bench/Cargo.toml
+++ b/crates/glaredb_bench/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 glaredb_error = { path = '../glaredb_error' }
 glaredb_core = { path = '../glaredb_core' }
 glaredb_rt_native = { path = '../glaredb_rt_native' }
+libtest-mimic = "0.7.3"
 logutil = { path = '../logutil' }
 futures = { workspace = true }
 clap = { version = "4.5.38", features = ["derive", "env"] }

--- a/crates/glaredb_bench/src/benchmark.rs
+++ b/crates/glaredb_bench/src/benchmark.rs
@@ -7,7 +7,6 @@ use glaredb_error::{DbError, Result, ResultExt};
 /// Describes a benchmark to run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Benchmark {
-    pub identifier: String,
     /// Setup queries to run prior to running the actual benchmark queries.
     pub setup: Vec<String>,
     /// The benchmark queries.
@@ -15,10 +14,10 @@ pub struct Benchmark {
 }
 
 impl Benchmark {
-    pub fn from_file(identifier: impl Into<String>, path: impl AsRef<Path>) -> Result<Self> {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        Self::from_buf_read(identifier, reader)
+        Self::from_buf_read(reader)
     }
 
     /// Construct a benchmark run from some reader.
@@ -42,7 +41,7 @@ impl Benchmark {
     /// Any number of setup and benchmark queries can be provided, however a
     /// setup query cannot be defined after a benchmark query has already been
     /// defined.
-    pub fn from_buf_read(identifier: impl Into<String>, reader: impl BufRead) -> Result<Self> {
+    pub fn from_buf_read(reader: impl BufRead) -> Result<Self> {
         let lines = reader.lines();
 
         let mut setup = Vec::new();
@@ -99,11 +98,7 @@ impl Benchmark {
             return Err(DbError::new("No benchmark queries"));
         }
 
-        Ok(Benchmark {
-            identifier: identifier.into(),
-            setup,
-            queries,
-        })
+        Ok(Benchmark { setup, queries })
     }
 }
 
@@ -144,9 +139,8 @@ run
 SELECT * FROM hello
 "#;
 
-        let bench = Benchmark::from_buf_read("single_setup", Cursor::new(contents)).unwrap();
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
         let expected = Benchmark {
-            identifier: "single_setup".to_string(),
             setup: vec!["CREATE TABLE hello (a INT)".to_string()],
             queries: vec!["SELECT * FROM hello".to_string()],
         };
@@ -160,9 +154,8 @@ SELECT * FROM hello
 SELECT * FROM hello
 "#;
 
-        let bench = Benchmark::from_buf_read("single_query", Cursor::new(contents)).unwrap();
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
         let expected = Benchmark {
-            identifier: "single_query".to_string(),
             setup: vec![],
             queries: vec!["SELECT * FROM hello".to_string()],
         };
@@ -179,7 +172,7 @@ setup
 CREATE TABLE hello (a INT)
 "#;
 
-        let _ = Benchmark::from_buf_read("missing_run", Cursor::new(contents)).unwrap_err();
+        let _ = Benchmark::from_buf_read(Cursor::new(contents)).unwrap_err();
     }
 
     #[test]
@@ -200,9 +193,8 @@ run
 SELECT * FROM hello2
 "#;
 
-        let bench = Benchmark::from_buf_read("multiple_setups", Cursor::new(contents)).unwrap();
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
         let expected = Benchmark {
-            identifier: "multiple_setups".to_string(),
             setup: vec![
                 "CREATE TABLE hello (a INT)".to_string(),
                 "CREATE TABLE hello2 (a INT)".to_string(),
@@ -229,7 +221,7 @@ setup
 CREATE TABLE hello2 (a INT)
 "#;
 
-        let _ = Benchmark::from_buf_read("invalid_order", Cursor::new(contents)).unwrap_err();
+        let _ = Benchmark::from_buf_read(Cursor::new(contents)).unwrap_err();
     }
 
     #[test]
@@ -243,9 +235,8 @@ run
 SELECT * FROM hello
 "#;
 
-        let bench = Benchmark::from_buf_read("multiline", Cursor::new(contents)).unwrap();
+        let bench = Benchmark::from_buf_read(Cursor::new(contents)).unwrap();
         let expected = Benchmark {
-            identifier: "multiline".to_string(),
             setup: vec!["CREATE TABLE\n  hello (a INT)".to_string()],
             queries: vec!["SELECT * FROM hello".to_string()],
         };

--- a/crates/glaredb_bench/src/lib.rs
+++ b/crates/glaredb_bench/src/lib.rs
@@ -8,61 +8,14 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use benchmark::Benchmark;
-use clap::Parser;
 use glaredb_core::engine::single_user::SingleUserEngine;
 use glaredb_core::runtime::pipeline::PipelineRuntime;
 use glaredb_core::runtime::system::SystemRuntime;
 use glaredb_error::{DbError, Result, ResultExt};
 use glaredb_rt_native::runtime::{NativeSystemRuntime, ThreadedNativeExecutor};
+use libtest_mimic::{Arguments, Measurement, Trial};
 use runner::{BenchmarkRunner, BenchmarkTimes};
 use tokio::runtime::Runtime as TokioRuntime;
-
-// TODO: Move this out.
-#[derive(Parser)]
-#[clap(name = "glaredb_bench")]
-pub struct Arguments {
-    /// Print the EXPLAIN output for queries prior to running them.
-    ///
-    /// Only printed once.
-    #[clap(long, env = "DEBUG_PRINT_EXPLAIN")]
-    pub print_explain: bool,
-    /// Print the profile data for a query after running it.
-    ///
-    /// Data is printed for every run of the query.
-    #[clap(long, env = "DEBUG_PRINT_PROFILE_DATA")]
-    pub print_profile_data: bool,
-    /// Print the results of the benchmark queries.
-    ///
-    /// Results are printed for every run of the query.
-    #[clap(long, env = "DEBUG_PRINT_RESULTS")]
-    pub print_results: bool,
-    /// If we should drop the page cache before the setup phase of a benchmark
-    /// file.
-    ///
-    /// On linux, this will write to procfs. On mac, this will use the `purge`
-    /// tool. Both methods require running the binary with sudo.
-    #[clap(long, default_value = "false")]
-    pub drop_page_cache: bool,
-    /// Number of times to run benchmark queries.
-    #[clap(long, short, default_value = "3")]
-    pub count: usize,
-    /// Optionally save results as a TSV to the provided file.
-    #[clap(long, short)]
-    pub save: Option<PathBuf>,
-    /// Path pointing to either a single benchmark file, or a directory
-    /// containing benchmark files.
-    ///
-    /// If provided a directory, the directory will be walked recursively to
-    /// find all benchmark files to run.
-    #[clap()]
-    pub path: PathBuf,
-}
-
-impl Arguments {
-    pub fn parse() -> Self {
-        Parser::parse()
-    }
-}
 
 #[derive(Debug)]
 pub struct RunConfig<E, R>
@@ -72,12 +25,6 @@ where
 {
     pub session: SingleUserEngine<E, R>,
     pub tokio_rt: TokioRuntime,
-}
-
-#[derive(Debug)]
-struct BenchmarkPath {
-    identifier: String,
-    path: PathBuf,
 }
 
 #[derive(Debug)]
@@ -113,15 +60,15 @@ impl TsvWriter {
     }
 
     pub fn write(&mut self, bench_identifier: &str, times: BenchmarkTimes) -> Result<()> {
-        for (idx, query_time) in times.query_times_ms.iter().enumerate() {
-            println!("{}\t{}\t{}", bench_identifier, idx + 1, query_time);
-        }
+        // for (idx, query_time) in times.query_times_ms.iter().enumerate() {
+        //     println!("{}\t{}\t{}", bench_identifier, idx + 1, query_time);
+        // }
 
-        if let Some(file) = self.file.as_mut() {
-            for (idx, query_time) in times.query_times_ms.iter().enumerate() {
-                writeln!(file, "{}\t{}\t{}", bench_identifier, idx + 1, query_time)?;
-            }
-        }
+        // if let Some(file) = self.file.as_mut() {
+        //     for (idx, query_time) in times.query_times_ms.iter().enumerate() {
+        //         writeln!(file, "{}\t{}\t{}", bench_identifier, idx + 1, query_time)?;
+        //     }
+        // }
 
         Ok(())
     }
@@ -149,46 +96,62 @@ pub struct RunArgs {
 /// session/single user engine to use for the benchmark.
 pub fn run<F>(
     writer: &mut TsvWriter,
-    args: RunArgs,
+    run_args: RunArgs,
     paths: impl IntoIterator<Item = PathBuf>,
     engine_fn: F,
 ) -> Result<()>
 where
-    F: Fn() -> Result<RunConfig<ThreadedNativeExecutor, NativeSystemRuntime>>,
+    F: Fn() -> Result<RunConfig<ThreadedNativeExecutor, NativeSystemRuntime>>
+        + Sync
+        + Send
+        + Clone
+        + 'static,
 {
-    let paths: Vec<BenchmarkPath> = paths
+    println!("HELLO?");
+
+    let mut args = Arguments::from_args();
+    // Always run the "tests" with one thread (this thread) sequentially. We
+    // spin up thread pools in the engine itself.
+    args.test_threads = Some(1);
+    args.test = false;
+    args.bench = true;
+
+    let benches: Vec<Trial> = paths
         .into_iter()
         .map(|path| {
-            let path_str = path.to_str().expect("valid utf8 paths");
+            let path_str = path.to_string_lossy();
 
-            // Make the identifier a bit nicer.
-            let identifier = path_str
+            let bench_name = path_str
+                .as_ref()
                 .trim_start_matches("./")
                 .trim_start_matches("../")
                 .to_string();
 
-            BenchmarkPath { identifier, path }
+            let engine_fn = engine_fn.clone();
+
+            Trial::bench(bench_name, move |_test_mode| {
+                let bench = Benchmark::from_file(path)?;
+                let conf = engine_fn()?;
+
+                let runner = BenchmarkRunner {
+                    engine: conf.session,
+                    benchmark: bench,
+                };
+
+                let times = conf.tokio_rt.block_on(runner.run(run_args))?;
+
+                // TODO
+                // writer.write(&path.identifier, times)?;
+
+                Ok(Some(Measurement {
+                    avg: times.query_avg(),
+                    variance: 0, // TODO
+                }))
+            })
         })
         .collect();
 
-    if paths.is_empty() {
-        // Nothing to do.
-        return Ok(());
-    }
-
-    for path in paths {
-        let bench = Benchmark::from_file(&path.identifier, path.path)?;
-        let conf = engine_fn()?;
-
-        let runner = BenchmarkRunner {
-            engine: conf.session,
-            benchmark: bench,
-        };
-
-        let times = conf.tokio_rt.block_on(runner.run(args))?;
-
-        writer.write(&path.identifier, times)?;
-    }
+    libtest_mimic::run(&args, benches).exit_if_failed();
 
     Ok(())
 }

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -17,7 +17,6 @@ ext_parquet = { path = '../crates/ext_parquet' }
 
 tokio = { workspace = true, default-features = false, features = ["rt", "rt-multi-thread", "time", "net"] }
 
-
 [[test]]
 harness = false
 name = "integration_slt"


### PR DESCRIPTION
```
% cargo bench --bench bench_runner -- bench/micro/

...

running 16 tests
test bench/micro/min_max_generate_series_10M.bench                ... bench:  20,312,014 ns/iter (+/- 0)
test bench/micro/limit/limit_early_stop.bench                     ... bench:      67,111 ns/iter (+/- 0)
test bench/micro/aggregates/redundant_group_by_exprs_64.bench     ... bench: 819,351,208 ns/iter (+/- 0)
test bench/micro/aggregates/many_small_string_groups_1M.bench     ... bench: 219,555,069 ns/iter (+/- 0)
test bench/micro/aggregates/many_int_groups_1M.bench              ... bench: 129,761,610 ns/iter (+/- 0)
test bench/micro/aggregates/many_distinct_values.bench            ... bench: 147,719,597 ns/iter (+/- 0)
test bench/micro/aggregates/corr_10M_points.bench                 ... bench: 643,271,083 ns/iter (+/- 0)
test bench/micro/aggregates/many_med_string_groups_1M.bench       ... bench: 2,252,371,472 ns/iter (+/- 0)
test bench/micro/select_1.bench                                   ... bench:      71,292 ns/iter (+/- 0)
test bench/micro/many_base_relation_join_8.bench                  ... bench:  10,730,096 ns/iter (+/- 0)
test bench/micro/functions/trim_large_inputs_small_patterns.bench ... bench:   5,782,055 ns/iter (+/- 0)
test bench/micro/case/large_case_statement.bench                  ... bench:  95,773,764 ns/iter (+/- 0)
test bench/micro/select/select_from_many_columns.bench            ... bench:   1,067,347 ns/iter (+/- 0)
test bench/micro/select/star_expand_many_cols.bench               ... bench:   5,078,528 ns/iter (+/- 0)
test bench/micro/select/select_from_many_regex_columns.bench      ... bench:   1,828,430 ns/iter (+/- 0)
test bench/micro/many_base_relation_join_10.bench                 ... bench: 110,134,986 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 16 measured; 0 filtered out; finished in 14.17s
```