### PR TITLE
remove reliance on a trait solver inference bug

### DIFF
--- a/crates/glaredb_core/src/arrays/executor/scalar/ternary.rs
+++ b/crates/glaredb_core/src/arrays/executor/scalar/ternary.rs
@@ -111,7 +111,7 @@ impl TernaryExecutor {
                     ExecutionFormat::Selection(a3) => a3,
                 };
 
-                Self::execute_selection_format::<S1, S2, S3, _, _>(
+                Self::execute_selection_format::<S1, S2, S3, O, _>(
                     &array1.validity,
                     a1,
                     sel1,


### PR DESCRIPTION
The parameter `O` of `execute_selection_format` is completely unconstrained by its arguments and return type. We are only able to infer it by assuming that the only associated type equal to `O::AddressableMut<'b>` is `O::AddressableMut<'b>` itself. It could just as well be some other associated type which only normalizes to `O::AddressableMut<'b>`. This will change with the next-generation trait solver and was encountered by a crater run https://github.com/rust-lang/rust/pull/133502.

cc https://github.com/rust-lang/trait-system-refactor-initiative/issues/168. The existing implementation already has the correct behavior for associated types which don't refer to any higher ranked region. This is why you already had to explicitly specify the types `S1` to `S3`.

There are a few crates which rely on `glaredb_core` on `crates.io`, so it would be great if you could release this fix as a new patch version. I am sorry for the inconvenience and am available if you have any questions.