### PR TITLE
fix: Sample columns across batches when computing table widths

### DIFF
--- a/crates/glaredb_core/src/arrays/format/pretty/table.rs
+++ b/crates/glaredb_core/src/arrays/format/pretty/table.rs
@@ -362,7 +362,7 @@ impl TableFormat {
         // Grow based on column average.
         Self::grow_using_stats(
             &mut header_widths,
-            &samples,
+            samples,
             max_width,
             has_ellided,
             |stat| stat.avg,
@@ -370,7 +370,7 @@ impl TableFormat {
         // Grow based on column max.
         Self::grow_using_stats(
             &mut header_widths,
-            &samples,
+            samples,
             max_width,
             has_ellided,
             |stat| stat.max,


### PR DESCRIPTION
Closes https://github.com/GlareDB/glaredb/issues/3846

```
glaredb> SELECT event_type, count(*) FROM ecommerce GROUP BY event_type;
┌────────────┬───────────┐
│ event_type │ count     │
│ Utf8       │ Int64     │
├────────────┼───────────┤
│ cart       │  19114063 │
│ view       │ 385746849 │
│ purchase   │   6848824 │
└────────────┴───────────┘
```